### PR TITLE
Add a missing dependency to jupyterlab_widgets

### DIFF
--- a/python/jupytergis_lab/pyproject.toml
+++ b/python/jupytergis_lab/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "jupyter-ydoc>=2,<3",
   "jupyterlab>=4,<5",
   "jupyter-collaboration>=2,<3",
+  "jupyterlab_widgets>=3",
   "ypywidgets>=0.9.0,<0.10.0",
   "yjs-widgets>=0.3.4,<0.4",
   "comm>=0.1.2,<0.2.0",


### PR DESCRIPTION
This PR adds a missing dependency on `jupyterlab_widgets`

<img src=https://github.com/user-attachments/assets/4eaf256b-051c-4465-af95-837974c93d5a width=500>
