### PR TITLE
Hotfix qgis loader for vector tile layer

### DIFF
--- a/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
@@ -182,6 +182,7 @@ def qgis_layer_to_jgis(
             pass
         # TODO Load style properly
         layer_parameters.update(type="fill")
+        layer_parameters.update(color=[])
 
     if layer_type is None:
         print(f"JUPYTERGIS - Enable to load layer type {type(layer)}")

--- a/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
@@ -161,6 +161,7 @@ def test_qgis_saver():
                 "name": "Vector Tile Layer",
                 "parameters": {
                     "opacity": 1.0,
+                    'color': [],
                     "source": source_ids[2],
                     "sourceLayer": "bingmlbuildings",
                     "type": "fill",


### PR DESCRIPTION
This is a temporary fix just to get vector tile layers showing up on QGZ files. We should do the proper thing and load the symbology properly from the QGZ files