### PR TITLE
Fix the export path

### DIFF
--- a/python/jupytergis_qgis/jupytergis_qgis/handlers.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/handlers.py
@@ -39,7 +39,10 @@ class ExportToQgisHandler(APIHandler):
         elif not virtual_file:
             raise HTTPError(400, "The file content is missing")
 
-        absolute_path = os.path.join(self.settings["server_root_dir"], path)
+        absolute_path = os.path.join(
+            os.path.expanduser(self.settings["server_root_dir"]),
+            path
+        )
         logs = export_project_to_qgis(absolute_path, virtual_file)
         self.finish(json.dumps({
             "exported": len(logs["errors"]) == 0,


### PR DESCRIPTION
QGIS API cannot save the file if the path contains '~' for home directory.

This PR expand the user path to get an absolute one.