### PR TITLE
Use file from test directory only in UI tests

### DIFF
--- a/ui-tests/tests/layer-browser.spec.ts
+++ b/ui-tests/tests/layer-browser.spec.ts
@@ -98,15 +98,15 @@ async function getGridTiles(page: IJupyterLabPageFixture): Promise<Locator> {
 test.describe('#layerBrowser', () => {
   test.beforeAll(async ({ request }) => {
     const content = galata.newContentsHelper(request);
-    await content.deleteDirectory('/examples');
-    await content.uploadDirectory(
-      path.resolve(__dirname, '../../examples'),
-      '/examples'
-    );
+    await content.deleteDirectory('/testDir');
+      await content.uploadDirectory(
+        path.resolve(__dirname, './gis-files'),
+        '/testDir'
+      );
   });
 
   test.beforeEach(async ({ page }) => {
-    await page.filebrowser.open('examples/test.jGIS');
+    await page.filebrowser.open('testDir/test.jGIS');
   });
 
   test.afterEach(async ({ page }) => {

--- a/ui-tests/tests/layer-browser.spec.ts
+++ b/ui-tests/tests/layer-browser.spec.ts
@@ -99,10 +99,10 @@ test.describe('#layerBrowser', () => {
   test.beforeAll(async ({ request }) => {
     const content = galata.newContentsHelper(request);
     await content.deleteDirectory('/testDir');
-      await content.uploadDirectory(
-        path.resolve(__dirname, './gis-files'),
-        '/testDir'
-      );
+    await content.uploadDirectory(
+      path.resolve(__dirname, './gis-files'),
+      '/testDir'
+    );
   });
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
This PR fixes the UI tests, which depended on a file removed from the example directory