### PR TITLE
Reactive toolbar w.r.t width

### DIFF
--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -3,6 +3,7 @@ import { CommandToolbarButton } from '@jupyterlab/apputils';
 import {
   ReactWidget,
   Toolbar,
+  ReactiveToolbar,
   ToolbarButton,
   addIcon,
   redoIcon,
@@ -29,9 +30,9 @@ export class Separator extends Widget {
   }
 }
 
-export class ToolbarWidget extends Toolbar {
+export class ToolbarWidget extends ReactiveToolbar {
   constructor(options: ToolbarWidget.IOptions) {
-    super(options);
+    super();
 
     this.addClass('jGIS-toolbar-widget');
 
@@ -150,7 +151,7 @@ export class ToolbarWidget extends Toolbar {
 
       this.addItem('New', NewButton);
 
-      this.addItem('spacer', Toolbar.createSpacerItem());
+      this.addItem('spacer', ReactiveToolbar.createSpacerItem());
 
       // Users
       this.addItem(


### PR DESCRIPTION
Porting https://github.com/jupytercad/JupyterCAD/pull/455 to JupyterGIS

<img width="652" alt="image" src="https://github.com/user-attachments/assets/e382e4f7-af25-43fb-94d4-7885b4294b99">

