### PR TITLE
Add `logoicon` as tab icon

### DIFF
--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -88,6 +88,7 @@ const activate = (
   }
 
   widgetFactory.widgetCreated.connect((sender, widget) => {
+    widget.title.icon = logoIcon;
     widget.context.pathChanged.connect(() => {
       tracker.save(widget);
     });


### PR DESCRIPTION
Port https://github.com/jupytercad/JupyterCAD/pull/466

<img width="1470" alt="Screenshot 2024-10-10 at 19 55 18" src="https://github.com/user-attachments/assets/74d21d44-5a60-42e3-b698-595152133756">
