### PR TITLE
[WIP] Avoid recreating layers on update

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -763,22 +763,22 @@ export class MainView extends React.Component<IProps, IStates> {
    * @param id - id of the layer.
    * @param index - expected index of the layer.
    */
-    moveLayer(id: string, index: number): void {
-      const currentIndex = this.getLayerIndex(id);
-      if (currentIndex === index || currentIndex === -1) {
-        return;
-      }
-      const layer = this.getLayer(id);
-      let nextIndex = index;
-      // should not be undefined since the id exists above
-      if (layer !== undefined) {
-        this._Map.getLayers().removeAt(currentIndex);
-        if (currentIndex < index) {
-          nextIndex -= 1;
-        }
-        this._Map.getLayers().insertAt(nextIndex, layer);
-      }
+  moveLayer(id: string, index: number): void {
+    const currentIndex = this.getLayerIndex(id);
+    if (currentIndex === index || currentIndex === -1) {
+      return;
     }
+    const layer = this.getLayer(id);
+    let nextIndex = index;
+    // should not be undefined since the id exists above
+    if (layer !== undefined) {
+      this._Map.getLayers().removeAt(currentIndex);
+      if (currentIndex < index) {
+        nextIndex -= 1;
+      }
+      this._Map.getLayers().insertAt(nextIndex, layer);
+    }
+  }
 
   /**
    * Update a layer of the map.


### PR DESCRIPTION
Draft PR to improve the `updateLayers` method in the main view.

Currently any change in the layer tree recreate all the layers from scratch in the OL map.

This PR aims to avoid it by reorganizing the layers in OL map, without removing them if not necessary.