### PR TITLE
Add nodata to geotiff source

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -395,8 +395,12 @@ export class MainView extends React.Component<IProps, IStates> {
       case 'GeoTiffSource': {
         const sourceParameters = source.parameters as IGeoTiffSource;
 
+        const addNoData = (url: (typeof sourceParameters.urls)[0]) => {
+          return { ...url, nodata: 0 };
+        };
+
         newSource = new GeoTIFFSource({
-          sources: sourceParameters.urls,
+          sources: sourceParameters.urls.map(addNoData),
           normalize: sourceParameters.normalize,
           wrapX: sourceParameters.wrapX
         });


### PR DESCRIPTION
Addresses one of the issues mentioned in #196. Adds `nodata` attribute to source info when creating `geotiff` sources so no black box is displayed.  Potentially this option could be added to the schema and exposed on the creation form instead. 

![no_box](https://github.com/user-attachments/assets/56926a35-139a-4d0b-8ff2-f82d0903da5a)
