### PR TITLE
Add support for other projections

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "@jupyterlab/services": " ^7.0.0"
   },
   "devDependencies": {
+    "@types/colormap": "^2.3.4",
+    "@types/proj4": "^2.5.5",
     "@types/webpack-env": "^1.18.5",
     "@typescript-eslint/eslint-plugin": "5.55.0",
     "@typescript-eslint/parser": "5.55.0",
@@ -76,11 +78,12 @@
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "latest",
-    "@types/colormap": "^2.3.4",
     "colormap": "^2.3.2",
     "geojson-vt": "^4.0.2",
     "geotiff": "^2.1.3",
     "ol": "^10.1.0",
-    "pmtiles": "^3.0.7"
+    "pmtiles": "^3.0.7",
+    "proj4": "^2.14.0",
+    "proj4-list": "^1.0.2"
   }
 }

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -51,7 +51,7 @@ import {
 import Static from 'ol/source/ImageStatic';
 //@ts-expect-error no types for ol-pmtiles
 import { PMTilesRasterSource, PMTilesVectorSource } from 'ol-pmtiles';
-import { register } from 'ol/proj/proj4.js';
+import { fromEPSGCode, register } from 'ol/proj/proj4.js';
 import { Rule } from 'ol/style/flat';
 import proj4 from 'proj4';
 import * as React from 'react';
@@ -75,12 +75,12 @@ interface IStates {
   firstLoad: boolean;
 }
 
-proj4.defs(Array.from(proj4list));
-register(proj4);
-
 export class MainView extends React.Component<IProps, IStates> {
   constructor(props: IProps) {
     super(props);
+
+    proj4.defs(Array.from(proj4list));
+    register(proj4);
 
     this._mainViewModel = this.props.viewModel;
     this._mainViewModel.viewSettingChanged.connect(this._onViewChanged, this);

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -51,12 +51,16 @@ import {
 import Static from 'ol/source/ImageStatic';
 //@ts-expect-error no types for ol-pmtiles
 import { PMTilesRasterSource, PMTilesVectorSource } from 'ol-pmtiles';
+import { register } from 'ol/proj/proj4.js';
 import { Rule } from 'ol/style/flat';
+import proj4 from 'proj4';
 import * as React from 'react';
 import shp from 'shpjs';
 import { isLightTheme } from '../tools';
 import { MainViewModel } from './mainviewmodel';
 import { Spinner } from './spinner';
+//@ts-expect-error no types for proj4-list
+import proj4list from 'proj4-list';
 
 interface IProps {
   viewModel: MainViewModel;
@@ -70,6 +74,9 @@ interface IStates {
   remoteUser?: User.IIdentity | null;
   firstLoad: boolean;
 }
+
+proj4.defs(Array.from(proj4list));
+register(proj4);
 
 export class MainView extends React.Component<IProps, IStates> {
   constructor(props: IProps) {
@@ -591,7 +598,6 @@ export class MainView extends React.Component<IProps, IStates> {
         }
 
         newMapLayer = new WebGlTileLayer(layerOptions);
-
         break;
       }
     }

--- a/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
@@ -369,6 +369,7 @@ def import_project_from_qgis(path: str | Path):
                 map_extent.yMaximum(),
             ],
             "useExtent": True,
+            "projection": project.crs().authid(),
         },
         **jgis_layer_tree,
     }

--- a/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
@@ -19,6 +19,7 @@ def test_qgis_loader():
         options={
             "bearing": 0.0,
             "pitch": 0,
+            "projection": "EPSG:3857",
             "extent": [
                 -25164292.70393259,
                 -15184674.291019961,
@@ -130,6 +131,7 @@ def test_qgis_saver():
         "options": {
             "bearing": 0.0,
             "pitch": 0,
+            "projection": "EPSG:3857",
             "extent": [
                 -25164292.70393259,
                 -15184674.291019961,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,7 @@ __metadata:
     "@fortawesome/free-solid-svg-icons": ^6.5.2
     "@fortawesome/react-fontawesome": latest
     "@types/colormap": ^2.3.4
+    "@types/proj4": ^2.5.5
     "@types/webpack-env": ^1.18.5
     "@typescript-eslint/eslint-plugin": 5.55.0
     "@typescript-eslint/parser": 5.55.0
@@ -1038,6 +1039,8 @@ __metadata:
     ol: ^10.1.0
     pmtiles: ^3.0.7
     prettier: ^3.0.0
+    proj4: ^2.14.0
+    proj4-list: ^1.0.2
     rimraf: ^3.0.2
     typescript: ^5
     webpack: ^5.76.3
@@ -3221,6 +3224,13 @@ __metadata:
   version: 2.7.3
   resolution: "@types/prettier@npm:2.7.3"
   checksum: 705384209cea6d1433ff6c187c80dcc0b95d99d5c5ce21a46a9a58060c527973506822e428789d842761e0280d25e3359300f017fbe77b9755bc772ab3dc2f83
+  languageName: node
+  linkType: hard
+
+"@types/proj4@npm:^2.5.5":
+  version: 2.5.5
+  resolution: "@types/proj4@npm:2.5.5"
+  checksum: 06a1898ffff6d7b4a0da04249b431b129ae31c1a75decfdcbdde6b6d7a7cf9560f8506e89f441b6ebe287e66ef5d0fd3e7ca33f9eb30c1427f8b9989bd3dc578
   languageName: node
   linkType: hard
 
@@ -9813,6 +9823,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proj4-list@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "proj4-list@npm:1.0.2"
+  checksum: 8705bfb92b7572c514d98944e148a6ab8891dc69aa49388677a999180d46d374758ddf0b733068e242b1454de2565c9e9bfcfd1c6b035d93834a0a879cd696d8
+  languageName: node
+  linkType: hard
+
 "proj4@npm:^2.1.4":
   version: 2.12.1
   resolution: "proj4@npm:2.12.1"
@@ -9820,6 +9837,16 @@ __metadata:
     mgrs: 1.0.0
     wkt-parser: ^1.3.3
   checksum: 72d7cbedc01a7d008c7308f9276573f847aa0cadb16ad62e04db89fa5ab2922601b43ea70bd2e0dd482ab560dfc9c35be17629007359974901eec1c9f10714f6
+  languageName: node
+  linkType: hard
+
+"proj4@npm:^2.14.0":
+  version: 2.14.0
+  resolution: "proj4@npm:2.14.0"
+  dependencies:
+    mgrs: 1.0.0
+    wkt-parser: ^1.3.3
+  checksum: 65c9e67658a89a152c002b5a512f25efeca3bf317c448868327ff16b77a8015c9315e4ce1a069e3a2dedd1acdd6c426f5e12d4a4fa7770f7f2c4ffb8675c3d1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Small fix for issue with the tif layer loading in the wrong location mentioned in #196 Should fix https://github.com/geojupyter/jupytergis/issues/191

![fix](https://github.com/user-attachments/assets/cede7239-dd7c-44dd-bfd9-a8c184ff927d)

Added support for reading projection info from `gqz` files. 

EPSG:3857
![3857](https://github.com/user-attachments/assets/0115f804-bf8e-4035-ab1c-bc3dd13f6713)

EPSG:4326
![4326](https://github.com/user-attachments/assets/145807e8-61fa-4743-84fd-a54ee087d9d7)
