### PR TITLE
Add a min-height to the toolbar separator

### DIFF
--- a/python/jupytergis_lab/style/base.css
+++ b/python/jupytergis_lab/style/base.css
@@ -193,6 +193,7 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
 }
 
 .jGIS-Toolbar-Separator {
+  min-height: 25px;
   width: var(--jp-border-width);
   background-color: var(--jp-border-color1);
   padding-left: 0px !important;


### PR DESCRIPTION
This PR fix the toolbar separator not displayed in the popup toolbar.

Related to https://github.com/jupyterlab/jupyterlab/issues/16884

![image](https://github.com/user-attachments/assets/789805af-ca58-4ef5-8973-ab9badc70004)
