### PR TITLE
Skip cache when building prod

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,6 +14,11 @@
       "dependsOn": ["^build:dev"],
       "inputs": ["default", "^default"],
       "outputs": ["{projectRoot}/lib"]
+    },
+    "build:prod": {
+      "dependsOn": ["^build:prod"],
+      "inputs": ["default", "^default"],
+      "outputs": ["{projectRoot}/lib"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "lerna run build",
-    "build:prod": "lerna run build:prod",
+    "build:prod": "lerna run build:prod --skip-nx-cache",
     "build:test": "lerna run build:test",
     "build:dev": "lerna run build:dev",
     "bump:js:version": "lerna version --no-push --force-publish --no-git-tag-version --yes",


### PR DESCRIPTION
Don't use cache when running `build:prod`