### PR TITLE
Use an external proxy server for loading shapefiles in JupyterLite

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -264,7 +264,10 @@ export class MainView extends React.Component<IProps, IStates> {
 
       return geojson;
     } catch (error) {
-      console.warn('Cannot communicate with the JupyterGIS proxy server', error);
+      console.warn(
+        'Cannot communicate with the JupyterGIS proxy server',
+        error
+      );
     }
 
     // Trying through an external proxy server
@@ -275,7 +278,10 @@ export class MainView extends React.Component<IProps, IStates> {
 
       return geojson;
     } catch (error) {
-      console.warn('Cannot communicate with the JupyterGIS proxy server', error);
+      console.warn(
+        'Cannot communicate with the JupyterGIS proxy server',
+        error
+      );
     }
 
     showErrorMessage('Network error', `Failed to fetch ${url}`);


### PR DESCRIPTION
Loading external ShapeFiles in JupyterLite does not work, because our server proxy is not available.

This PR adds two more ways to try and download external files:
- directly (in case CORS is not an issue)
- using an externally hosted proxy server