### PR TITLE
Grey out symbology entry for unsupported layers

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -50,9 +50,34 @@ export function addCommands(
   commands.addCommand(CommandIDs.symbology, {
     label: trans.__('Edit Symbology'),
     isEnabled: () => {
-      return tracker.currentWidget
-        ? tracker.currentWidget.context.model.sharedModel.editable
-        : false;
+      const model = tracker.currentWidget?.context.model;
+      const localState = model?.sharedModel.awareness.getLocalState();
+
+      if (!model || !localState || !localState['selected']?.value) {
+        return false;
+      }
+
+      const selectedLayers = localState['selected'].value;
+
+      // Can't open more than one symbology dialog at once
+      if (Object.keys(selectedLayers).length > 1) {
+        return false;
+      }
+
+      const layerId = Object.keys(selectedLayers)[0];
+      const layer = model.getLayer(layerId);
+
+      if (!layer) {
+        return false;
+      }
+
+      const isValidLayer = [
+        'VectorLayer',
+        'VectorTileLayer',
+        'WebGlLayer'
+      ].includes(layer.type);
+
+      return isValidLayer;
     },
     execute: Private.createSymbologyDialog(tracker, state),
 


### PR DESCRIPTION
#254 

Greys out "Edit Symbology" context menu item for unsupported layers. 

![disable](https://github.com/user-attachments/assets/6b733024-1316-47c7-955c-21a9f67613cb)
