### PR TITLE
Automatically upgrade GitHub Action dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package_ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      gha-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
We have some outdated versions called out in GitHub actions ([here](https://github.com/geojupyter/jupytergis/actions/runs/12433229995), scroll down to see "Annotations"), some scheduled for deprecation.