### PR TITLE
Make prettier output more human readable, improve documentation of linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,5 +12,5 @@ What does this PR change? Why?
 - [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
 - [ ] Checks are passing.
       Failing lint checks can be resolved with:
-  * `pre-commit run --all-files`
-  * `jlpm run lint`
+  - `pre-commit run --all-files`
+  - `jlpm run lint`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Description
+
+<!--
+Insert Pull Request description here.
+
+What does this PR change? Why?
+-->
+
+## Checklist
+
+- [ ] PR has a descriptive title and content.
+- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
+- [ ] Checks are passing.
+      Failing lint checks can be resolved with:
+  * `pre-commit run --all-files`
+  * `jlpm run lint`

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -126,15 +126,20 @@ We have several tools configured for checking code quality:
   Install checks with ``pre-commit install``.
   Run them manually with ``pre-commit run --all-files``.
   **Will exit non-zero when finding errors or changing files.**
+
   * Ruff formats and lints (sometimes autofixes) Python code.
+
   * Generic pre-commit checks help avoid common mistakes like committing large
     files or trailing whitespace.
+
 * Package scripts (defined in ``package.json``) to check (and/or fix)
   TypeScript, JavaScript, CSS, JSON, Markdown, and YAML.
   Run manually with ``jlpm run lint``.
   **Will exit 0 when applying fixes.
   Check the logs and/or ``git status`` after every run.**
+
   * Prettier formats the file types listed above.
+
   * Eslint lints (sometimes autofixes) JS/TS code.
 
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -117,6 +117,27 @@ Development uninstall
 In development mode, you will also need to remove the symlink created by ``jupyter labextension develop`` command. To find its location, you can run ``jupyter labextension list`` to figure out where the ``labextensions`` folder is located. Then you can remove the symlink named ``jupytergis`` within that folder.
 
 
+Code quality
+------------
+
+We have several tools configured for checking code quality:
+
+* Pre-commit checks run automatically at commit time.
+  Install checks with ``pre-commit install``.
+  Run them manually with ``pre-commit run --all-files``.
+  **Will exit non-zero when finding errors or changing files.**
+  * Ruff formats and lints (sometimes autofixes) Python code.
+  * Generic pre-commit checks help avoid common mistakes like committing large
+    files or trailing whitespace.
+* Package scripts (defined in ``package.json``) to check (and/or fix)
+  TypeScript, JavaScript, CSS, JSON, Markdown, and YAML.
+  Run manually with ``jlpm run lint``.
+  **Will exit 0 when applying fixes.
+  Check the logs and/or ``git status`` after every run.**
+  * Prettier formats the file types listed above.
+  * Eslint lints (sometimes autofixes) JS/TS code.
+
+
 Troubleshooting
 ---------------
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "eslint . --ext .ts,.tsx --cache --fix",
     "eslint:check": "eslint . --ext .ts,.tsx",
     "prettier": "prettier --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\"",
-    "prettier:check": "prettier --list-different \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\"",
+    "prettier:check": "prettier --check \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md,.yml}\"",
     "lint:check": "jlpm run prettier:check && jlpm run eslint:check",
     "lint": "jlpm run prettier && jlpm run eslint",
     "test": "lerna run test",


### PR DESCRIPTION
I don't consider this a resolution to #281 , I feel there is discussion to be had about other elements of that issue.

`--check` provides a more useful output:

```
Checking formatting...
[warn] .github/dependabot.yml
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

Compared to `--list-different`, which is meant to be used when machine-readable output is needed, for example to pipe the list of different files to another command:

```
.github/dependabot.yml
```