### PR TITLE
Refactor layer tree updates

### DIFF
--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -247,7 +247,8 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
       const groupState = await state.fetch(`jupytergis:${group.name}`);
 
       setOpen(
-        ((groupState as ReadonlyPartialJSONObject).expanded as boolean) ?? false
+        ((groupState as ReadonlyPartialJSONObject)?.expanded as boolean) ??
+          false
       );
     };
 


### PR DESCRIPTION
This modifies how layer tree updates are handled, basically it changes `_addLayerTreeItem`, `_removeLayerTreeLayer`, and `_removeLayerTreeGroup`  to modify a working copy of the layer tree, and then syncs the changes with the `y.js` document so only the final version of the layer tree is used when firing relevant signals, instead of triggering the signals on intermediate changes.

This should fix the inputs to the changes made in #269.

<!-- readthedocs-preview jupytergis start -->
📚 Documentation preview: https://jupytergis--284.org.readthedocs.build/en/284/
💡 JupyterLite preview: {docs-pre-index-url}/lite

<!-- readthedocs-preview jupytergis end -->