### PR TITLE
Fix typo in ReadTheDocs PR link automation

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -20,5 +20,6 @@ jobs:
         with:
           project-slug: 'jupytergis'
           message-template: |
+            ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview: {docs-pre-index-url}/lite
+            💡 JupyterLite preview: {docs-pr-index-url}/lite

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -22,4 +22,4 @@ jobs:
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview: {docs-pr-index-url}/lite
+            💡 JupyterLite preview: {docs-pr-index-url}lite


### PR DESCRIPTION
Woops! :bell: 

The automation is adding the following to every PR:


> 📚 Documentation preview: https://jupytergis--285.org.readthedocs.build/en/285/
> 💡 JupyterLite preview: {docs-pre-index-url}/lite

But it should look like:

> ---
> 📚 Documentation preview: https://jupytergis--285.org.readthedocs.build/en/285/
> 💡 JupyterLite preview: https://jupytergis--285.org.readthedocs.build/en/285/lite