### PR TITLE
Temporary PR comment for lite preview

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -22,4 +22,4 @@ jobs:
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview: {docs-pr-index-url}lite
+            💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)


### PR DESCRIPTION
## Description

Temporary message for lite preview (waiting for https://github.com/readthedocs/actions/issues/47).
See https://github.com/geojupyter/jupytergis/pull/285#issuecomment-2573852400 for context.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--290.org.readthedocs.build/en/290/
💡 JupyterLite preview: {docs-pr-index-url}lite

<!-- readthedocs-preview jupytergis end -->