### PR TITLE
Add zoom to layer to layer context menu

### DIFF
--- a/packages/base/src/annotations/components/Annotation.tsx
+++ b/packages/base/src/annotations/components/Annotation.tsx
@@ -63,7 +63,7 @@ const Annotation = ({
   };
 
   const centerOnAnnotation = () => {
-    jgisModel?.centerOnAnnotation(itemId);
+    jgisModel?.centerOnPosition(itemId);
   };
 
   return (

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -887,7 +887,7 @@ export function addCommands(
       }
 
       const layerId = Object.keys(selectedItems)[0];
-      model.centerOnAnnotation(layerId);
+      model.centerOnPosition(layerId);
     }
   });
 }

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -872,13 +872,22 @@ export function addCommands(
   });
 
   commands.addCommand(CommandIDs.zoomToLayer, {
-    label: trans.__('Select the completion suggestion.'),
+    label: trans.__('Zoom to Layer'),
     execute: () => {
       const currentWidget = tracker.currentWidget;
       if (!currentWidget || !completionProviderManager) {
         return;
       }
       console.log('zooming');
+      const model = tracker.currentWidget.context.model;
+      const selectedItems = model.localState?.selected.value;
+
+      if (!selectedItems) {
+        return;
+      }
+
+      const layerId = Object.keys(selectedItems)[0];
+      model.centerOnAnnotation(layerId);
     }
   });
 }

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -870,6 +870,17 @@ export function addCommands(
       }
     }
   });
+
+  commands.addCommand(CommandIDs.zoomToLayer, {
+    label: trans.__('Select the completion suggestion.'),
+    execute: () => {
+      const currentWidget = tracker.currentWidget;
+      if (!currentWidget || !completionProviderManager) {
+        return;
+      }
+      console.log('zooming');
+    }
+  });
 }
 
 namespace Private {

--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -63,6 +63,7 @@ export namespace CommandIDs {
 
   // Map Commands
   export const addAnnotation = 'jupytergis:addAnnotation';
+  export const zoomToLayer = 'jupytergis:zoomToLayer';
 }
 
 interface IRegisteredIcon {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -121,7 +121,7 @@ export class MainView extends React.Component<IProps, IStates> {
       this._onSharedMetadataChanged,
       this
     );
-    this._model.zoomToAnnotationSignal.connect(this._onZoomToAnnotation, this);
+    this._model.zoomToPositionSignal.connect(this._onZoomToPosition, this);
 
     this.state = {
       id: this._mainViewModel.id,
@@ -1403,7 +1403,7 @@ export class MainView extends React.Component<IProps, IStates> {
     });
   }
 
-  private _onZoomToAnnotation(_: IJupyterGISModel, id: string) {
+  private _onZoomToPosition(_: IJupyterGISModel, id: string) {
     // Check if the id is an annotation
     const annotation = this._model.annotationModel?.getAnnotation(id);
     if (annotation) {

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -162,7 +162,7 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   sharedLayerTreeChanged: ISignal<IJupyterGISDoc, IJGISLayerTreeDocChange>;
   sharedSourcesChanged: ISignal<IJupyterGISDoc, IJGISSourceDocChange>;
   sharedMetadataChanged: ISignal<IJupyterGISModel, MapChange>;
-  zoomToAnnotationSignal: ISignal<IJupyterGISModel, string>;
+  zoomToPositionSignal: ISignal<IJupyterGISModel, string>;
 
   setContentsManager(
     value: Contents.IManager | undefined,
@@ -207,7 +207,7 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
 
   addMetadata(key: string, value: string): void;
   removeMetadata(key: string): void;
-  centerOnAnnotation(id: string): void;
+  centerOnPosition(id: string): void;
 
   toggleIdentify(): void;
   isIdentifying: boolean;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -155,8 +155,8 @@ export class JupyterGISModel implements IJupyterGISModel {
     return this._sharedMetadataChanged;
   }
 
-  get zoomToAnnotationSignal(): ISignal<this, string> {
-    return this._zoomToAnnotationSignal;
+  get zoomToPositionSignal(): ISignal<this, string> {
+    return this._zoomToPositionSignal;
   }
 
   set isIdentifying(isIdentifying: boolean) {
@@ -167,8 +167,8 @@ export class JupyterGISModel implements IJupyterGISModel {
     return this._isIdentifying;
   }
 
-  centerOnAnnotation(id: string) {
-    this._zoomToAnnotationSignal.emit(id);
+  centerOnPosition(id: string) {
+    this._zoomToPositionSignal.emit(id);
   }
 
   private _metadataChangedHandler(_: IJupyterGISDoc, args: MapChange) {
@@ -696,7 +696,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     Map<number, IJupyterGISClientState>
   >(this);
   private _sharedMetadataChanged = new Signal<this, MapChange>(this);
-  private _zoomToAnnotationSignal = new Signal<this, string>(this);
+  private _zoomToPositionSignal = new Signal<this, string>(this);
 
   private _isIdentifying = false;
 

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -185,6 +185,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
       selector: '.jp-gis-layerItem'
     });
 
+    app.contextMenu.addItem({
+      command: CommandIDs.zoomToLayer,
+      selector: '.jp-gis-layerItem',
+      rank: 2
+    });
+
     const moveLayerSubmenu = new Menu({ commands: app.commands });
     moveLayerSubmenu.title.label = translator
       .load('jupyterlab')

--- a/ui-tests/tests/contextmenu.spec.ts
+++ b/ui-tests/tests/contextmenu.spec.ts
@@ -41,12 +41,9 @@ test.describe('context menu', () => {
       .getByText('Open Topo Map')
       .click({ button: 'right' });
 
-    await page.getByRole('menu').hover();
+    await page.getByText('Move Selected Layers to Group').hover();
 
-    const submenu = page.locator('div').filter({
-      hasText:
-        'Move to Rootlevel 1 grouplevel 2 groupMove Selected Layers to New Group'
-    });
+    const submenu = page.locator('#jp-gis-contextmenu-movelayer');
 
     const firstItem = page.getByText('Move to Root');
     await expect(firstItem).toBeVisible();


### PR DESCRIPTION
## Description

#225 Add `zoom to layer` option to layer context menu

![zoomtolayer](https://github.com/user-attachments/assets/db26f155-2299-4197-933f-dcfd320927b8)

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--294.org.readthedocs.build/en/294/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->