### PR TITLE
Update dev install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,6 @@ The `jlpm` command is JupyterLab's pinned version of
 git clone https://github.com/geojupyter/jupytergis.git
 # Change directory to the jupytergis directory
 cd jupytergis
-# Install JupyterLab for jlpm
-pip install jupyterlab
 # Install package in development mode
 python scripts/dev-install.py
 ```

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,6 +4,6 @@ hatchling>=1.5.0,<2
 jupyterlab>=4,<5
 mercantile>=1.2
 pillow>=10
-pydantic==2.4.2
+pydantic>=2.4.2,<3
 ruff>=0.6
 xyzservices>=2024.6.0


### PR DESCRIPTION
## Description

The [CONTRIBUTING.md](https://github.com/geojupyter/jupytergis/blob/d7a311296eeb9c0b9d9919702fa62b185d85070b/CONTRIBUTING.md?plain=1#L16-L17) guide instructs to install JupyterLab, but it's already present in [requirements-build.txt](https://github.com/geojupyter/jupytergis/blob/9946ec0821600ed6016fd2ecf98838baab52ef30/requirements-build.txt#L4).
Also, [pydantic v2.4.2](https://github.com/geojupyter/jupytergis/blob/9946ec0821600ed6016fd2ecf98838baab52ef30/requirements-build.txt#L7) doesn't seem to have wheels for Python 3.13, and would need a Rust compiler, so I guess a newer version should be allowed.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
