### PR TITLE
Use image layer in python API

### DIFF
--- a/examples/Notebook.ipynb
+++ b/examples/Notebook.ipynb
@@ -88,35 +88,6 @@
     "    ],\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a8c5e541-4467-4025-8216-3dfe228f8ae4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "doc.add_video_layer(\n",
-    "    urls=[\n",
-    "        \"https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4\",\n",
-    "        \"https://static-assets.mapbox.com/mapbox-gl-js/drone.webm\",\n",
-    "    ],\n",
-    "    coordinates=[\n",
-    "        [-122.51596391201019, 37.56238816766053],\n",
-    "        [-122.51467645168304, 37.56410183312965],\n",
-    "        [-122.51309394836426, 37.56339170854942],\n",
-    "        [-122.51423120498657, 37.56161849366671],\n",
-    "    ],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "da4fddb7-2b6e-4d6b-8dfd-9c72e662c39b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -321,7 +321,7 @@ class GISDocument(CommWidget):
         source_id = self._add_source(OBJECT_FACTORY.create_source(source, self))
 
         layer = {
-            "type": LayerType.RasterLayer,
+            "type": LayerType.ImageLayer,
             "name": name,
             "visible": True,
             "parameters": {"source": source_id, "opacity": opacity},


### PR DESCRIPTION
## Description
Resolves #296. The python API was still using raster layers when creating image layers. That must've been left over from when we were using MapLibre. I also removed the cell using the video layer because we don't have video layers in OpenLayers. 

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--297.org.readthedocs.build/en/297/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->