### PR TITLE
Add issue linkage to PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ What does this PR change? Why?
 ## Checklist
 
 - [ ] PR has a descriptive title and content.
+- [ ] PR description contains [linkages](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
 - [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
 - [ ] Checks are passing.
       Failing lint checks can be resolved with:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ What does this PR change? Why?
 ## Checklist
 
 - [ ] PR has a descriptive title and content.
-- [ ] PR description contains [linkages](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
+- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
 - [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
 - [ ] Checks are passing.
       Failing lint checks can be resolved with:


### PR DESCRIPTION
## Description

Add issue linkage checklist item to PR template.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
