### PR TITLE
Remove unnecessary jupyterlab install

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -64,9 +64,6 @@ Install dependencies and build
 
 .. code-block:: bash
 
-    # Install JupyterLab for jlpm
-    python -m pip install jupyterlab
-
     # Install packages in development mode.
     # WARNING: This step may hang indefinitely due to a bug in Nx. See
     #          troubleshooting below.


### PR DESCRIPTION
Follow-up of #295.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--301.org.readthedocs.build/en/301/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->