### PR TITLE
Add Hillshade layer to notebook api

### DIFF
--- a/packages/schema/src/schema/rasterDemSource.json
+++ b/packages/schema/src/schema/rasterDemSource.json
@@ -9,19 +9,9 @@
       "type": "string",
       "description": "The url to the tile provider"
     },
-    "tileSize": {
-      "type": "number",
-      "description": " The tile size",
-      "default": 512
-    },
     "attribution": {
       "type": "string",
       "description": "The attribution for the raster-dem source"
-    },
-    "encoding": {
-      "type": "string",
-      "enum": ["terrarium", "mapbox"],
-      "default": "mapbox"
     },
     "urlParameters": {
       "type": "object",

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -23,6 +23,7 @@ from .objects import (
     IVectorTileSource,
     IVideoSource,
     IWebGlLayer,
+    IRasterDemSource,
     LayerType,
     SourceType,
 )
@@ -414,6 +415,41 @@ class GISDocument(CommWidget):
 
         return self._add_layer(OBJECT_FACTORY.create_layer(layer, self))
 
+    def add_hillshade_layer(
+        self,
+        url: str,
+        name: str = "Hillshade Layer",
+        urlParameters: Dict = {},
+        attribution: str = "",
+    ):
+        """
+        Add a hillshade layer
+
+        :param str url: URL of the hillshade layer
+        :param str name: The name that will be used for the object in the document, defaults to "Hillshade Layer"
+        :param attribution: The attribution.
+        """
+
+        source = {
+            "type": SourceType.RasterDemSource,
+            "name": f"{name} Source",
+            "parameters": {
+                "url": url,
+                "attribution": attribution,
+                "urlParameters": urlParameters,
+            },
+        }
+        source_id = self._add_source(OBJECT_FACTORY.create_source(source, self))
+
+        layer = {
+            "type": LayerType.HillshadeLayer,
+            "name": name,
+            "visible": True,
+            "parameters": {"source": source_id},
+        }
+
+        return self._add_layer(OBJECT_FACTORY.create_layer(layer, self))
+
     def create_color_expr(
         self,
         color_stops: Dict,
@@ -655,6 +691,7 @@ class JGISSource(BaseModel):
         IImageSource,
         IVideoSource,
         IGeoTiffSource,
+        IRasterDemSource,
     ]
     _parent = Optional[GISDocument]
 
@@ -740,3 +777,4 @@ OBJECT_FACTORY.register_factory(SourceType.GeoJSONSource, IGeoJSONSource)
 OBJECT_FACTORY.register_factory(SourceType.ImageSource, IImageSource)
 OBJECT_FACTORY.register_factory(SourceType.VideoSource, IVideoSource)
 OBJECT_FACTORY.register_factory(SourceType.GeoTiffSource, IGeoTiffSource)
+OBJECT_FACTORY.register_factory(SourceType.RasterDemSource, IRasterDemSource)

--- a/python/jupytergis_lab/jupytergis_lab/notebook/objects/__init__.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/objects/__init__.py
@@ -13,3 +13,4 @@ from ._schema.geojsonsource import IGeoJSONSource  # noqa
 from ._schema.videoSource import IVideoSource  # noqa
 from ._schema.imageSource import IImageSource  # noqa
 from ._schema.geoTiffSource import IGeoTiffSource  # noqa
+from ._schema.rasterDemSource import IRasterDemSource  # noqa


### PR DESCRIPTION
## Description
Add `add_hillshade_layer` to notebook api and removes some old MapLibre stuff from the `RasterDemSource` schema.  
<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--304.org.readthedocs.build/en/304/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->