### PR TITLE
Add keyboard shortcuts for undo and redo

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -14,12 +14,14 @@ import { WidgetTracker, showErrorMessage } from '@jupyterlab/apputils';
 import { ICompletionProviderManager } from '@jupyterlab/completer';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator } from '@jupyterlab/translation';
+import { CommandRegistry } from '@lumino/commands';
+import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { CommandIDs, icons } from './constants';
 import { CreationFormDialog } from './dialogs/formdialog';
 import { LayerBrowserWidget } from './dialogs/layerBrowserDialog';
 import { SymbologyWidget } from './dialogs/symbology/symbologyDialog';
+import keybindings from './keybindings.json';
 import { JupyterGISWidget } from './widget';
-import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 
 interface ICreateEntry {
   tracker: WidgetTracker<JupyterGISWidget>;
@@ -31,6 +33,16 @@ interface ICreateEntry {
   layerData?: IDict;
   sourceType: SourceType;
   layerType?: LayerType;
+}
+
+function loadKeybindings(commands: CommandRegistry, keybindings: any[]) {
+  keybindings.forEach(binding => {
+    commands.addKeyBinding({
+      command: binding.command,
+      keys: binding.keys,
+      selector: binding.selector
+    });
+  });
 }
 
 /**
@@ -890,6 +902,8 @@ export function addCommands(
       model.centerOnPosition(layerId);
     }
   });
+
+  loadKeybindings(commands, keybindings);
 }
 
 namespace Private {

--- a/packages/base/src/keybindings.json
+++ b/packages/base/src/keybindings.json
@@ -1,0 +1,62 @@
+[
+  {
+    "command": "jupytergis:undo",
+    "keys": ["Accel Z"],
+    "selector": ".data-jgis-keybinding"
+  },
+  {
+    "command": "jupytergis:redo",
+    "keys": ["Accel Shift Z"],
+    "selector": ".data-jgis-keybinding"
+  },
+  {
+    "command": "jupytergis:identify",
+    "keys": ["Escape"],
+    "selector": ".data-jgis-keybinding"
+  },
+  {
+    "command": "jupytergis:removeSource",
+    "keys": ["Delete"],
+    "selector": ".data-jgis-keybinding .jp-gis-source.jp-gis-sourceUnused"
+  },
+  {
+    "command": "jupytergis:renameSource",
+    "keys": ["F2"],
+    "selector": ".data-jgis-keybinding .jp-gis-source"
+  },
+  {
+    "command": "jupytergis:removeLayer",
+    "keys": ["Delete"],
+    "selector": ".data-jgis-keybinding .jp-gis-layerItem"
+  },
+  {
+    "command": "jupytergis:renameLayer",
+    "keys": ["F2"],
+    "selector": ".data-jgis-keybinding .jp-gis-layerItem"
+  },
+  {
+    "command": "jupytergis:removeGroup",
+    "keys": ["Delete"],
+    "selector": ".data-jgis-keybinding .jp-gis-layerGroupHeader"
+  },
+  {
+    "command": "jupytergis:renameGroup",
+    "keys": ["F2"],
+    "selector": ".data-jgis-keybinding .jp-gis-layerGroupHeader"
+  },
+  {
+    "command": "jupytergis:executeConsole",
+    "keys": ["Shift Enter"],
+    "selector": ".jpgis-console .jp-CodeConsole[data-jp-interaction-mode='notebook'] .jp-CodeConsole-promptCell"
+  },
+  {
+    "command": "jupytergis:invokeConsoleCompleter",
+    "keys": ["Tab"],
+    "selector": ".jpgis-console .jp-CodeConsole-promptCell .jp-mod-completer-enabled"
+  },
+  {
+    "command": "jupytergis:selectConsoleCompleter",
+    "keys": ["Enter"],
+    "selector": ".jpgis-console .jp-ConsolePanel .jp-mod-completer-active"
+  }
+]

--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -37,6 +37,7 @@ export class LeftPanelWidget extends SidePanel {
   constructor(options: LeftPanelWidget.IOptions) {
     super();
     this.addClass('jGIS-sidepanel-widget');
+
     this._model = options.model;
     this._state = options.state;
 

--- a/packages/base/src/panelview/rightpanel.tsx
+++ b/packages/base/src/panelview/rightpanel.tsx
@@ -18,6 +18,7 @@ export class RightPanelWidget extends SidePanel {
   constructor(options: RightPanelWidget.IOptions) {
     super();
     this.addClass('jGIS-sidepanel-widget');
+
     this._model = options.model;
     this._annotationModel = options.annotationModel;
 

--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -47,6 +47,12 @@ export class ToolbarWidget extends ReactiveToolbar {
         })
       );
 
+      options.commands.addKeyBinding({
+        command: CommandIDs.undo,
+        keys: ['Accel Z'],
+        selector: '#main'
+      });
+
       this.addItem(
         'redo',
         new CommandToolbarButton({
@@ -56,6 +62,12 @@ export class ToolbarWidget extends ReactiveToolbar {
           commands: options.commands
         })
       );
+
+      options.commands.addKeyBinding({
+        command: CommandIDs.redo,
+        keys: ['Accel Shift Z'],
+        selector: '#main'
+      });
 
       this.addItem('separator0', new Separator());
 

--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -47,12 +47,6 @@ export class ToolbarWidget extends ReactiveToolbar {
         })
       );
 
-      options.commands.addKeyBinding({
-        command: CommandIDs.undo,
-        keys: ['Accel Z'],
-        selector: '#main'
-      });
-
       this.addItem(
         'redo',
         new CommandToolbarButton({
@@ -62,12 +56,6 @@ export class ToolbarWidget extends ReactiveToolbar {
           commands: options.commands
         })
       );
-
-      options.commands.addKeyBinding({
-        command: CommandIDs.redo,
-        keys: ['Accel Shift Z'],
-        selector: '#main'
-      });
 
       this.addItem('separator0', new Separator());
 
@@ -171,12 +159,6 @@ export class ToolbarWidget extends ReactiveToolbar {
           commands: options.commands
         })
       );
-
-      options.commands.addKeyBinding({
-        command: CommandIDs.identify,
-        keys: ['Escape'],
-        selector: '#main'
-      });
 
       this.addItem('spacer', ReactiveToolbar.createSpacerItem());
 

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -4,5 +4,10 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src/**/*", "src/schema/*.json", "src/_interface/*.json"]
+  "include": [
+    "src/**/*",
+    "src/schema/*.json",
+    "src/_interface/*.json",
+    "src/*.json"
+  ]
 }

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -78,6 +78,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
       completionProviderManager
     );
 
+    app.shell.addClass('data-jgis-keybinding');
+
     // SOURCES context menu
     const newSourceSubMenu = new Menu({ commands: app.commands });
     newSourceSubMenu.title.label = translator
@@ -129,22 +131,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
       command: CommandIDs.removeSource
     });
 
-    app.commands.addKeyBinding({
-      command: CommandIDs.removeSource,
-      keys: ['Delete'],
-      selector: '.jp-gis-source.jp-gis-sourceUnused'
-    });
-
     app.contextMenu.addItem({
       selector: '.jp-gis-source',
       rank: 1,
       command: CommandIDs.renameSource
-    });
-
-    app.commands.addKeyBinding({
-      command: CommandIDs.renameSource,
-      keys: ['F2'],
-      selector: '.jp-gis-sourceItem'
     });
 
     // LAYERS and LAYER GROUPS context menu
@@ -167,22 +157,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
       rank: 2
     });
 
-    app.commands.addKeyBinding({
-      command: CommandIDs.removeLayer,
-      keys: ['Delete'],
-      selector: '.jp-gis-layerItem'
-    });
-
     app.contextMenu.addItem({
       command: CommandIDs.renameLayer,
       selector: '.jp-gis-layerItem',
       rank: 2
-    });
-
-    app.commands.addKeyBinding({
-      command: CommandIDs.renameLayer,
-      keys: ['F2'],
-      selector: '.jp-gis-layerItem'
     });
 
     app.contextMenu.addItem({
@@ -214,22 +192,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
       rank: 2
     });
 
-    app.commands.addKeyBinding({
-      command: CommandIDs.removeGroup,
-      keys: ['Delete'],
-      selector: '.jp-gis-layerGroupHeader'
-    });
-
     app.contextMenu.addItem({
       command: CommandIDs.renameGroup,
       selector: '.jp-gis-layerGroupHeader',
       rank: 2
-    });
-
-    app.commands.addKeyBinding({
-      command: CommandIDs.renameGroup,
-      keys: ['F2'],
-      selector: '.jp-gis-layerGroupHeader'
     });
 
     // Separator
@@ -273,27 +239,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
     if (mainMenu) {
       populateMenus(mainMenu, isEnabled);
     }
-
-    // Keybindings for the console
-    app.commands.addKeyBinding({
-      command: CommandIDs.executeConsole,
-      keys: ['Shift Enter'],
-      selector:
-        ".jpgis-console .jp-CodeConsole[data-jp-interaction-mode='notebook'] .jp-CodeConsole-promptCell"
-    });
-
-    app.commands.addKeyBinding({
-      command: CommandIDs.invokeCompleter,
-      keys: ['Tab'],
-      selector:
-        '.jpgis-console .jp-CodeConsole-promptCell .jp-mod-completer-enabled'
-    });
-
-    app.commands.addKeyBinding({
-      command: CommandIDs.selectCompleter,
-      keys: ['Enter'],
-      selector: '.jpgis-console .jp-ConsolePanel .jp-mod-completer-active'
-    });
   }
 };
 


### PR DESCRIPTION
## Description
Fix for #308 

Adds keyboard shortcuts for undo and redo commands.
<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--320.org.readthedocs.build/en/320/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->