### PR TITLE
Add layer browser icon for geotiff

### DIFF
--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -78,12 +78,14 @@ const iconObject = {
   ImageSource: { iconClass: 'fa fa-image' },
   VideoSource: { iconClass: 'fa fa-video' },
   ShapefileSource: { iconClass: 'fa fa-file' },
+  GeoTiffSource: { iconClass: 'fa fa-gear' },
 
   RasterLayer: { icon: rasterIcon },
   VectorLayer: { iconClass: 'fa fa-vector-square' },
   HillshadeLayer: { icon: moundIcon },
   ImageLayer: { iconClass: 'fa fa-image' },
   VideoLayer: { iconClass: 'fa fa-video' },
+  WebGlLayer: { iconClass: 'fa fa-gear' },
 
   [CommandIDs.redo]: { icon: redoIcon },
   [CommandIDs.undo]: { icon: undoIcon },
@@ -95,7 +97,7 @@ const iconObject = {
   [CommandIDs.newImageEntry]: { iconClass: 'fa fa-image' },
   [CommandIDs.newVideoEntry]: { iconClass: 'fa fa-video' },
   [CommandIDs.newShapefileLayer]: { iconClass: 'fa fa-file' },
-  [CommandIDs.newGeoTiffEntry]: { iconClass: 'fa fa-image' },
+  [CommandIDs.newGeoTiffEntry]: { iconClass: 'fa fa-gear' },
   [CommandIDs.symbology]: { iconClass: 'fa fa-brush' },
   [CommandIDs.identify]: { iconClass: 'fa fa-info' }
 };


### PR DESCRIPTION
## Description
Adds icon for `GeoTiff` sources and and `WebGlTile` layers in the layer browser.

![geotifficon](https://github.com/user-attachments/assets/5abb21cb-7925-4f57-9ced-f5b8ff0908e1)

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
