### PR TITLE
Prototype of streamlined Graphical GIS <-> Notebook "bounce" workflow

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/geo_debug.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/geo_debug.py
@@ -1,0 +1,30 @@
+from sidecar import Sidecar
+
+from jupytergis_lab import GISDocument
+
+
+def geo_debug(geojson_path: str) -> None:
+    """Run a JupyterGIS data interaction interface alongside a Notebook."""
+    # TODO: allow user to specify a different project file; 
+    doc = GISDocument("debug.jgis")
+
+    # TODO: Basemap choices
+    doc.add_raster_layer("https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}")
+
+    # TODO: Support lots of file types
+    doc.add_geojson_layer(geojson_path)
+
+    # TODO: Zoom to layer; is that feasible to do from Python? Currently not exposed in
+    #       Python API.
+
+    # TODO: Make map take up the whole sidebar space.
+    # TODO: Toolbar not visible.
+    #       /home/shared/jupytergis/packages/base/src/toolbar/widget.tsx
+    #       
+    # TODO: Activate left and right panel -- not sure how feasible yet from Python.
+    #       Also, if using sidecar, right panel can't be displayed. Can we open a
+    #       "native" JupyterLab pane instead of using sidecar?
+
+    sc = Sidecar(title="JupyterGIS sidecar")
+    with sc:
+        display(doc)

--- a/python/jupytergis_lab/pyproject.toml
+++ b/python/jupytergis_lab/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "comm>=0.1.2,<0.2.0",
   "pydantic>=2,<3",
   "jupytergis_core>=0.1.0,<1",
+  "sidecar>=0.7.0",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Description

Just barely got started implementing a streamlined version of the "GIS<->Notebook bounce" workflow with huge thanks to @martinRenou for making some time to teach me stuff this morning! I wanted to share our progress so far.

Still TODO, and I don't have time today:

- [ ] Display the JupyterGIS toolbar in the widget; working on this now
- [ ] Add a video to this PR
- [ ] All the other TODOs in the changeset ;)

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
