### PR TITLE
Register new projections if needed when adding layers

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -134,6 +134,7 @@ export class MainView extends React.Component<IProps, IStates> {
     };
 
     this._sources = [];
+    this._loadingLayers = new Set();
     this._commands = new CommandRegistry();
     this._contextMenu = new ContextMenu({ commands: this._commands });
   }
@@ -761,10 +762,7 @@ export class MainView extends React.Component<IProps, IStates> {
       await this.addSource(sourceId, source, id);
     }
 
-    if (this._layerCounter === -1) {
-      this._layerCounter = 0;
-    }
-    this._layerCounter++;
+    this._loadingLayers.add(id);
 
     let newMapLayer;
     let layerParameters;
@@ -865,7 +863,7 @@ export class MainView extends React.Component<IProps, IStates> {
       register(proj4);
     }
 
-    this._layerCounter--;
+    this._loadingLayers.delete(id);
 
     return newMapLayer;
   }
@@ -1084,7 +1082,7 @@ export class MainView extends React.Component<IProps, IStates> {
   private _waitForReady(): Promise<void> {
     return new Promise(resolve => {
       const checkReady = () => {
-        if (this._layerCounter === 0) {
+        if (this._loadingLayers.size === 0) {
           resolve();
         } else {
           setTimeout(checkReady, 50);
@@ -1663,5 +1661,5 @@ export class MainView extends React.Component<IProps, IStates> {
   private _sourceToLayerMap = new Map();
   private _documentPath?: string;
   private _contextMenu: ContextMenu;
-  private _layerCounter = -1;
+  private _loadingLayers: Set<string>;
 }

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -40,11 +40,10 @@ import {
   VectorTile as VectorTileLayer,
   WebGLTile as WebGlTileLayer
 } from 'ol/layer';
-// import BaseLayer from 'ol/layer/Base';
 import TileLayer from 'ol/layer/Tile';
 import {
   fromLonLat,
-  get as olGetProj,
+  get as getRegisteredProjection,
   toLonLat,
   transformExtent
 } from 'ol/proj';
@@ -52,7 +51,6 @@ import Feature from 'ol/render/Feature';
 import {
   GeoTIFF as GeoTIFFSource,
   ImageTile as ImageTileSource,
-  Source,
   Vector as VectorSource,
   VectorTile as VectorTileSource,
   XYZ as XYZSource
@@ -101,36 +99,6 @@ interface IStates {
 export class MainView extends React.Component<IProps, IStates> {
   constructor(props: IProps) {
     super(props);
-
-    // console.log('proj4list["EPSG:22300"]', proj4list['EPSG:22300']);
-    // const proj4Values: [string, string][] = Object.values(proj4list);
-
-    // const proj4Filtered = proj4Values.filter(([_, second]) => second !== '');
-
-    // const excludedCodes = [
-    //   'EPSG:4326',
-    //   'EPSG:4269',
-    //   'EPSG:32601',
-    //   'EPSG:32701',
-    //   'EPSG:32602',
-    //   'EPSG:32702',
-    //   'EPSG:32603',
-    //   'EPSG:32703',
-    //   'EPSG:32604',
-    //   'EPSG:32704',
-    //   'EPSG:32605',
-    //   'EPSG:32705',
-    //   'EPSG:32606',
-    //   'EPSG:32706',
-    //   'EPSG:32607',
-    //   'EPSG:3785',
-    //   'EPSG:5514',
-    //   'EPSG:27700',
-    //   'EPSG:28992'
-    // ];
-    // proj4.defs(proj4Filtered);
-
-    // register(proj4);
 
     this._mainViewModel = this.props.viewModel;
     this._mainViewModel.viewSettingChanged.connect(this._onViewChanged, this);
@@ -468,8 +436,7 @@ export class MainView extends React.Component<IProps, IStates> {
     source: IJGISSource,
     layerId?: string
   ): Promise<void> {
-    let newSource: Source;
-    this._ready = false;
+    let newSource;
 
     switch (source.type) {
       case 'RasterSource': {
@@ -654,54 +621,9 @@ export class MainView extends React.Component<IProps, IStates> {
       }
     }
 
-    //@ts-expect-error isidsd
-    this.waitForSourceReady(newSource)
-      .then(() => {
-        console.log('The source is ready!');
-        newSource.set('id', id);
-        // const sp = newSource.getProjection();
-        // const c = sp?.getCode();
-        // console.log('source = id', id);
-        // console.log('source = sp', sp);
-        // _sources is a list of OpenLayers sources
-        this.addProj(newSource);
-        this._sources[id] = newSource;
-
-        // const l1 = olGetProj(c);
-        // console.log('l1', l1, c);
-        // if (!l1) {
-        //   proj4.defs([proj4list[c]]);
-        //   register(proj4);
-        // }
-        // const l2 = olGetProj(c);
-        // console.log('l2', l2);
-        this._ready = true;
-      })
-      .catch(error => {
-        console.error('An error occurred:', error.message);
-      });
-  }
-
-  waitForSourceReady(source: Source) {
-    return new Promise<void>((resolve, reject) => {
-      const checkState = () => {
-        const state = source.getState();
-        console.log(`Source state: ${state}`);
-        if (state === 'ready') {
-          source.un('change', checkState); // Stop listening once it's ready
-          resolve(); // Resolve the promise
-        } else if (state === 'error') {
-          source.un('change', checkState); // Stop listening on error
-          reject(new Error('Source failed to load.'));
-        }
-      };
-
-      // Listen for state changes
-      source.on('change', checkState);
-
-      // Check the state immediately in case it's already 'ready'
-      checkState();
-    });
+    newSource.set('id', id);
+    // _sources is a list of OpenLayers sources
+    this._sources[id] = newSource;
   }
 
   private computeSourceUrl(source: IJGISSource): string {
@@ -839,6 +761,11 @@ export class MainView extends React.Component<IProps, IStates> {
       await this.addSource(sourceId, source, id);
     }
 
+    if (this._layerCounter === -1) {
+      this._layerCounter = 0;
+    }
+    this._layerCounter++;
+
     let newMapLayer;
     let layerParameters;
 
@@ -921,11 +848,24 @@ export class MainView extends React.Component<IProps, IStates> {
       }
     }
 
+    await this._waitForSourceReady(newMapLayer);
+
     // OpenLayers doesn't have name/id field so add it
     newMapLayer.set('id', id);
 
     // we need to keep track of which source has which layers
     this._sourceToLayerMap.set(layerParameters.source, id);
+
+    const sourceProjection = newMapLayer.getSource().getProjection();
+    const projectionCode = sourceProjection?.getCode();
+    const isProjectionRegistered = getRegisteredProjection(projectionCode);
+
+    if (!isProjectionRegistered) {
+      proj4.defs([proj4list[projectionCode]]);
+      register(proj4);
+    }
+
+    this._layerCounter--;
 
     return newMapLayer;
   }
@@ -945,50 +885,10 @@ export class MainView extends React.Component<IProps, IStates> {
 
     const newMapLayer = await this._buildMapLayer(id, layer);
     if (newMapLayer !== undefined) {
-      await this.waitForReady();
+      await this._waitForReady();
 
-      console.log('calling insert');
       this._Map.getLayers().insertAt(index, newMapLayer);
     }
-  }
-
-  addProj(newMapLayer: Source) {
-    // const s = newMapLayer.getSource();
-    // console.log('josn shit', JSON.parse(JSON.stringify(s)));
-    const spp = newMapLayer.getProjection();
-    const c = spp?.getCode();
-    console.log('addProj projection', spp);
-    const test = olGetProj('EPSG:3857');
-    console.log('test projection', test);
-    const l1 = olGetProj(c);
-    console.log('added projection pre', l1);
-    if (!l1) {
-      proj4.defs([proj4list[c]]);
-      register(proj4);
-    }
-    const l2 = olGetProj(c);
-    console.log('added projection post', l2);
-  }
-
-  /**
-   * Waits until the `ready` boolean in the parent class is `true`.
-   */
-  private waitForReady(): Promise<void> {
-    return new Promise(resolve => {
-      const checkReady = () => {
-        if (this._ready) {
-          // If ready, resolve the promise
-          console.log('ready in waitForReady');
-          resolve();
-        } else {
-          // If not ready, check again after a short delay
-          console.log('setting timeout in waitForReady');
-          setTimeout(checkReady, 50); // Poll every 50ms
-        }
-      };
-
-      checkReady();
-    });
   }
 
   vectorLayerStyleRuleBuilder = (layer: IJGISLayer) => {
@@ -1176,6 +1076,48 @@ export class MainView extends React.Component<IProps, IStates> {
         break;
       }
     }
+  }
+
+  /**
+   * Wait for all layers to be loaded.
+   */
+  private _waitForReady(): Promise<void> {
+    return new Promise(resolve => {
+      const checkReady = () => {
+        if (this._layerCounter === 0) {
+          resolve();
+        } else {
+          setTimeout(checkReady, 50);
+        }
+      };
+
+      checkReady();
+    });
+  }
+
+  /**
+   * Wait for a layers source state to be 'ready'
+   * @param layer The Layer to check
+   */
+  private _waitForSourceReady(layer: Layer) {
+    return new Promise<void>((resolve, reject) => {
+      const checkState = () => {
+        const state = layer.getSourceState();
+        if (state === 'ready') {
+          layer.un('change', checkState);
+          resolve();
+        } else if (state === 'error') {
+          layer.un('change', checkState);
+          reject(new Error('Source failed to load.'));
+        }
+      };
+
+      // Listen for state changes
+      layer.on('change', checkState);
+
+      // Check the state immediately in case it's already 'ready'
+      checkState();
+    });
   }
 
   /**
@@ -1721,4 +1663,5 @@ export class MainView extends React.Component<IProps, IStates> {
   private _sourceToLayerMap = new Map();
   private _documentPath?: string;
   private _contextMenu: ContextMenu;
+  private _layerCounter = -1;
 }


### PR DESCRIPTION
## Description
Fix for #326 

This checks that the projection for a new layer is already registered with OpenLayers, and if not it registers the projection using definitions from  `Proj4List`
<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--343.org.readthedocs.build/en/343/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->