### PR TITLE
Include files in lite deployment for `local.jGIS`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,12 @@ copyright = "2024, The JupyterGIS Development Team"
 author = "The JupyterGIS Development Team"
 language = "en"
 
-jupyterlite_contents = ["../examples/*.jGIS", "../examples/*.json"]
+jupyterlite_contents = [
+    "../examples/*.jGIS",
+    "../examples/*.json",
+    "../examples/nyc.zip",
+    "../examples/radar.gif",
+]
 jupyterlite_dir = "."
 jupyterlite_config = "jupyter_lite_config.json"
 jupyterlite_silence = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ jupyterlite_contents = [
     "../examples/*.json",
     "../examples/*.zip",
     "../examples/*.gif",
+    "../examples/*.geojson",
 ]
 jupyterlite_dir = "."
 jupyterlite_config = "jupyter_lite_config.json"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,8 +24,8 @@ language = "en"
 jupyterlite_contents = [
     "../examples/*.jGIS",
     "../examples/*.json",
-    "../examples/nyc.zip",
-    "../examples/radar.gif",
+    "../examples/*.zip",
+    "../examples/*.gif",
 ]
 jupyterlite_dir = "."
 jupyterlite_config = "jupyter_lite_config.json"


### PR DESCRIPTION
## Description

Shall close #344 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/bc8287c5-80f7-416d-bdf9-e51a219bcfc4" />


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--345.org.readthedocs.build/en/345/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->