### PR TITLE
Fix JupyterGISDoc.setSource

### DIFF
--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -55,10 +55,14 @@ export class JupyterGISDoc
     return { layers, layerTree, sources, options, metadata };
   }
 
-  setSource(value: JSONObject): void {
+  setSource(value: JSONObject | string): void {
     if (!value) {
       return;
     }
+    if (typeof value === 'string') {
+      value = JSON.parse(value);
+    }
+    value = value as JSONObject;
     this.transact(() => {
       const layers = value['layers'] ?? {};
       Object.entries(layers).forEach(([key, val]) =>


### PR DESCRIPTION
## Description

The source can be set from a JSON or a string value, according to jupyter-ydoc's [API](https://github.com/jupyter-server/jupyter_ydoc/blob/697715eb03ae6870e97dd0ccc2ea385debd8aa51/javascript/src/api.ts#L143).

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--346.org.readthedocs.build/en/346/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->