### PR TITLE
Fix Lite Deployment Badge via RTD on PR using Custom Action

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -16,10 +16,10 @@ jobs:
   autolink-rtd-previews:
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'readthedocs/actions/preview@v1'
+      - uses: 'mfisher87/readthedocs-actions/preview@main'
         with:
           project-slug: 'jupytergis'
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)
+            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]({docs-pr-index-url}/lite)

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -22,4 +22,4 @@ jobs:
           message-template: |
             ---
             📚 Documentation preview: {docs-pr-index-url}
-            💡 JupyterLite preview is available from the doc, by clicking on [![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)]({docs-pr-index-url}/lite)
+            💡 JupyterLite preview: {docs-pr-index-url}lite


### PR DESCRIPTION
---------

## Description

This fixes the lite badge on PR which now correctly redirects to Read the Docs lite deployment.

This was a nasty one!

All thanks to @mfisher87 for patching the [GH action on his fork](https://github.com/mfisher87/readthedocs-actions) that we've been using 🚀 

It has been tested on [this PR on my fork](https://github.com/arjxn-py/jupytergis/pull/19)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--356.org.readthedocs.build/en/356/
💡 JupyterLite preview is available from the doc, by clicking on ![lite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)

<!-- readthedocs-preview jupytergis end -->