### PR TITLE
Add a pretty JupyterLite button to docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,4 +37,4 @@ repos:
     rev: v6.2.4
     hooks:
       - id: rstcheck
-        args: ['--ignore-directives=tabs,toctree,autoclass', '--report-level=warning']
+        args: ['--ignore-directives=tabs,toctree,autoclass,cssclass', '--report-level=warning']

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -1,0 +1,17 @@
+.try-in-jupyterlite-button a {
+  background-color: #f7dc1e;
+  color: black;
+  text-decoration: none;
+
+  border: none;
+  padding: 5px 10px;
+  border-radius: 15px;
+  font-family: vibur;
+  font-size: larger;
+  box-shadow: 0 2px 5px rgba(108, 108, 108, 0.2);
+}
+
+.try-in-jupyterlite-button a:hover {
+  color: white;
+  box-shadow: 0 2px 5px #f7dc1e;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,11 @@ on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {"github_url": "https://github.com/geojupyter/jupytergis"}
 
+html_static_path = ["assets"]
+html_css_files = [
+    "css/custom.css",
+]
+
 extensions = [
     "jupyterlite_sphinx",
     "sphinx.ext.autodoc",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,9 +2,9 @@
 JupyterGIS
 ==========
 
-.. image:: https://jupyterlite.rtfd.io/en/latest/_static/badge.svg
-   :alt: Try JupyterGIS now in JupyterLite!
-   :target: lite/
+.. cssclass:: try-in-jupyterlite-button
+
+  `Try it with JupyterLite! <lite/>`_
 
 JupyterGIS is a JupyterLab extension for collaborative GIS (Geographical Information System). It is designed to
 allow multiple people to work on the same geospatial project simultaneously, facilitating discussion and collaboration


### PR DESCRIPTION
## Description

![Recording 2025-01-17 at 18 23 18](https://github.com/user-attachments/assets/79006f37-e9b5-4745-b35f-cdf58b25be3e)

I knew I had seen this somewhere! Someone amazing found it :) https://jupyter.zulipchat.com/#narrow/channel/474838-jupyterlite/topic/Beautiful.20.22Try.20JupyterLite.22.20button/near/494275235

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--361.org.readthedocs.build/en/361/
💡 JupyterLite preview: https://jupytergis--361.org.readthedocs.build/en/361/lite

<!-- readthedocs-preview jupytergis end -->