### PR TITLE
Add Path Validation for `ShapefileSource` and `ImageSource`.

### DIFF
--- a/packages/base/src/formbuilder/creationform.tsx
+++ b/packages/base/src/formbuilder/creationform.tsx
@@ -213,6 +213,7 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
               formChangedSignal={this.sourceFormChangedSignal}
               formErrorSignal={this.props.formErrorSignal}
               dialogOptions={this.props.dialogOptions}
+              sourceType={this.props.sourceType}
             />
           </div>
         )}

--- a/packages/base/src/formbuilder/editform.tsx
+++ b/packages/base/src/formbuilder/editform.tsx
@@ -120,6 +120,7 @@ export class EditForm extends React.Component<IEditFormProps, any> {
                 this.syncObjectProperties(this.props.source, properties);
               }}
               formChangedSignal={this.sourceFormChangedSignal}
+              sourceType={source?.type || 'RasterSource'}
             />
           </div>
         )}

--- a/packages/base/src/formbuilder/formselectors.ts
+++ b/packages/base/src/formbuilder/formselectors.ts
@@ -7,6 +7,7 @@ import { TileSourcePropertiesForm } from './objectform/tilesourceform';
 import { VectorLayerPropertiesForm } from './objectform/vectorlayerform';
 import { WebGlLayerPropertiesForm } from './objectform/webGlLayerForm';
 import { GeoTiffSourcePropertiesForm } from './objectform/geotiffsource';
+import { PathBasedSourcePropertiesForm } from './objectform/pathbasedsource';
 
 export function getLayerTypeForm(
   layerType: LayerType
@@ -36,6 +37,12 @@ export function getSourceTypeForm(sourceType: SourceType): typeof BaseForm {
     case 'GeoJSONSource':
       SourceForm = GeoJSONSourcePropertiesForm;
       break;
+    case 'ImageSource':
+      SourceForm = PathBasedSourcePropertiesForm;
+      break;
+    case 'ShapefileSource':
+      SourceForm = PathBasedSourcePropertiesForm;
+      break;
     case 'GeoTiffSource':
       SourceForm = GeoTiffSourcePropertiesForm;
       break;
@@ -45,6 +52,7 @@ export function getSourceTypeForm(sourceType: SourceType): typeof BaseForm {
       break;
     // ADD MORE FORM TYPES HERE
   }
+  (SourceForm as any).sourceType = sourceType;
 
   return SourceForm;
 }

--- a/packages/base/src/formbuilder/formselectors.ts
+++ b/packages/base/src/formbuilder/formselectors.ts
@@ -52,7 +52,5 @@ export function getSourceTypeForm(sourceType: SourceType): typeof BaseForm {
       break;
     // ADD MORE FORM TYPES HERE
   }
-  (SourceForm as any).sourceType = sourceType;
-
   return SourceForm;
 }

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -8,6 +8,7 @@ import { Signal } from '@lumino/signaling';
 import { deepCopy } from '../../tools';
 import { IDict } from '../../types';
 import { Slider, SliderLabel } from '@jupyter/react-components';
+import { SourceType } from '@jupytergis/schema';
 
 export interface IBaseFormStates {
   schema?: IDict;
@@ -72,6 +73,11 @@ export interface IBaseFormProps {
    * and other form-related parameters.
    */
   dialogOptions?: any;
+
+  /**
+   * Source type property
+   */
+  sourceType: SourceType;
 }
 
 const WrappedFormComponent = (props: any): JSX.Element => {

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -8,7 +8,6 @@ import { Signal } from '@lumino/signaling';
 import { deepCopy } from '../../tools';
 import { IDict } from '../../types';
 import { Slider, SliderLabel } from '@jupyter/react-components';
-import { FileSelectorWidget } from './fileselectorwidget';
 
 export interface IBaseFormStates {
   schema?: IDict;
@@ -201,20 +200,6 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
         if (this.props.formContext === 'update') {
           this.removeFormEntry(k, data, schema, uiSchema);
         }
-      }
-
-      // Customize the widget for path field
-      if (schema.properties && schema.properties.path) {
-        const docManager =
-          this.props.formChangedSignal?.sender.props.formSchemaRegistry.getDocManager();
-
-        uiSchema.path = {
-          'ui:widget': FileSelectorWidget,
-          'ui:options': {
-            docManager,
-            formOptions: this.props
-          }
-        };
       }
     });
   }

--- a/packages/base/src/formbuilder/objectform/fileselectorwidget.tsx
+++ b/packages/base/src/formbuilder/objectform/fileselectorwidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { FileDialog } from '@jupyterlab/filebrowser';
 import { Dialog } from '@jupyterlab/apputils';
 import { CreationFormDialog } from '../../dialogs/formdialog';
@@ -10,9 +10,10 @@ export const FileSelectorWidget = (props: any) => {
 
   const [serverFilePath, setServerFilePath] = useState('');
   const [urlPath, setUrlPath] = useState('');
+  const isTypingURL = useRef(false); // Tracks whether the user is manually typing a URL
 
   useEffect(() => {
-    if (props.value) {
+    if (!isTypingURL.current && props.value) {
       if (
         props.value.startsWith('http://') ||
         props.value.startsWith('https://')
@@ -85,10 +86,15 @@ export const FileSelectorWidget = (props: any) => {
   };
 
   const handleURLChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const url = event.target.value;
-    setServerFilePath('');
+    const url = event.target.value.trim();
+    isTypingURL.current = true;
     setUrlPath(url);
+    setServerFilePath('');
     props.onChange(url);
+  };
+
+  const handleURLBlur = () => {
+    isTypingURL.current = false;
   };
 
   return (
@@ -114,6 +120,7 @@ export const FileSelectorWidget = (props: any) => {
           id="root_path"
           className="jp-mod-styled"
           onChange={handleURLChange}
+          onBlur={handleURLBlur}
           value={urlPath || ''}
           style={{ width: '100%' }}
         />

--- a/packages/base/src/formbuilder/objectform/geojsonsource.ts
+++ b/packages/base/src/formbuilder/objectform/geojsonsource.ts
@@ -45,7 +45,7 @@ export class GeoJSONSourcePropertiesForm extends PathBasedSourcePropertiesForm {
       try {
         const geoJSONData = await loadFile({
           filepath: path,
-          type: this._sourceType,
+          type: this.props.sourceType,
           model: this.props.model
         });
         valid = this._validate(geoJSONData);

--- a/packages/base/src/formbuilder/objectform/geojsonsource.ts
+++ b/packages/base/src/formbuilder/objectform/geojsonsource.ts
@@ -1,17 +1,17 @@
 import { IDict } from '@jupytergis/schema';
-import { showErrorMessage } from '@jupyterlab/apputils';
-import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
 import { Ajv, ValidateFunction } from 'ajv';
 import * as geojson from '@jupytergis/schema/src/schema/geojson.json';
 
-import { BaseForm, IBaseFormProps } from './baseform';
+import { IBaseFormProps } from './baseform';
+import { PathBasedSourcePropertiesForm } from './pathbasedsource';
 import { loadFile } from '../../tools';
-import { FileSelectorWidget } from './fileselectorwidget';
 
 /**
  * The form to modify a GeoJSON source.
  */
-export class GeoJSONSourcePropertiesForm extends BaseForm {
+export class GeoJSONSourcePropertiesForm extends PathBasedSourcePropertiesForm {
+  private _validate: ValidateFunction;
+
   constructor(props: IBaseFormProps) {
     super(props);
     const ajv = new Ajv();
@@ -29,54 +29,6 @@ export class GeoJSONSourcePropertiesForm extends BaseForm {
     }
 
     super.processSchema(data, schema, uiSchema);
-    if (!schema.properties || !data) {
-      return;
-    }
-
-    // This is not user-editable
-    delete schema.properties.valid;
-
-    // Customize the widget for path field
-    if (schema.properties && schema.properties.path) {
-      const docManager =
-        this.props.formChangedSignal?.sender.props.formSchemaRegistry.getDocManager();
-
-      uiSchema.path = {
-        'ui:widget': FileSelectorWidget,
-        'ui:options': {
-          docManager,
-          formOptions: this.props
-        }
-      };
-    }
-  }
-
-  protected onFormBlur(id: string, value: any) {
-    // Is there a better way to spot the path text entry?
-    if (!id.endsWith('_path')) {
-      return;
-    }
-
-    this._validatePath(value);
-  }
-
-  // we need to use `onFormChange` instead of `onFormBlur` because it's no longer a text field
-  protected onFormChange(e: IChangeEvent): void {
-    super.onFormChange(e);
-    if (e.formData?.path !== undefined) {
-      this._validatePath(e.formData.path);
-    }
-  }
-
-  protected onFormSubmit(e: ISubmitEvent<any>) {
-    if (this.state.extraErrors?.path?.__errors?.length >= 1) {
-      showErrorMessage(
-        'Invalid JSON file',
-        this.state.extraErrors.path.__errors[0]
-      );
-      return;
-    }
-    super.onFormSubmit(e);
   }
 
   /**
@@ -84,7 +36,7 @@ export class GeoJSONSourcePropertiesForm extends BaseForm {
    *
    * @param path - the path to validate.
    */
-  private async _validatePath(path: string) {
+  protected async _validatePath(path: string) {
     const extraErrors: IDict = this.state.extraErrors;
 
     let error = '';
@@ -93,7 +45,7 @@ export class GeoJSONSourcePropertiesForm extends BaseForm {
       try {
         const geoJSONData = await loadFile({
           filepath: path,
-          type: 'GeoJSONSource',
+          type: this._sourceType,
           model: this.props.model
         });
         valid = this._validate(geoJSONData);
@@ -127,6 +79,4 @@ export class GeoJSONSourcePropertiesForm extends BaseForm {
       this.props.formErrorSignal.emit(!valid);
     }
   }
-
-  private _validate: ValidateFunction;
 }

--- a/packages/base/src/formbuilder/objectform/pathbasedsource.ts
+++ b/packages/base/src/formbuilder/objectform/pathbasedsource.ts
@@ -17,8 +17,9 @@ export class PathBasedSourcePropertiesForm extends BaseForm {
     this._sourceType = (
       this.constructor as typeof BaseForm & { sourceType: SourceType }
     ).sourceType;
-    if (this._sourceType !== 'GeoJSONSource')
-      {this._validatePath(props.sourceData?.path ?? '');}
+    if (this._sourceType !== 'GeoJSONSource') {
+      this._validatePath(props.sourceData?.path ?? '');
+    }
   }
 
   protected processSchema(

--- a/packages/base/src/formbuilder/objectform/pathbasedsource.ts
+++ b/packages/base/src/formbuilder/objectform/pathbasedsource.ts
@@ -18,7 +18,7 @@ export class PathBasedSourcePropertiesForm extends BaseForm {
       this.constructor as typeof BaseForm & { sourceType: SourceType }
     ).sourceType;
     if (this._sourceType !== 'GeoJSONSource')
-      this._validatePath(props.sourceData?.path ?? '');
+      {this._validatePath(props.sourceData?.path ?? '');}
   }
 
   protected processSchema(

--- a/packages/base/src/formbuilder/objectform/pathbasedsource.ts
+++ b/packages/base/src/formbuilder/objectform/pathbasedsource.ts
@@ -1,4 +1,4 @@
-import { IDict, SourceType } from '@jupytergis/schema';
+import { IDict } from '@jupytergis/schema';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
 
@@ -10,14 +10,10 @@ import { FileSelectorWidget } from './fileselectorwidget';
  * The form to modify a PathBasedSource source.
  */
 export class PathBasedSourcePropertiesForm extends BaseForm {
-  protected _sourceType: SourceType;
-
   constructor(props: IBaseFormProps) {
     super(props);
-    this._sourceType = (
-      this.constructor as typeof BaseForm & { sourceType: SourceType }
-    ).sourceType;
-    if (this._sourceType !== 'GeoJSONSource') {
+
+    if (this.props.sourceType !== 'GeoJSONSource') {
       this._validatePath(props.sourceData?.path ?? '');
     }
   }
@@ -90,12 +86,12 @@ export class PathBasedSourcePropertiesForm extends BaseForm {
       try {
         await loadFile({
           filepath: path,
-          type: this._sourceType,
+          type: this.props.sourceType,
           model: this.props.model
         });
       } catch (e) {
         valid = false;
-        error = `"${path}" is not a valid ${this._sourceType} file.`;
+        error = `"${path}" is not a valid ${this.props.sourceType} file.`;
       }
     }
 

--- a/packages/base/src/formbuilder/objectform/pathbasedsource.ts
+++ b/packages/base/src/formbuilder/objectform/pathbasedsource.ts
@@ -10,14 +10,15 @@ import { FileSelectorWidget } from './fileselectorwidget';
  * The form to modify a PathBasedSource source.
  */
 export class PathBasedSourcePropertiesForm extends BaseForm {
-  private _sourceType: SourceType;
+  protected _sourceType: SourceType;
 
   constructor(props: IBaseFormProps) {
     super(props);
     this._sourceType = (
       this.constructor as typeof BaseForm & { sourceType: SourceType }
     ).sourceType;
-    this._validatePath(props.sourceData?.path ?? '');
+    if (this._sourceType !== 'GeoJSONSource')
+      this._validatePath(props.sourceData?.path ?? '');
   }
 
   protected processSchema(
@@ -43,6 +44,8 @@ export class PathBasedSourcePropertiesForm extends BaseForm {
         }
       };
     }
+    // This is not user-editable
+    delete schema.properties.valid;
   }
 
   protected onFormBlur(id: string, value: any) {
@@ -74,7 +77,7 @@ export class PathBasedSourcePropertiesForm extends BaseForm {
    *
    * @param path - the path to validate.
    */
-  private async _validatePath(path: string) {
+  protected async _validatePath(path: string) {
     const extraErrors: IDict = this.state.extraErrors;
 
     let error = '';


### PR DESCRIPTION
## Description

Resolves https://github.com/geojupyter/jupytergis/issues/357.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--362.org.readthedocs.build/en/362/
💡 JupyterLite preview: https://jupytergis--362.org.readthedocs.build/en/362/lite

<!-- readthedocs-preview jupytergis end -->