### PR TITLE
Disable Image Smoothing for `ImageSource`

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -80,6 +80,7 @@ import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { singleClick } from 'ol/events/condition';
 import TileSource from 'ol/source/Tile';
 import { FeatureLike } from 'ol/Feature';
+import ImageSource from 'ol/source/Image';
 
 interface IProps {
   viewModel: MainViewModel;
@@ -1127,6 +1128,21 @@ export class MainView extends React.Component<IProps, IStates> {
         const state = layer.getSourceState();
         if (state === 'ready') {
           layer.un('change', checkState);
+
+          // Apply image smoothing logic for image layers only
+          const source = layer.getSource();
+          if (source && source instanceof ImageSource) {
+            layer.on('prerender', event => {
+              const context = event.context;
+              if (context && context.canvas) {
+                const canvasContext = context.canvas.getContext('2d');
+                if (canvasContext) {
+                  canvasContext.imageSmoothingEnabled = false;
+                }
+              }
+            });
+          }
+
           resolve();
         } else if (state === 'error') {
           layer.un('change', checkState);


### PR DESCRIPTION
## Description

Fixes https://github.com/geojupyter/jupytergis/issues/353.

Before
![image](https://github.com/user-attachments/assets/4560253d-fc16-462a-9875-731d44fa20a9)

After
![image](https://github.com/user-attachments/assets/3bfc6fe0-26f9-4294-acb3-b5499f2c388b)


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--364.org.readthedocs.build/en/364/
💡 JupyterLite preview: https://jupytergis--364.org.readthedocs.build/en/364/lite

<!-- readthedocs-preview jupytergis end -->