### PR TITLE
Keep extension package name extension-artifacts for 3.12 to fix bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload extension packages
         uses: actions/upload-artifact@v4
         with:
-          name: extension-artifacts-${{ matrix.python-version }}
+          name: ${{ matrix.python-version == '3.12' && 'extension-artifacts' || format('extension-artifacts-{0}', matrix.python-version) }}
           path: |
             python/jupytergis_core/dist/jupytergis*
             python/jupytergis_lab/dist/jupytergis*
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: extension-artifacts-3.12
+          name: extension-artifacts
 
       - name: Install and Test
         shell: bash -l {0}
@@ -166,7 +166,7 @@ jobs:
       - name: Download extension package
         uses: actions/download-artifact@v4
         with:
-          name: extension-artifacts-3.12
+          name: extension-artifacts
 
       - name: Install the extension
         shell: bash -l {0}
@@ -279,7 +279,7 @@ jobs:
       - name: Download extension package
         uses: actions/download-artifact@v4
         with:
-          name: extension-artifacts-3.12
+          name: extension-artifacts
 
       - name: Install the extension
         shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,10 @@ jobs:
           pip install hatch
           yarn build:packages
 
+      - name: Log extension package name
+        run: |
+          echo "Extension package name: ${{ matrix.python-version == '3.12' && 'extension-artifacts' || format('extension-artifacts-{0}', matrix.python-version) }}"
+
       - name: Upload extension packages
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,6 @@ jobs:
           pip install hatch
           yarn build:packages
 
-      - name: Log extension package name
-        run: |
-          echo "Extension package name: ${{ matrix.python-version == '3.12' && 'extension-artifacts' || format('extension-artifacts-{0}', matrix.python-version) }}"
-
       - name: Upload extension packages
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--366.org.readthedocs.build/en/366/
💡 JupyterLite preview: https://jupytergis--366.org.readthedocs.build/en/366/lite

<!-- readthedocs-preview jupytergis end -->