### PR TITLE
Use `interpolate` property to Disable Image Smoothing for `ImageLayers`

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -64,7 +64,6 @@ import {
   VectorTile as VectorTileSource,
   XYZ as XYZSource
 } from 'ol/source';
-import ImageSource from 'ol/source/Image';
 import Static from 'ol/source/ImageStatic';
 import TileSource from 'ol/source/Tile';
 import { Circle, Fill, Stroke, Style } from 'ol/style';
@@ -621,7 +620,7 @@ export class MainView extends React.Component<IProps, IStates> {
         newSource = new Static({
           imageExtent: extent,
           url: imageUrl,
-          interpolate: true,
+          interpolate: false,
           crossOrigin: ''
         });
 
@@ -1164,21 +1163,6 @@ export class MainView extends React.Component<IProps, IStates> {
         const state = layer.getSourceState();
         if (state === 'ready') {
           layer.un('change', checkState);
-
-          // Apply image smoothing logic for image layers only
-          const source = layer.getSource();
-          if (source && source instanceof ImageSource) {
-            layer.on('prerender', event => {
-              const context = event.context;
-              if (context && context.canvas) {
-                const canvasContext = context.canvas.getContext('2d');
-                if (canvasContext) {
-                  canvasContext.imageSmoothingEnabled = false;
-                }
-              }
-            });
-          }
-
           resolve();
         } else if (state === 'error') {
           layer.un('change', checkState);


### PR DESCRIPTION
## Description

Fixes https://github.com/geojupyter/jupytergis/issues/372.
Thanks @gjmooney 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--373.org.readthedocs.build/en/373/
💡 JupyterLite preview: https://jupytergis--373.org.readthedocs.build/en/373/lite

<!-- readthedocs-preview jupytergis end -->