### PR TITLE
Support path lib objects

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -48,7 +48,7 @@ class GISDocument(CommWidget):
 
     def __init__(
         self,
-        path: Optional[str] = None,
+        path: Optional[str | Path] = None,
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
         zoom: Optional[float] = None,
@@ -57,7 +57,10 @@ class GISDocument(CommWidget):
         pitch: Optional[float] = None,
         projection: Optional[str] = None,
     ):
-        comm_metadata = GISDocument._path_to_comm(str(path))
+        if isinstance(path, Path):
+            path = str(path)
+
+        comm_metadata = GISDocument._path_to_comm(path)
 
         ydoc = Doc()
 
@@ -102,9 +105,12 @@ class GISDocument(CommWidget):
         """
         return self._layerTree.to_py()
 
-    def export_to_qgis(self, path: str) -> bool:
+    def export_to_qgis(self, path: str | Path) -> bool:
         # Lazy import, jupytergis_qgis of qgis may not be installed
         from jupytergis_qgis.qgis_loader import export_project_to_qgis
+
+        if isinstance(path, Path):
+            path = str(path)
 
         virtual_file = {
             "layers": self._layers.to_py(),
@@ -227,7 +233,7 @@ class GISDocument(CommWidget):
 
     def add_geojson_layer(
         self,
-        path: str | None = None,
+        path: str | Path | None = None,
         data: Dict | None = None,
         name: str = "GeoJSON Layer",
         type: "circle" | "fill" | "line" = "line",
@@ -249,6 +255,9 @@ class GISDocument(CommWidget):
         :param opacity: The opacity, between 0 and 1.
         :param color_expr: The style expression used to style the layer, defaults to None
         """
+        if isinstance(path, Path):
+            path = str(path)
+
         if path is None and data is None:
             raise ValueError("Cannot create a GeoJSON layer without data")
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -16,6 +16,7 @@ from .objects import (
     IHillshadeLayer,
     IImageLayer,
     IImageSource,
+    IRasterDemSource,
     IRasterLayer,
     IRasterSource,
     IVectorLayer,
@@ -23,7 +24,6 @@ from .objects import (
     IVectorTileSource,
     IVideoSource,
     IWebGlLayer,
-    IRasterDemSource,
     LayerType,
     SourceType,
 )
@@ -57,7 +57,7 @@ class GISDocument(CommWidget):
         pitch: Optional[float] = None,
         projection: Optional[str] = None,
     ):
-        comm_metadata = GISDocument._path_to_comm(path)
+        comm_metadata = GISDocument._path_to_comm(str(path))
 
         ydoc = Doc()
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/y_connector.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/y_connector.py
@@ -7,10 +7,13 @@ logger = logging.getLogger(__file__)
 
 
 class YDocConnector(Widget):
-    def __init__(self, path: Optional[str], **kwargs) -> None:
+    def __init__(self, path: Optional[str | Path], **kwargs) -> None:
         self.path = None
         self._format = None
         self._contentType = None
+
+        if isinstance(path, Path):
+            path = str(path)
 
         if path is not None:
             self.path = path


### PR DESCRIPTION
## Description
#314 
<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--378.org.readthedocs.build/en/378/
💡 JupyterLite preview: https://jupytergis--378.org.readthedocs.build/en/378/lite

<!-- readthedocs-preview jupytergis end -->