### PR TITLE
Move jupyterlab dependency from jupytergis_lab to jupytergis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
           sudo rm -rf $(which node)
 
           cp ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl .
-          python -m pip install jupytergis*.whl
+          python -m pip install jupytergis*.whl "jupyterlab>=4.3,<5"
 
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "jupytergis.*OK"
@@ -173,7 +173,7 @@ jobs:
         run: |
           set -eux
           cp ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl .
-          python -m pip install jupytergis*.whl "jupyter-collaboration>=3,<4"
+          python -m pip install jupytergis*.whl "jupyter-collaboration>=3,<4" "jupyterlab>=4.3,<5"
 
       - name: Install dependencies
         shell: bash -l {0}

--- a/python/jupytergis/pyproject.toml
+++ b/python/jupytergis/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "jupytergis_lab>=0.1.0,<1",
   "jupytergis_qgis>=0.1.0,<1",
   "jupyter-collaboration>=3,<4",
+  "jupyterlab>=4.3,<5",
 ]
 dynamic = ["version"]
 license = {file = "LICENSE"}

--- a/python/jupytergis_lab/pyproject.toml
+++ b/python/jupytergis_lab/pyproject.toml
@@ -25,9 +25,7 @@ classifiers = [
 dependencies = [
   "mapbox-vector-tile",
   "requests",
-  "jupyter_server>=2.0.1,<3",
   "jupyter-ydoc>=2,<3",
-  "jupyterlab>=4.3,<5",
   "ypywidgets>=0.9.0,<0.10.0",
   "yjs-widgets>=0.3.5,<0.4",
   "comm>=0.1.2,<0.2.0",

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,7 +2,7 @@
 datamodel-code-generator>=0.23.0
 hatchling>=1.5.0,<2
 jupyter-collaboration>=3,<4
-jupyterlab>=4,<5
+jupyterlab>=4.3,<5
 mercantile>=1.2
 pillow>=10
 pydantic>=2.4.2,<3


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--382.org.readthedocs.build/en/382/
💡 JupyterLite preview: https://jupytergis--382.org.readthedocs.build/en/382/lite

<!-- readthedocs-preview jupytergis end -->