### PR TITLE
Add optional-chaining check for `symbologyState`

### DIFF
--- a/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
@@ -21,7 +21,7 @@ const TiffRendering = ({
   }
   useEffect(() => {
     const layer = context.model.getLayer(layerId);
-    const renderType = layer?.parameters?.symbologyState.renderType;
+    const renderType = layer?.parameters?.symbologyState?.renderType;
     setSelectedRenderType(renderType ?? 'Singleband Pseudocolor');
   }, []);
 


### PR DESCRIPTION
## Description

Fixes this error.

![image](https://github.com/user-attachments/assets/04995801-198f-48e8-aa7c-cd1a356ac4c4)


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--383.org.readthedocs.build/en/383/
💡 JupyterLite preview: https://jupytergis--383.org.readthedocs.build/en/383/lite

<!-- readthedocs-preview jupytergis end -->