### PR TITLE
Fix name typo `notebookRenderePlugin` -> `notebookRendererPlugin`

### DIFF
--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -31,7 +31,7 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { ContextMenu, Menu } from '@lumino/widgets';
-import { notebookRenderePlugin } from './notebookrenderer';
+import { notebookRendererPlugin } from './notebookrenderer';
 
 const NAME_SPACE = 'jupytergis';
 
@@ -381,4 +381,4 @@ function buildGroupsMenu(
   });
 }
 
-export default [plugin, controlPanel, notebookRenderePlugin];
+export default [plugin, controlPanel, notebookRendererPlugin];

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -51,7 +51,7 @@ export class YJupyterGISLuminoWidget extends Panel {
   private _jgisWidget: JupyterGISPanel;
 }
 
-export const notebookRenderePlugin: JupyterFrontEndPlugin<void> = {
+export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
   id: 'jupytergis:yjswidget-plugin',
   autoStart: true,
   optional: [IJupyterYWidgetManager, ICollaborativeDrive],


### PR DESCRIPTION
## Description

Fix a typo!

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--400.org.readthedocs.build/en/400/
💡 JupyterLite preview: https://jupytergis--400.org.readthedocs.build/en/400/lite

<!-- readthedocs-preview jupytergis end -->