### PR TITLE
Create a new file from the Python API

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import uuid4
@@ -62,6 +63,11 @@ class GISDocument(CommWidget):
             path = str(path)
 
         comm_metadata = GISDocument._path_to_comm(path)
+
+        # Create an empty project file if it does not exist
+        if comm_metadata["path"] and not os.path.isfile(comm_metadata["path"]):
+            with open(comm_metadata["path"], "w") as fd:
+                fd.write("{}")
 
         ydoc = Doc()
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -3,6 +3,7 @@ import unittest
 
 from jupytergis_lab import GISDocument
 
+
 class ProjectCreation(unittest.TestCase):
     filename = "test.jgis"
 
@@ -18,6 +19,7 @@ class ProjectCreation(unittest.TestCase):
         self.doc = GISDocument(self.filename)
 
         assert os.path.isfile(self.filename)
+
 
 class VectorTileTests(unittest.TestCase):
     def setUp(self):

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -1,7 +1,23 @@
+import os
 import unittest
 
 from jupytergis_lab import GISDocument
 
+class ProjectCreation(unittest.TestCase):
+    filename = "test.jgis"
+
+    def setUp(self):
+        if os.path.isfile(self.filename):
+            os.remove(self.filename)
+
+    def tearDown(self):
+        if os.path.isfile(self.filename):
+            os.remove(self.filename)
+
+    def test_creation(self):
+        self.doc = GISDocument(self.filename)
+
+        assert os.path.isfile(self.filename)
 
 class VectorTileTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

Fixes #398.

Creates an empty file if it does not exist when instantiating a `GisDocument` in a Notebook.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--402.org.readthedocs.build/en/402/
💡 JupyterLite preview: https://jupytergis--402.org.readthedocs.build/en/402/lite

<!-- readthedocs-preview jupytergis end -->