### PR TITLE
Fix shared document interface

### DIFF
--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -10,6 +10,7 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { Contents, User } from '@jupyterlab/services';
+import { JSONObject } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { SplitPanel } from '@lumino/widgets';
 
@@ -26,7 +27,6 @@ import {
   SourceType
 } from './_interface/jgis';
 import { IRasterSource } from './_interface/rastersource';
-
 export { IGeoJSONSource } from './_interface/geojsonsource';
 
 export type JgisCoordinates = { x: number; y: number };
@@ -89,6 +89,9 @@ export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
 
   readonly editable: boolean;
   readonly toJGISEndpoint?: string;
+
+  getSource(): JSONObject;
+  setSource(value: JSONObject | string): void;
 
   layerExists(id: string): boolean;
   getLayer(id: string): IJGISLayer | undefined;


### PR DESCRIPTION
## Description

Should fix https://github.com/geojupyter/jupytergis/issues/404

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--406.org.readthedocs.build/en/406/
💡 JupyterLite preview: https://jupytergis--406.org.readthedocs.build/en/406/lite

<!-- readthedocs-preview jupytergis end -->