### PR TITLE
Upgrade jupyter-ydoc python to match the npm version

### DIFF
--- a/python/jupytergis_core/pyproject.toml
+++ b/python/jupytergis_core/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "jupyter-ydoc>=2,<3",
+  "jupyter-ydoc>=2,<4",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 license = {file = "LICENSE"}

--- a/python/jupytergis_lab/pyproject.toml
+++ b/python/jupytergis_lab/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
   "mapbox-vector-tile",
   "requests",
-  "jupyter-ydoc>=2,<3",
+  "jupyter-ydoc>=2,<4",
   "ypywidgets>=0.9.0,<0.10.0",
   "yjs-widgets>=0.3.5,<0.4",
   "comm>=0.1.2,<0.2.0",

--- a/python/jupytergis_qgis/pyproject.toml
+++ b/python/jupytergis_qgis/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "jupyter_server>=2.0.1,<3",
-  "jupyter-ydoc>=2,<3",
+  "jupyter-ydoc>=2,<4",
   "jupytergis_lab"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]


### PR DESCRIPTION
## Description

Upgrade the python package of `jupyter-ydoc` to `>=2,<4`.

This has been discussed [here](https://github.com/geojupyter/jupytergis/pull/406#issuecomment-2621291250)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--409.org.readthedocs.build/en/409/
💡 JupyterLite preview: https://jupytergis--409.org.readthedocs.build/en/409/lite

<!-- readthedocs-preview jupytergis end -->