### PR TITLE
Don't change paths to absolute backend paths

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -29,7 +29,6 @@ from .objects import (
     LayerType,
     SourceType,
 )
-from .utils import normalize_path
 
 logger = logging.getLogger(__file__)
 
@@ -708,7 +707,7 @@ class GISDocument(CommWidget):
         contentType = None
 
         if filePath is not None:
-            path = normalize_path(filePath)
+            path = filePath
             file_name = Path(path).name
             try:
                 ext = file_name.split(".")[1].lower()

--- a/python/jupytergis_lab/jupytergis_lab/notebook/utils.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/utils.py
@@ -1,4 +1,3 @@
-import os
 from enum import Enum
 from urllib.parse import urljoin
 import requests
@@ -16,10 +15,3 @@ def multi_urljoin(*parts) -> str:
         parts[0],
         "/".join(part for part in parts[1:]),
     )
-
-
-def normalize_path(path: str) -> str:
-    if os.path.isabs(path):
-        return path
-    else:
-        return os.path.abspath(os.path.join(os.getcwd(), path))


### PR DESCRIPTION
## Description

Fixes #352.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--425.org.readthedocs.build/en/425/
💡 JupyterLite preview: https://jupytergis--425.org.readthedocs.build/en/425/lite

<!-- readthedocs-preview jupytergis end -->