### PR TITLE
Fix link to contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please check out [our documentation's contributing guide](https://jupytergis.readthedocs.io/en/latest/contributing.html).
+Please check out [our documentation's contributing guide](https://jupytergis.readthedocs.io/en/latest/contributor_guide/index.html).

--- a/docs/user_guide/install.rst
+++ b/docs/user_guide/install.rst
@@ -16,4 +16,3 @@ Alternatively, you can install JupyterGIS with ``pip``
 .. code-block:: bash
 
    pip install jupytergis
-

--- a/docs/user_guide/install.rst
+++ b/docs/user_guide/install.rst
@@ -4,14 +4,16 @@
 Installing JupyterGIS
 =====================
 
-JupyterGIS can be installed with ``pip``
+It is best to install JupyterGIS using ``mamba`` or ``conda``, since you'll be able to install ``qgis`` as well, allowing you to open ``.qgz`` files.
+
+.. code-block:: bash
+
+   mamba install -c conda-forge jupytergis qgis
+
+
+Alternatively, you can install JupyterGIS with ``pip``
 
 .. code-block:: bash
 
    pip install jupytergis
 
-It is best if you also install ``qgis``, this will allow you to open ``.qgz`` files. It can be installed using ``mamba`` or ``conda``
-
-.. code-block:: bash
-
-   mamba install -c conda-forge qgis

--- a/docs/user_guide/tutorials/intro.md
+++ b/docs/user_guide/tutorials/intro.md
@@ -15,7 +15,7 @@ By the end of this tutorial, you will:
 
 :::{admonition} Prerequisites
 :class: warning
-Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://geojupyter.github.io/jupytergis/install.html)) or you can use an online version of JupyterGIS (such as [![Jupyterlite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://geojupyter.github.io/jupytergis/lite/lab/index.html?path=france_hiking.jGIS/)).
+Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)) or you can use an online version of JupyterGIS (such as [![Jupyterlite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://geojupyter.github.io/jupytergis/lite/lab/index.html?path=france_hiking.jGIS/)).
 :::
 
 ## Introduction to JupyterGIS


### PR DESCRIPTION
This should fix the CI

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--440.org.readthedocs.build/en/440/
💡 JupyterLite preview: https://jupytergis--440.org.readthedocs.build/en/440/lite

<!-- readthedocs-preview jupytergis end -->