### PR TITLE
Add add_vector_layer function

### DIFF
--- a/examples/Notebook.ipynb
+++ b/examples/Notebook.ipynb
@@ -74,6 +74,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a1e75c62-db0d-49ec-b6ff-2c7c01dc9642",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://github.com/opengeos/datasets/releases/download/world/countries.geojson\"\n",
+    "doc.add_vector_layer(path=url, name=\"GeoJSON\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "664dca2f-e4ee-4fcb-994c-9940143d4a78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://github.com/opengeos/datasets/releases/download/world/continents.zip\"\n",
+    "doc.add_vector_layer(path=url, name=\"Shapefile\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "3629be32-bf06-4f68-a734-9af3cc17a7e3",
    "metadata": {},
    "outputs": [],
@@ -106,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -302,6 +302,50 @@ class GISDocument(CommWidget):
 
         return self._add_layer(OBJECT_FACTORY.create_layer(layer, self))
 
+    def add_vector_layer(
+        self,
+        path: Optional[Union[str, Path]] = None,
+        name: str = "Vector Layer",
+        type: str = "line",
+        opacity: float = 1.0,
+        logical_op: Optional[str] = None,
+        feature: Optional[str] = None,
+        operator: Optional[str] = None,
+        value: Optional[Union[str, int, float]] = None,
+        color_expr: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        """
+        Adds a vector layer to the map.
+
+        Args:
+            path (Optional[Union[str, Path]]): The path to the vector file.
+            name (str): The name of the vector layer. Defaults to "Vector Layer".
+            type (str): The type of the vector layer. Defaults to "line".
+            opacity (float): The opacity of the vector layer. Defaults to 1.0.
+            logical_op (Optional[str]): The logical operation to apply. Defaults to None.
+            feature (Optional[str]): The feature to apply the logical operation on. Defaults to None.
+            operator (Optional[str]): The operator to use in the logical operation. Defaults to None.
+            value (Optional[Union[str, int, float]]): The value to use in the logical operation. Defaults to None.
+            color_expr (Optional[str]): The color expression to use for the vector layer. Defaults to None.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            None
+        """
+        geojson = vector_to_geojson(path, **kwargs)
+        self.add_geojson_layer(
+            data=geojson,
+            name=name,
+            type=type,
+            opacity=opacity,
+            logical_op=logical_op,
+            feature=feature,
+            operator=operator,
+            value=value,
+            color_expr=color_expr,
+        )
+
     def add_image_layer(
         self,
         url: str,
@@ -837,6 +881,99 @@ class ObjectFactoryManager(metaclass=SingletonMeta):
             )
 
         return None
+
+
+def vector_to_geojson(
+    filepath,
+    out_geojson=None,
+    bbox=None,
+    mask=None,
+    rows=None,
+    epsg="4326",
+    encoding="utf-8",
+    **kwargs,
+):
+    """Converts any geopandas-supported vector dataset to GeoJSON.
+
+    Args:
+        filepath (str): Either the absolute or relative path to the file or URL
+            to be opened, or any object with a read() method (such as an open
+            file or StringIO).
+        out_geojson (str, optional): The file path to the output GeoJSON.
+            Defaults to None.
+        bbox (tuple | GeoDataFrame or GeoSeries | shapely Geometry, optional):
+            Filter features by given bounding box, GeoSeries, GeoDataFrame or
+            a shapely geometry. CRS mis-matches are resolved if given a GeoSeries
+            or GeoDataFrame. Cannot be used with mask. Defaults to None.
+        mask (dict | GeoDataFrame or GeoSeries | shapely Geometry, optional):
+            Filter for features that intersect with the given dict-like geojson
+            geometry, GeoSeries, GeoDataFrame or shapely geometry. CRS mis-matches
+            are resolved if given a GeoSeries or GeoDataFrame. Cannot be used with
+            bbox. Defaults to None.
+        rows (int or slice, optional): Load in specific rows by passing an integer
+            (first n rows) or a slice() object.. Defaults to None.
+        epsg (str, optional): The EPSG number to convert to. Defaults to "4326".
+        encoding (str, optional): The encoding of the input file. Defaults to "utf-8".
+        kwargs: Additional arguments to pass to geopandas.read_file.
+
+
+    Raises:
+        ValueError: When the output file path is invalid.
+
+    Returns:
+        dict: A dictionary containing the GeoJSON.
+    """
+
+    try:
+        import geopandas as gpd
+    except ImportError:
+        raise ImportError(
+            "geopandas is required for this function. Please install it using `pip install geopandas`."
+        )
+
+    if not filepath.startswith("http"):
+        filepath = os.path.abspath(filepath)
+        if filepath.endswith(".zip"):
+            filepath = "zip://" + filepath
+    ext = os.path.splitext(filepath)[1].lower()
+    if ext == ".kml":
+
+        try:
+            import fiona
+        except ImportError:
+            raise ImportError(
+                "fiona is required for this function. Please install it using `pip install fiona`."
+            )
+
+        fiona.drvsupport.supported_drivers["KML"] = "rw"
+        df = gpd.read_file(
+            filepath,
+            bbox=bbox,
+            mask=mask,
+            rows=rows,
+            driver="KML",
+            encoding=encoding,
+            **kwargs,
+        )
+    else:
+        df = gpd.read_file(
+            filepath, bbox=bbox, mask=mask, rows=rows, encoding=encoding, **kwargs
+        )
+    gdf = df.to_crs(epsg=epsg)
+
+    if out_geojson is not None:
+        if not out_geojson.lower().endswith(".geojson"):
+            raise ValueError("The output file must have a geojson file extension.")
+
+        out_geojson = os.path.abspath(out_geojson)
+        out_dir = os.path.dirname(out_geojson)
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+
+        gdf.to_file(out_geojson, driver="GeoJSON")
+
+    else:
+        return gdf.__geo_interface__
 
 
 OBJECT_FACTORY = ObjectFactoryManager()


### PR DESCRIPTION
Fix https://github.com/geojupyter/jupytergis/issues/437

This PR adds:
- add_vector_layer function for loading any geopandas supported vector format, including shapefile, geopackage, kml
- vector_to_geojson function for converting any geopandas supported vector format to GeoJSON
- Update the notebook example to include the `add_vector_layer` examples.


