### PR TITLE
Fix a typo in gis_document.py

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -726,7 +726,7 @@ class GISDocument(CommWidget):
             else:
                 raise ValueError("File extension is not supported!")
         return dict(
-            path=path, format=format, contentType=contentType, createydoc=path is None
+            path=path, format=format, contentType=contentType, create_ydoc=path is None
         )
 
 


### PR DESCRIPTION
## Description

There was a typo in `gis_document.py`, the expected [`create_ydoc`](https://github.com/QuantStack/yjs-widgets/blob/5c1eebbdb8406cd18636e0d5aa04b0178747c528/src/model.ts#L69) property was misspelled `createydoc`.

No idea if there are consequences to that :smiley: 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--448.org.readthedocs.build/en/448/
💡 JupyterLite preview: https://jupytergis--448.org.readthedocs.build/en/448/lite

<!-- readthedocs-preview jupytergis end -->