### PR TITLE
Add jupytergis-lite metapackage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           name: ${{ matrix.python-version == '3.12' && 'extension-artifacts' || format('extension-artifacts-{0}', matrix.python-version) }}
           path: |
+            python/jupytergis/dist/jupytergis*
             python/jupytergis_core/dist/jupytergis*
             python/jupytergis_lab/dist/jupytergis*
             python/jupytergis_qgis/dist/jupytergis*
@@ -131,7 +132,7 @@ jobs:
           sudo rm -rf $(which node)
           sudo rm -rf $(which node)
 
-          cp ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl .
+          cp ./jupytergis/dist/jupytergis*.whl ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl .
           python -m pip install jupytergis*.whl "jupyterlab>=4.3,<5"
 
           jupyter labextension list
@@ -172,7 +173,7 @@ jobs:
         shell: bash -l {0}
         run: |
           set -eux
-          cp ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl .
+          cp ./jupytergis/dist/jupytergis*.whl ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl .
           python -m pip install jupytergis*.whl "jupyter-collaboration>=3,<4" "jupyterlab>=4.3,<5"
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Docker build source is at <https://github.com/geojupyter/jupytergis-docker>.
 
 ## Documentation
 
-https://geojupyter.github.io/jupytergis
+https://jupytergis.readthedocs.io
 
 ## Contributing
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -16,3 +16,4 @@ dependencies:
       - my-jupyter-shared-drive
       - ../python/jupytergis_lab
       - ../python/jupytergis_core
+      - ../python/jupytergis_lite

--- a/docs/user_guide/tutorials/intro.md
+++ b/docs/user_guide/tutorials/intro.md
@@ -15,7 +15,7 @@ By the end of this tutorial, you will:
 
 :::{admonition} Prerequisites
 :class: warning
-Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)) or you can use an online version of JupyterGIS (such as [![Jupyterlite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://geojupyter.github.io/jupytergis/lite/lab/index.html?path=france_hiking.jGIS/)).
+Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)) or you can use an online version of JupyterGIS (such as [![Jupyterlite badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://jupytergis.readthedocs.io/en/latest/lite/lab/index.html?path=france_hiking.jGIS/)).
 :::
 
 ## Introduction to JupyterGIS
@@ -187,7 +187,6 @@ Congratulations on completing this tutorial! You've created a basic map in Jupyt
 
 ## Additional resources
 
-- [JupyterGIS Documentation](https://geojupyter.github.io/jupytergis)
 - [Folium Library](https://python-visualization.github.io/folium/latest/)
 - [Geopandas Documentation](https://geopandas.org/en/stable/docs.html)
 - [QGIS Documentation](https://www.qgis.org)

--- a/examples/Notebook.ipynb
+++ b/examples/Notebook.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jupytergis_lab import GISDocument"
+    "from jupytergis import GISDocument"
    ]
   },
   {

--- a/examples/vector_colors.ipynb
+++ b/examples/vector_colors.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "from jupytergis_lab import GISDocument\n",
+    "from jupytergis import GISDocument\n",
     "\n",
     "doc = GISDocument()\n",
     "\n",

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -201,7 +201,7 @@ export class JupyterGISPanel extends SplitPanel {
         this.setRelativeSizes([2, 1]);
         this._consoleOpened = true;
         await consolePanel.console.inject(
-          `from jupytergis_lab import GISDocument\ndoc = GISDocument("${jgisPath}")`
+          `from jupytergis import GISDocument\ndoc = GISDocument("${jgisPath}")`
         );
         consolePanel.console.sessionContext.kernelChanged.connect((_, arg) => {
           if (!arg.newValue) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ python_packages = [
     "python/jupytergis_core:jupytergis_core",
     "python/jupytergis_lab:jupytergis_lab",
     "python/jupytergis_qgis:jupytergis_qgis",
+    "python/jupytergis_lite:jupytergis",
 ]
 
 [tool.jupyter-releaser.hooks]

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -29,7 +29,6 @@ import {
   IJupyterYWidget,
   IJupyterYWidgetManager,
   JupyterYDoc,
-  // JupyterYDoc,
   JupyterYModel
 } from 'yjs-widgets';
 

--- a/python/jupytergis_lite/LICENSE
+++ b/python/jupytergis_lite/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, JupyterGIS contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/python/jupytergis_lite/README.md
+++ b/python/jupytergis_lite/README.md
@@ -1,0 +1,1 @@
+# JupyterGIS meta-package for JupyterLite

--- a/python/jupytergis_lite/jupytergis/__init__.py
+++ b/python/jupytergis_lite/jupytergis/__init__.py
@@ -1,0 +1,3 @@
+__version__ = "0.3.0"
+
+from jupytergis_lab import GISDocument  # noqa

--- a/python/jupytergis_lite/pyproject.toml
+++ b/python/jupytergis_lite/pyproject.toml
@@ -33,6 +33,9 @@ requires-python = ">=3.10"
 [tool.hatch.version]
 path = "jupytergis/__init__.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["jupytergis"]
+
 [tool.jupyter-releaser.options]
 version_cmd = "hatch version"
 

--- a/python/jupytergis_lite/pyproject.toml
+++ b/python/jupytergis_lite/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling>=1.5.0,<2"]
+
+[project]
+classifiers = [
+  "Framework :: Jupyter",
+  "Framework :: Jupyter :: JupyterLab",
+  "Framework :: Jupyter :: JupyterLab :: 4",
+  "Framework :: Jupyter :: JupyterLab :: Extensions",
+  "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+  "jupytergis_core>=0.1.0,<1",
+  "jupytergis_lab>=0.1.0,<1",
+  "my-jupyter-shared-drive",
+]
+dynamic = ["version"]
+license = {file = "LICENSE"}
+name = "jupytergis-lite"
+readme = "README.md"
+requires-python = ">=3.10"
+
+
+[tool.hatch.version]
+path = "jupytergis/__init__.py"
+
+[tool.jupyter-releaser.options]
+version_cmd = "hatch version"
+
+[tool.check-wheel-contents]
+ignore = ["W002"]

--- a/python/jupytergis_lite/scripts/bump-version.py
+++ b/python/jupytergis_lite/scripts/bump-version.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from subprocess import run
+
+HATCH_VERSION = "hatch version"
+ROOT = Path(__file__).parent.parent
+
+
+def bump():
+    # bump the Python version with hatch
+    run(f"{HATCH_VERSION}", shell=True, check=True, cwd=ROOT)
+
+
+if __name__ == "__main__":
+    bump()

--- a/python/jupytergis_lite/setup.py
+++ b/python/jupytergis_lite/setup.py
@@ -1,0 +1,1 @@
+__import__("setuptools").setup()

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -12,7 +12,12 @@ def build_packages():
     install_build_deps = f"python -m pip install -r {requirements_build_path}"
 
     python_package_prefix = "python"
-    python_packages = ["jupytergis", "jupytergis_core", "jupytergis_lab", "jupytergis_qgis"]
+    python_packages = [
+        "jupytergis",
+        "jupytergis_core",
+        "jupytergis_lab",
+        "jupytergis_qgis",
+    ]
 
     execute(install_build_deps)
 

--- a/scripts/build_packages.py
+++ b/scripts/build_packages.py
@@ -12,7 +12,7 @@ def build_packages():
     install_build_deps = f"python -m pip install -r {requirements_build_path}"
 
     python_package_prefix = "python"
-    python_packages = ["jupytergis_core", "jupytergis_lab", "jupytergis_qgis"]
+    python_packages = ["jupytergis", "jupytergis_core", "jupytergis_lab", "jupytergis_qgis"]
 
     execute(install_build_deps)
 

--- a/scripts/dev-install.py
+++ b/scripts/dev-install.py
@@ -14,7 +14,7 @@ def install_dev():
     build_js = "jlpm build"
 
     python_package_prefix = "python"
-    python_packages = ["jupytergis_core", "jupytergis_lab", "jupytergis_qgis"]
+    python_packages = ["jupytergis_core", "jupytergis_lab", "jupytergis_qgis", "jupytergis"]
 
     execute(install_build_deps)
     execute(install_js_deps)

--- a/scripts/dev-install.py
+++ b/scripts/dev-install.py
@@ -14,7 +14,12 @@ def install_dev():
     build_js = "jlpm build"
 
     python_package_prefix = "python"
-    python_packages = ["jupytergis_core", "jupytergis_lab", "jupytergis_qgis", "jupytergis"]
+    python_packages = [
+        "jupytergis_core",
+        "jupytergis_lab",
+        "jupytergis_qgis",
+        "jupytergis",
+    ]
 
     execute(install_build_deps)
     execute(install_js_deps)

--- a/scripts/dev-install.py
+++ b/scripts/dev-install.py
@@ -15,7 +15,6 @@ def install_dev():
 
     python_package_prefix = "python"
     python_packages = [
-        "jupytergis",
         "jupytergis_core",
         "jupytergis_lab",
         "jupytergis_qgis",
@@ -32,11 +31,7 @@ def install_dev():
         if py_package == "jupytergis_qgis":
             execute("jupyter server extension enable jupytergis_qgis")
 
-        # Only the metapackage doesn't have a labext
-        if py_package != "jupytergis":
-            execute(
-                f"jupyter labextension develop {python_package_prefix}/{py_package} --overwrite"
-            )
+    execute(f"pip install -e {python_package_prefix}/jupytergis")
 
 
 if __name__ == "__main__":

--- a/scripts/dev-install.py
+++ b/scripts/dev-install.py
@@ -15,10 +15,10 @@ def install_dev():
 
     python_package_prefix = "python"
     python_packages = [
+        "jupytergis",
         "jupytergis_core",
         "jupytergis_lab",
         "jupytergis_qgis",
-        "jupytergis",
     ]
 
     execute(install_build_deps)

--- a/scripts/dev-install.py
+++ b/scripts/dev-install.py
@@ -32,9 +32,11 @@ def install_dev():
         if py_package == "jupytergis_qgis":
             execute("jupyter server extension enable jupytergis_qgis")
 
-        execute(
-            f"jupyter labextension develop {python_package_prefix}/{py_package} --overwrite"
-        )
+        # Only the metapackage doesn't have a labext
+        if py_package != "jupytergis":
+            execute(
+                f"jupyter labextension develop {python_package_prefix}/{py_package} --overwrite"
+            )
 
 
 if __name__ == "__main__":

--- a/ui-tests/tests/notebooks/Notebook.ipynb
+++ b/ui-tests/tests/notebooks/Notebook.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jupytergis_lab import GISDocument\n",
+    "from jupytergis import GISDocument\n",
     "\n",
     "doc = GISDocument()\n",
     "\n",


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

This PR introduces a new `jupytergis-lite` metapackage, allowing to easily install jupytergis in a JupyterLite environment.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--451.org.readthedocs.build/en/451/
💡 JupyterLite preview: https://jupytergis--451.org.readthedocs.build/en/451/lite

<!-- readthedocs-preview jupytergis end -->