### PR TITLE
fix #418 path validation of shapefiles

### DIFF
--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -530,10 +530,13 @@ export const loadFile = async (fileInfo: {
           await saveToIndexedDB(filepath, geojson);
           return geojson;
         } catch (error) {
-          console.warn('Cannot communicate with the JupyterGIS proxy server:', error);
+          console.warn(
+            'Cannot communicate with the JupyterGIS proxy server:',
+            error
+          );
         }
 
-         // Trying through an external proxy server
+        // Trying through an external proxy server
         try {
           const response = await fetch(`https://corsproxy.io/?url=${filepath}`);
           const arrayBuffer = await response.arrayBuffer();
@@ -541,15 +544,11 @@ export const loadFile = async (fileInfo: {
           await saveToIndexedDB(filepath, geojson);
           return geojson;
         } catch (error) {
-          console.warn(
-             'Cannot communicate with external proxy server',
-             error
-          );
-       }
+          console.warn('Cannot communicate with external proxy server', error);
+        }
 
-       showErrorMessage('Network error', 'Failed to fetch ${filepath}');
-       throw new Error('Failed to fetch ${filepath}');
-
+        showErrorMessage('Network error', 'Failed to fetch ${filepath}');
+        throw new Error('Failed to fetch ${filepath}');
       }
 
       case 'GeoJSONSource': {


### PR DESCRIPTION
## Description

The  PR aims to fix #418 e.g. update the Path Validation for ShapefileSource as it rejected remote shape files (zipped). Following suggestion from @martinRenou in #418 :
- Revive https://github.com/geojupyter/jupytergis/pull/245  by 
- try to load the file directly and if there are CORS issues, try fetching from an accessible CORS proxy

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--453.org.readthedocs.build/en/453/
💡 JupyterLite preview: https://jupytergis--453.org.readthedocs.build/en/453/lite

<!-- readthedocs-preview jupytergis end -->