### PR TITLE
Updating version of proj4-list

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -76,7 +76,7 @@
     "pbf": "^4.0.1",
     "pmtiles": "^3.0.7",
     "proj4": "^2.14.0",
-    "proj4-list": "^1.0.2",
+    "proj4-list": "^1.0.4",
     "react": "^18.0.1",
     "shpjs": "^6.1.0",
     "styled-components": "^5.3.6",

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -71,7 +71,6 @@ import TileSource from 'ol/source/Tile';
 import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { Rule } from 'ol/style/flat';
 import proj4 from 'proj4';
-//@ts-expect-error no types for proj4list
 import proj4list from 'proj4-list';
 import * as React from 'react';
 import AnnotationFloater from '../annotations/components/AnnotationFloater';


### PR DESCRIPTION
## Description

I updated proj4-list package, I added the types in the library so the @ts-expect-error line is not required anymore.

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--459.org.readthedocs.build/en/459/
💡 JupyterLite preview: https://jupytergis--459.org.readthedocs.build/en/459/lite

<!-- readthedocs-preview jupytergis end -->