### PR TITLE
Pin meta-package dependencies

### DIFF
--- a/python/jupytergis/pyproject.toml
+++ b/python/jupytergis/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling>=1.5.0,<2"]
+requires = ["hatchling>=1.5.0,<2", "tomlkit>=0.13.2,<0.14"]
 
 [project]
 classifiers = [

--- a/python/jupytergis/pyproject.toml
+++ b/python/jupytergis/pyproject.toml
@@ -19,9 +19,9 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "jupytergis_core>=0.1.0,<1",
-  "jupytergis_lab>=0.1.0,<1",
-  "jupytergis_qgis>=0.1.0,<1",
+  "jupytergis_core==0.3.0",
+  "jupytergis_lab==0.3.0",
+  "jupytergis_qgis==0.3.0",
   "jupyter-collaboration>=3,<4",
   "jupyterlab>=4.3,<5",
 ]

--- a/python/jupytergis/scripts/bump-version.py
+++ b/python/jupytergis/scripts/bump-version.py
@@ -5,10 +5,11 @@
 
 import argparse
 import json
+from typing import List
 from packaging.version import parse as parse_version
 from pathlib import Path
 from subprocess import run
-
+import tomlkit
 
 ENC = dict(encoding="utf-8")
 HATCH_VERSION = "hatch version"
@@ -25,6 +26,20 @@ def next_version():
     if v.is_prerelease:
         return f"{v.major}.{v.minor}.{v.micro}{v.pre[0]}{v.pre[1] + 1}"
     return f"{v.major}.{v.minor}.{v.micro + 1}"
+
+
+def bump_jupytergis_deps(py_version: str):
+    with open(ROOT / "pyproject.toml", "r") as f:
+        data = tomlkit.load(f)
+    dependencies: List[str] = data["project"]["dependencies"]
+
+    for index, value in enumerate(dependencies):
+        if value.startswith("jupytergis"):
+            lib = value.split("==")[0]
+            dependencies[index] = f"{lib}=={py_version}"
+
+    with open(ROOT / "pyproject.toml", "w") as f:
+        tomlkit.dump(data, f)
 
 
 def bump():
@@ -51,6 +66,8 @@ def bump():
     )
     # bump the Python version with hatch
     run(f"{HATCH_VERSION} {py_version}", shell=True, check=True, cwd=ROOT)
+    # pin jupytergis_* package to the same version
+    bump_jupytergis_deps(py_version)
     # bump the JS version with lerna
     run(f"yarn run bump:js:version {js_version}", shell=True, check=True)
 

--- a/python/jupytergis_lite/pyproject.toml
+++ b/python/jupytergis_lite/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "jupytergis_core>=0.1.0,<1",
-  "jupytergis_lab>=0.1.0,<1",
+  "jupytergis_core==0.3.0",
+  "jupytergis_lab==0.3.0",
   "my-jupyter-shared-drive",
 ]
 dynamic = ["version"]

--- a/python/jupytergis_lite/scripts/bump-version.py
+++ b/python/jupytergis_lite/scripts/bump-version.py
@@ -1,11 +1,24 @@
 from pathlib import Path
 from subprocess import run
 from typing import List
+from packaging.version import parse as parse_version
 import tomlkit
 import argparse
 
 HATCH_VERSION = "hatch version"
 ROOT = Path(__file__).parent.parent
+
+
+def get_version():
+    cmd = run([HATCH_VERSION], capture_output=True, shell=True, check=True, cwd=ROOT)
+    return cmd.stdout.decode("utf-8").strip().split("\n")[-1]
+
+
+def next_version():
+    v = parse_version(get_version())
+    if v.is_prerelease:
+        return f"{v.major}.{v.minor}.{v.micro}{v.pre[0]}{v.pre[1] + 1}"
+    return f"{v.major}.{v.minor}.{v.micro + 1}"
 
 
 def bump_jupytergis_deps(py_version: str):

--- a/python/jupytergis_lite/scripts/bump-version.py
+++ b/python/jupytergis_lite/scripts/bump-version.py
@@ -1,13 +1,36 @@
 from pathlib import Path
 from subprocess import run
+from typing import List
+import tomlkit
+import argparse
 
 HATCH_VERSION = "hatch version"
 ROOT = Path(__file__).parent.parent
 
 
+def bump_jupytergis_deps(py_version: str):
+    with open(ROOT / "pyproject.toml", "r") as f:
+        data = tomlkit.load(f)
+    dependencies: List[str] = data["project"]["dependencies"]
+
+    for index, value in enumerate(dependencies):
+        if value.startswith("jupytergis"):
+            lib = value.split("==")[0]
+            dependencies[index] = f"{lib}=={py_version}"
+
+    with open(ROOT / "pyproject.toml", "w") as f:
+        tomlkit.dump(data, f)
+
+
 def bump():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    args = parser.parse_args()
+    py_version = next_version() if args.version == "next" else args.version
     # bump the Python version with hatch
     run(f"{HATCH_VERSION}", shell=True, check=True, cwd=ROOT)
+    # pin jupytergis_* package to the same version
+    bump_jupytergis_deps(py_version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
#454 

Pin the `jupytergis` and `jupytergis-lite` meta package dependencies and updates `bump-version` script. 
<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--460.org.readthedocs.build/en/460/
💡 JupyterLite preview: https://jupytergis--460.org.readthedocs.build/en/460/lite

<!-- readthedocs-preview jupytergis end -->