### PR TITLE
Lazy import jupyter_server

### DIFF
--- a/python/jupytergis_core/jupytergis_core/__init__.py
+++ b/python/jupytergis_core/jupytergis_core/__init__.py
@@ -9,8 +9,6 @@ except ImportError:
     warnings.warn("Importing 'jupytergis_core' outside a proper installation.")
     __version__ = "dev"
 
-from .handler import setup_handlers
-
 
 def _jupyter_labextension_paths():
     return [{"src": "labextension", "dest": "@jupytergis/jupytergis-core"}]
@@ -28,6 +26,8 @@ def _load_jupyter_server_extension(server_app):
     server_app: jupyterlab.labapp.LabApp
         JupyterLab application instance
     """
+    from .handler import setup_handlers
+
     setup_handlers(server_app.web_app)
     name = "jupytergis_core"
     print(f"Registered {name} server extension")


### PR DESCRIPTION
Since now jupyter_server is not a dependency of `jupytergis_core`. This code will only be triggered if it's running in a jupyter server.