### PR TITLE
Install JupyterGIS metapackage in Update snapshots workflow

### DIFF
--- a/.github/workflows/update_galata_references.yaml
+++ b/.github/workflows/update_galata_references.yaml
@@ -91,7 +91,7 @@ jobs:
         shell: bash -l {0}
         run: |
           whereis python
-          cp ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl .
+          cp ./jupytergis_core/dist/jupytergis*.whl ./jupytergis_lab/dist/jupytergis*.whl ./jupytergis_qgis/dist/jupytergis*.whl ./jupytergis/dist/jupytergis*.whl .
           python -m pip install jupytergis*.whl
 
       - name: Install dependencies


### PR DESCRIPTION
## Description

To avoid installing jupyter-collaboration manually

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--477.org.readthedocs.build/en/477/
💡 JupyterLite preview: https://jupytergis--477.org.readthedocs.build/en/477/lite

<!-- readthedocs-preview jupytergis end -->