### PR TITLE
Add `remove_layer` method to Python `GISDocument` API

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -520,6 +520,21 @@ class GISDocument(CommWidget):
 
         return self._add_layer(OBJECT_FACTORY.create_layer(layer, self))
 
+    def remove_layer(self, layer_id: str):
+        """
+        Remove a layer from the GIS document.
+
+        :param layer_id: The ID of the layer to remove.
+        :raises KeyError: If the layer does not exist.
+        """
+
+        layer = self._layers.get(layer_id)
+
+        if layer is None:
+            raise KeyError(f"No layer found with ID: {layer_id}")
+
+        del self._layers[layer_id]
+
     def create_color_expr(
         self,
         color_stops: Dict,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -534,6 +534,21 @@ class GISDocument(CommWidget):
             raise KeyError(f"No layer found with ID: {layer_id}")
 
         del self._layers[layer_id]
+        self._remove_source_if_orphaned(layer['parameters']['source'])
+
+    def _remove_source_if_orphaned(self, source_id: str):
+        source = self._sources.get(source_id)
+
+        if source is None:
+            raise KeyError(f"No source found with ID: {source_id}")
+
+        source_is_orphan = not any(
+            layer['parameters']['source'] == source_id
+            for layer in self._layers.values()
+        )
+
+        if source_is_orphan:
+            del self._sources[source_id]
 
     def create_color_expr(
         self,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -534,7 +534,7 @@ class GISDocument(CommWidget):
             raise KeyError(f"No layer found with ID: {layer_id}")
 
         del self._layers[layer_id]
-        self._remove_source_if_orphaned(layer['parameters']['source'])
+        self._remove_source_if_orphaned(layer["parameters"]["source"])
 
     def _remove_source_if_orphaned(self, source_id: str):
         source = self._sources.get(source_id)
@@ -543,7 +543,7 @@ class GISDocument(CommWidget):
             raise KeyError(f"No source found with ID: {source_id}")
 
         source_is_orphan = not any(
-            layer['parameters']['source'] == source_id
+            layer["parameters"]["source"] == source_id
             for layer in self._layers.values()
         )
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from jupytergis_lab import GISDocument
 
 
@@ -38,3 +40,7 @@ class TestLayerManipulation(TestDocument):
 
         self.doc.remove_layer(layer_id)
         assert len(self.doc.layers) == 0
+
+    def test_remove_nonexistent_layer_raises(self):
+        with pytest.raises(KeyError):
+            self.doc.remove_layer("foo")

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -4,6 +4,8 @@ import pytest
 
 from jupytergis_lab import GISDocument
 
+TEST_TIF = "https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif"
+
 
 class TestDocument:
     def setup_method(self):
@@ -24,22 +26,20 @@ class TestTiffLayer(TestDocument):
             },
         )
 
-        tif_layer = self.doc.add_tiff_layer(
-            url="https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif",
-            color_expr=color,
-        )
+        tif_layer = self.doc.add_tiff_layer(url=TEST_TIF, color_expr=color)
         assert self.doc.layers[tif_layer]["parameters"]["color"] == color
 
 
 class TestLayerManipulation(TestDocument):
-    def test_add_remove_layer(self):
-        layer_id = self.doc.add_tiff_layer(
-            url="https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif",
-        )
+    def test_add_and_remove_layer_and_source(self):
+        layer_id = self.doc.add_tiff_layer(url=TEST_TIF)
         assert len(self.doc.layers) == 1
 
+        # After removing the layer, the source is not associated with any layer, so we
+        # expect it to be removed as well.
         self.doc.remove_layer(layer_id)
         assert len(self.doc.layers) == 0
+        assert len(self.doc._sources) == 0
 
     def test_remove_nonexistent_layer_raises(self):
         with pytest.raises(KeyError):

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -27,3 +27,14 @@ class TestTiffLayer(TestDocument):
             color_expr=color,
         )
         assert self.doc.layers[tif_layer]["parameters"]["color"] == color
+
+
+class TestLayerManipulation(TestDocument):
+    def test_add_remove_layer(self):
+        layer_id = self.doc.add_tiff_layer(
+            url="https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif",
+        )
+        assert len(self.doc.layers) == 1
+
+        self.doc.remove_layer(layer_id)
+        assert len(self.doc.layers) == 0

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -1,18 +1,14 @@
 import os
-import unittest
 
 from jupytergis_lab import GISDocument
 
 
-class VectorTileTests(unittest.TestCase):
-    def setUp(self):
+class TestDocument:
+    def setup_method(self):
         self.doc = GISDocument()
 
 
-class TiffLayerTests(unittest.TestCase):
-    def setUp(self):
-        self.doc = GISDocument()
-
+class TestTiffLayer(TestDocument):
     def test_sourcelayer(self):
         color = self.doc.create_color_expr(
             interpolation_type="linear",


### PR DESCRIPTION
## Description

@YaoTingYao and I pair programmed on this during the hackathon!

Resolves #439 


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--478.org.readthedocs.build/en/478/
💡 JupyterLite preview: https://jupytergis--478.org.readthedocs.build/en/478/lite

<!-- readthedocs-preview jupytergis end -->