### PR TITLE
Update `image.jGIS` to load correctly

### DIFF
--- a/examples/image.jGIS
+++ b/examples/image.jGIS
@@ -26,16 +26,16 @@
   "options": {
     "bearing": 0.0,
     "extent": [
-      -10668221.937387919,
-      2968957.3199346415,
-      -5919998.764311256,
-      6642297.157880763
+      -13957340.607405175,
+      -4131544.7694810475,
+      3839728.534463562,
+      12390226.369708324
     ],
-    "latitude": 39.583682016837116,
-    "longitude": -74.5072609634211,
+    "latitude": 34.74543821495182,
+    "longitude": -45.44402781957822,
     "pitch": 0.0,
     "projection": "EPSG:3857",
-    "zoom": 4.988635458547391
+    "zoom": 3.0398860010821136
   },
   "sources": {
     "5f7a1edf-1b76-4f82-893f-540d28998b1d": {
@@ -71,7 +71,7 @@
             37.936
           ]
         ],
-        "url": "https://maplibre.org/maplibre-gl-js/docs/assets/radar.gif"
+        "path": "https://maplibre.org/maplibre-gl-js/docs/assets/radar.gif"
       },
       "type": "ImageSource"
     }


### PR DESCRIPTION
## Description

image.jGIS was not loading with `Failed to add Custom Image Layer: Cannot read properties of undefined (reading 'startsWith')`

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
