### PR TITLE
Disable smoothing on all raster sources

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -465,6 +465,9 @@ export class MainView extends React.Component<IProps, IStates> {
     source: IJGISSource,
     layerId?: string
   ): Promise<void> {
+    const rasterSourceCommon = {
+      interpolate: false,
+    }
     let newSource;
 
     switch (source.type) {
@@ -476,6 +479,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
         if (!pmTiles) {
           newSource = new XYZSource({
+            ...rasterSourceCommon,
             attributions: sourceParameters.attribution,
             minZoom: sourceParameters.minZoom,
             maxZoom: sourceParameters.maxZoom,
@@ -484,6 +488,7 @@ export class MainView extends React.Component<IProps, IStates> {
           });
         } else {
           newSource = new PMTilesRasterSource({
+            ...rasterSourceCommon,
             attributions: sourceParameters.attribution,
             tileSize: 256,
             url: url
@@ -496,6 +501,7 @@ export class MainView extends React.Component<IProps, IStates> {
         const sourceParameters = source.parameters as IRasterDemSource;
 
         newSource = new ImageTileSource({
+          ...rasterSourceCommon,
           url: this.computeSourceUrl(source),
           attributions: sourceParameters.attribution
         });
@@ -614,9 +620,9 @@ export class MainView extends React.Component<IProps, IStates> {
         });
 
         newSource = new Static({
+          ...rasterSourceCommon,
           imageExtent: extent,
           url: imageUrl,
-          interpolate: false,
           crossOrigin: ''
         });
 
@@ -649,6 +655,7 @@ export class MainView extends React.Component<IProps, IStates> {
         );
 
         newSource = new GeoTIFFSource({
+          ...rasterSourceCommon,
           sources: sourcesWithBlobs,
           normalize: sourceParameters.normalize,
           wrapX: sourceParameters.wrapX

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -220,7 +220,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
         const layerId = UUID.uuid4();
 
-        this.addSource(sourceId, sourceModel, layerId);
+        this.addSource(sourceId, sourceModel);
 
         this._model.sharedModel.addSource(sourceId, sourceModel);
 
@@ -463,7 +463,6 @@ export class MainView extends React.Component<IProps, IStates> {
   async addSource(
     id: string,
     source: IJGISSource,
-    layerId?: string
   ): Promise<void> {
     const rasterSourceCommon = {
       interpolate: false
@@ -707,7 +706,7 @@ export class MainView extends React.Component<IProps, IStates> {
     // remove source being updated
     this.removeSource(id);
     // create updated source
-    await this.addSource(id, source, layerId);
+    await this.addSource(id, source);
     // change source of target layer
     (mapLayer as Layer).setSource(this._sources[id]);
   }
@@ -805,7 +804,7 @@ export class MainView extends React.Component<IProps, IStates> {
     this._loadingLayers.add(id);
 
     if (!this._sources[sourceId]) {
-      await this.addSource(sourceId, source, id);
+      await this.addSource(sourceId, source);
     }
 
     this._loadingLayers.add(id);
@@ -1123,7 +1122,7 @@ export class MainView extends React.Component<IProps, IStates> {
     }
 
     if (!this._sources[sourceId]) {
-      await this.addSource(sourceId, source, id);
+      await this.addSource(sourceId, source);
     }
 
     mapLayer.setVisible(layer.visible);

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -466,8 +466,8 @@ export class MainView extends React.Component<IProps, IStates> {
     layerId?: string
   ): Promise<void> {
     const rasterSourceCommon = {
-      interpolate: false,
-    }
+      interpolate: false
+    };
     let newSource;
 
     switch (source.type) {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -460,10 +460,7 @@ export class MainView extends React.Component<IProps, IStates> {
    * @param id - the source id.
    * @param source - the source object.
    */
-  async addSource(
-    id: string,
-    source: IJGISSource,
-  ): Promise<void> {
+  async addSource(id: string, source: IJGISSource): Promise<void> {
     const rasterSourceCommon = {
       interpolate: false
     };


### PR DESCRIPTION
## Description

This is a touch hacky -- right now we don't know in advance whether someone is going to visualize gridded observation data, for which preserving grid cell boundaries is important, or stylistic raster data like a hillshade, or rasterized vector data, for which smoothing would look nice. This change prioritizes the first use case at the expense of the others, where smoothing may be useful, but in my view not critical. Hillshade layers will just be slightly less pretty at high zoom levels until we can separate these use cases. E.g. moving to a model where source creation is dependent on the layer type.

Resolves #466 

Unfortunately, there doesn't seem to be a way to override the smoothing setting at the layer level. To me, that doesn't make sense; pixel interpolation is a rendering option, so it should not be at the source level. ... right? :shrug: 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
