### PR TITLE
Move layer visibility toggle to the left of the layer title and icon

### DIFF
--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -416,27 +416,31 @@ function LayerComponent(props: ILayerProps): JSX.Element {
         onClick={setSelection}
         onContextMenu={setSelection}
       >
+
+        <Button
+          title={layer.visible ? 'Hide layer' : 'Show layer'}
+          onClick={toggleVisibility}
+          minimal
+        >
+          <LabIcon.resolveReact
+            icon={layer.visible ? visibilityIcon : nonVisibilityIcon}
+            className={`${LAYER_ICON_CLASS}${layer.visible ? '' : ' jp-gis-mod-hidden'}`}
+            tag="span"
+          />
+        </Button>
+
         {icons.has(layer.type) && (
           <LabIcon.resolveReact
             {...icons.get(layer.type)}
             className={LAYER_ICON_CLASS}
           />
         )}
+
         <span id={id} className={LAYER_TEXT_CLASS}>
           {name}
         </span>
+
       </div>
-      <Button
-        title={layer.visible ? 'Hide layer' : 'Show layer'}
-        onClick={toggleVisibility}
-        minimal
-      >
-        <LabIcon.resolveReact
-          icon={layer.visible ? visibilityIcon : nonVisibilityIcon}
-          className={`${LAYER_ICON_CLASS}${layer.visible ? '' : ' jp-gis-mod-hidden'}`}
-          tag="span"
-        />
-      </Button>
     </div>
   );
 }

--- a/packages/base/style/leftPanel.css
+++ b/packages/base/style/leftPanel.css
@@ -75,7 +75,6 @@
 
 .jp-gis-layer button,
 .jp-gis-source button {
-  margin-left: auto;
   min-height: unset;
   min-width: unset;
   padding: unset;


### PR DESCRIPTION
## Description

Resolves #244 

Before: 
![image](https://github.com/user-attachments/assets/2dc16dc7-3000-44b4-8337-687ace39e233)


After: 
![image](https://github.com/user-attachments/assets/9a6e52f7-2351-46aa-8625-0933388a52b2)

Keeping the button on the right raises questions about how to handle when the button overlaps with the text. After playing with it for a bit, I felt that having the button on the left is ideal. Especially as we move towards implementing #486, I feel having the button on the right misses an opportunity to convey information about grouping through indentation of the button.

![image](https://github.com/user-attachments/assets/cb48c5b9-b2bf-4559-a738-fc98d060732d)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
