### PR TITLE
Use `dist/` while using lite-artifacts

### DIFF
--- a/.github/workflows/update_lite_galata_references.yaml
+++ b/.github/workflows/update_lite_galata_references.yaml
@@ -76,6 +76,7 @@ jobs:
           workflow: 'build.yml'
           workflow_conclusion: ''
           name: lite-artifacts
+          path: dist
           allow_forks: true
 
       - name: Install dependencies


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--491.org.readthedocs.build/en/491/
💡 JupyterLite preview: https://jupytergis--491.org.readthedocs.build/en/491/lite

<!-- readthedocs-preview jupytergis end -->