### PR TITLE
Put commandRegistry back in consoleOptions

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -1,3 +1,8 @@
+import {
+  IJupyterGISDocumentWidget,
+  IJupyterGISModel,
+  IJupyterGISOutputWidget
+} from '@jupytergis/schema';
 import { MainAreaWidget } from '@jupyterlab/apputils';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { DocumentWidget } from '@jupyterlab/docregistry';
@@ -5,17 +10,12 @@ import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
 import { JSONValue } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import { SplitPanel, Widget } from '@lumino/widgets';
-import {
-  IJupyterGISModel,
-  IJupyterGISOutputWidget,
-  IJupyterGISDocumentWidget
-} from '@jupytergis/schema';
 
+import { CommandRegistry } from '@lumino/commands';
+import { MessageLoop } from '@lumino/messaging';
+import { ConsoleView } from './console';
 import { JupyterGISMainViewPanel } from './mainview';
 import { MainViewModel } from './mainview/mainviewmodel';
-import { ConsoleView } from './console';
-import { MessageLoop } from '@lumino/messaging';
-import { CommandRegistry } from '@lumino/commands';
 
 const CELL_OUTPUT_WIDGET_CLASS = 'jgis-cell-output-widget';
 
@@ -100,7 +100,7 @@ export class JupyterGISPanel extends SplitPanel {
       options;
     this._initModel({ model, commandRegistry });
     this._initView();
-    this._consoleOption = consoleOption;
+    this._consoleOption = { commandRegistry, ...consoleOption };
     this._consoleTracker = consoleTracker;
   }
 


### PR DESCRIPTION
## Description
Fix #496 

![console](https://github.com/user-attachments/assets/28e3b40d-8ac7-422b-ac69-daee744db713)

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--499.org.readthedocs.build/en/499/
💡 JupyterLite preview: https://jupytergis--499.org.readthedocs.build/en/499/lite

<!-- readthedocs-preview jupytergis end -->