### PR TITLE
Fix to vector colors notebook

### DIFF
--- a/examples/vector_colors.ipynb
+++ b/examples/vector_colors.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "execution_state": "idle",
    "id": "1f5dc83a-eebe-4090-8c7a-79c92510dc73",
    "metadata": {},
    "outputs": [],
@@ -25,26 +24,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "execution_state": "idle",
    "id": "9da5f69d-4b02-4056-bf64-ce4caa97d3cf",
    "metadata": {},
    "outputs": [],
    "source": [
     "doc.add_vectortile_layer(\n",
     "    url=\"https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/tile/{z}/{y}/{x}.pbf\",\n",
-    "    source_layer=\"Continent\",\n",
     "    color_expr={\"fill-color\": \"#00FF00\", \"circle-fill-color\": \"#FF0000\"},\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "execution_state": "idle",
-   "id": "e0d20393-8605-4b48-ad81-03ec308a0ee1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Description

follow up #506 
Fixes:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/ad511c9c-be28-4beb-9ec8-a5e2b2ddb49c" />


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--507.org.readthedocs.build/en/507/
💡 JupyterLite preview: https://jupytergis--507.org.readthedocs.build/en/507/lite

<!-- readthedocs-preview jupytergis end -->