### PR TITLE
Fix releaser for publishing jupytergis-lite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ python_packages = [
     "python/jupytergis_core:jupytergis_core",
     "python/jupytergis_lab:jupytergis_lab",
     "python/jupytergis_qgis:jupytergis_qgis",
-    "python/jupytergis_lite:jupytergis",
+    "python/jupytergis_lite:jupytergis_lite",
 ]
 
 [tool.jupyter-releaser.hooks]


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--524.org.readthedocs.build/en/524/
💡 JupyterLite preview: https://jupytergis--524.org.readthedocs.build/en/524/lite

<!-- readthedocs-preview jupytergis end -->