### PR TITLE
Enable ruff's bugbear "B" ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ extend-include = ["*.ipynb"]
 select = [
     # pycodestyle
     "E",
-    # bugbear: Disallow mutable argument defaults
-    "B006",
+    # bugbear
+    "B",
 ]
 ignore = ["E501", "E731"]

--- a/python/jupytergis_core/jupytergis_core/__init__.py
+++ b/python/jupytergis_core/jupytergis_core/__init__.py
@@ -6,7 +6,10 @@ except ImportError:
     # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
     import warnings
 
-    warnings.warn("Importing 'jupytergis_core' outside a proper installation.")
+    warnings.warn(
+        "Importing 'jupytergis_core' outside a proper installation.",
+        stacklevel=2,
+    )
     __version__ = "dev"
 
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -741,8 +741,9 @@ class GISDocument(CommWidget):
             file_name = Path(path).name
             try:
                 ext = file_name.split(".")[1].lower()
-            except Exception:
-                raise ValueError("Can not detect file extension!")
+            except Exception as e:
+                raise ValueError("Can not detect file extension!") from e
+
             if ext == "jgis":
                 format = "text"
                 contentType = "jgis"

--- a/python/jupytergis_lab/jupytergis_lab/notebook/y_connector.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/y_connector.py
@@ -19,8 +19,9 @@ class YDocConnector(Widget):
             self.path = path
             try:
                 ext = path.split(".")[1].lower()
-            except Exception:
-                raise Exception("Can not detect file extension!")
+            except Exception as e:
+                raise Exception("Can not detect file extension!") from e
+
             if ext == "jgis":
                 self._format = "text"
                 self._contentType = "jgis"

--- a/python/jupytergis_qgis/jupytergis_qgis/__init__.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/__init__.py
@@ -6,7 +6,10 @@ except ImportError:
     # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
     import warnings
 
-    warnings.warn("Importing 'jupytergis_qgis' outside a proper installation.")
+    warnings.warn(
+        "Importing 'jupytergis_qgis' outside a proper installation.",
+        stacklevel=2,
+    )
     __version__ = "dev"
 from .handlers import setup_handlers
 


### PR DESCRIPTION
## Description

Resolves #561 

Enable the [bugbear ruleset](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b), which detects many classes of likely bugs. 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--562.org.readthedocs.build/en/562/
💡 JupyterLite preview: https://jupytergis--562.org.readthedocs.build/en/562/lite

<!-- readthedocs-preview jupytergis end -->