### PR TITLE
Remove reprojection from buffer operation

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -383,7 +383,6 @@ export function addCommands(
           sourceData: {
             inputLayer: selectedLayerId,
             bufferDistance: 10,
-            projection: 'EPSG:4326'
           },
           formContext: 'create',
           processingType: 'buffer',
@@ -444,8 +443,6 @@ export function addCommands(
         const options = [
           '-f',
           'GeoJSON',
-          '-t_srs',
-          formValues.projection,
           '-dialect',
           'SQLITE',
           '-sql',

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -382,7 +382,7 @@ export function addCommands(
           model: model,
           sourceData: {
             inputLayer: selectedLayerId,
-            bufferDistance: 10,
+            bufferDistance: 10
           },
           formContext: 'create',
           processingType: 'buffer',

--- a/packages/schema/src/schema/processing/buffer.json
+++ b/packages/schema/src/schema/processing/buffer.json
@@ -13,11 +13,6 @@
       "type": "number",
       "default": 10,
       "description": "The distance used for buffering the geometry (in projection units)."
-    },
-    "projection": {
-      "type": "string",
-      "description": "The spatial reference system of the buffered output.",
-      "default": "EPSG:4326"
     }
   }
 }


### PR DESCRIPTION
## Description

Following the lead of the QGIS processing toolbox; treat this as more of a simple building block to be combined with other processing operations (e.g. reprojection).

Related #554 


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--563.org.readthedocs.build/en/563/
💡 JupyterLite preview: https://jupytergis--563.org.readthedocs.build/en/563/lite

<!-- readthedocs-preview jupytergis end -->