### PR TITLE
Fix docs build warning: Adjust documentation headings to start at H1

### DIFF
--- a/docs/contributor_guide/docs.md
+++ b/docs/contributor_guide/docs.md
@@ -1,26 +1,26 @@
-## Building JupyterGIS documentation locally
+# Building JupyterGIS documentation locally
 
 To install a conda environment with **([Micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html))**, run the following command inside `docs/`:
 
-### 1. Create the environment from `environment-docs.yml`
+## 1. Create the environment from `environment-docs.yml`
 
 ```
 micromamba create -f environment-docs.yml
 ```
 
-### 2. Activate the `jupytergis-docs` environment
+## 2. Activate the `jupytergis-docs` environment
 
 ```
 micromamba activate jupytergis-docs
 ```
 
-### 3. Build the documentation
+## 3. Build the documentation
 
 ```
 make html
 ```
 
-### 4. Open the documentation
+## 4. Open the documentation
 
 Once the build is complete, open:
 
@@ -28,7 +28,7 @@ Once the build is complete, open:
 docs/build/index.html
 ```
 
-### 5. Make changes and rebuild
+## 5. Make changes and rebuild
 
 After making docs edits, rerun:
 


### PR DESCRIPTION
## Description

Fixes failure in #565 


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--566.org.readthedocs.build/en/566/
💡 JupyterLite preview: https://jupytergis--566.org.readthedocs.build/en/566/lite

<!-- readthedocs-preview jupytergis end -->