### PR TITLE
Add architecture docs

### DIFF
--- a/docs/contributor_guide/architecture.md
+++ b/docs/contributor_guide/architecture.md
@@ -36,7 +36,7 @@ JupyterGIS is a monorepo containing TypeScript and Python packages.
     JupyterLite.
   * `jupytergis_qgis`: Enables importing and exporting QGIS project files.
 * `packages/`: The TypeScript packages.
-  * `base/`: 
+  * `base/`:
     * `src/index.ts`: Entrypoint for Typescript code.
     * :star: `src/constants.ts`: Defines all the JupyterGIS command names and
       corresponding icons.

--- a/docs/contributor_guide/architecture.md
+++ b/docs/contributor_guide/architecture.md
@@ -1,7 +1,7 @@
 # Architecture overview
 
 JupyterGIS is a JupyterLab extension (based on the structure defined by
-[jupyterlab/extensions-cookiecutter-ts](https://github.com/jupyterlab/extension-cookiecutter-ts).
+[jupyterlab/extensions-cookiecutter-ts](https://github.com/jupyterlab/extension-cookiecutter-ts)).
 
 Its architecture is based on QuantStack's
 [JupyterCAD](https://github.com/jupytercad/JupyterCAD) architecture.
@@ -9,68 +9,103 @@ Its architecture is based on QuantStack's
 
 ## JupyterLab
 
-### Backbone
+### About Lumino and JupyterLab
 
-...
+JupyterGIS is a JupyterLab extension. It may be useful to read more about the
+[extensions developer documentation](https://jupyterlab.readthedocs.io/en/latest/extension/extension_dev.html).
+
+The [Lumino](https://lumino.readthedocs.io/en/latest/api/index.html) library is a
+framework used to control the UI - i.e., tracks what changes in the UI and how it should
+react to that change.
 
 
-## JupyterGIS components
-
-### Directory structure
+## JupyterGIS components and structure
 
 JupyterGIS is a monorepo containing TypeScript and Python packages.
 
-* `python/`: The Python packages! These may include some TypeScript as well (_TODO: why?
-  Link to JupyterLab extension doc?_).
-  * `jupytergis`: A metapackage including `jupytergis_core`, `jupytergis_lab`,
-    `jupytergis_qgis`, `jupyter-collaboration`, and `jupyterlab`.
-  * `jupytergis_core`: Python methods specific to JupyterLab (not JupyterLite).
-    * :star: `src/jgisplugin/plugins.ts`: Where all the commands we've defined are
-      registered in TypeScript land -- defines behaviors for menu items.
-    * `src/jgisplugin/plugins.ts`: Where commands are linked to layer and source context
-      menus.
-  * `jupytergis_lab`: _TODO: Ask Martin_.
-    * :star: `jupytergis_lab/notebook/gis_document.ts`: Entrypoint for Python API.
-    * `src/notebookrenderer.ts`: Enables rendering JupyterGIS in a Notebook.
-  * `jupytergis_lite`: A metapackage for deployment and testing of JupyterGIS in
-    JupyterLite.
-  * `jupytergis_qgis`: Enables importing and exporting QGIS project files.
-* `packages/`: The TypeScript packages.
-  * `base/`:
-    * `src/index.ts`: Entrypoint for Typescript code.
-    * :star: `src/constants.ts`: Defines all the JupyterGIS command names and
-      corresponding icons.
-    * :star: `src/commands.ts`: For each command, defines the labels, the behaviors, and
-      in what contexts each command is available.
-    * :star: `src/mainview/index.ts`: Entrypoint for the main map view.
-    * `src/toolbar/widget.tsx`: Where commands are linked to the toolbar.
-    * `src/formbuilder/`: Base React components for forms.
-  * :star: `schema/`: The source of truth for data structures in JupyterGIS. Python
-    classes and Typescript types are generated from this.
+
+### TypeScript packages
+
+TypeScript packages live in the `packages/` directory.
+
+If you change anything about TypeScript packages, you'll need to rebuild with `jlpm run
+build`.
 
 
-### Schema
+### `@jupytergis/base`
 
-The fundamental source of truth for many other components of JupyterGIS.
+This package contains everything that controls the map using
+[OpenLayers](https://openlayers.org/doc/), panels, buttons, dialogs.
+It is a UI library, collection of tools - but it does not do anything by itself.
+We use this package to make the JupyterLab extension.
+
+* Defines the map view. See `packages/base/src/mainview`.
+* Generates the layer gallery. See
+  `packages/base/rasterlayer_gallery_generator.py`.
+* Defines "commands" that appear in various GUI menus and the command pallette
+  (`CTRL+SHIFT+C`).
+  See `packages/base/src/commands/`.
+  * Defines the toolbar and associated commands.
+    See `packages/base/src/toolbar/widget.tsx`.
+* Generates forms from the schema package.
+  See `packages/base/src/formbuilder/`.
+* Contains all logic related to adding layers and reading data.
+
+
+### `@jupytergis/schema`
+
+Defines our `.jgis` file format - as JSON schemas.
+The source of truth for data structures in JupyterGIS.
+If you wish to add a new layer _type_, you would need to add it to the schema.
+
+Python classes and Typescript types are automatically generated from the schema at
+build-time (i.e. not commited to the repository) using
+[`json2ts`](https://github.com/GregorBiswanger/json2ts) for TypeScript,
+and
+[`datamodel-code-generator`](https://docs.pydantic.dev/latest/integrations/datamodel_code_generator/)
+for Python.
 
 * Forms: Generated from e.g. `schema/src/schema/project/layers/vectorlayer.json`
 * Project file / shared model: `schema/src/schema/project/jgis.json`
 
 
-### Model
+### Python packages
 
-Structure defined in schema `packages/schema/src/schema/project/jgis.json`.
+Python packages live in the `python/` directory.
+These Python packages may include some TypeScript as well.
+
+* `jupytergis`: A metapackage including `jupytergis_core`, `jupytergis_lab`,
+  `jupytergis_qgis`, `jupyter-collaboration`, and `jupyterlab`.
+* `jupytergis_lite`: A metapackage including `jupytergis_core` and `jupytergis_lab`.
+  For deployment and testing of JupyterGIS in JupyterLite.
+* `jupytergis_core`: Gets the UI to do things - e.g., load / create JupyterGIS files,
+  and work with them.
+  Also includes a server endpoint for saving the created `.jgis` files to disk (not used
+  in JupyterLite).
+* `jupytergis_lab`: Contains everything needed for JupyterGIS to work within a notebook,
+  **the Python API**, the notebook renderer (the part that displays the JupyterGIS
+  session in the notebook).
+  **Might be worth considering renaming this folder? Current name doesn't reflect what
+  it does**.
+* `jupytergis_qgis`: Enables importing and exporting QGIS project files.
+  Requires a server component, and currently is not used in JupyterLite.
+
+
+### "Model"
+
+Structure is defined in schema `packages/schema/src/schema/project/jgis.json`.
 
 
 #### Shared model
 
-All collaborators share this and listen for changes to this. It mediates changes with
-Conflict-free Replicated Data Types (CRDTs), which is handled by `yjs`. It is the "magic
-sauce" that enables collaboration!
+All collaborators share this and listen for changes to this.
+It mediates changes with Conflict-free Replicated Data Types (CRDTs), which is handled
+by `yjs`.
+It is the "magic sauce" that enables collaboration!
 
 :::tip
 You can view the shared model in many contexts by writing
-`console.log(model.sharedModel)` in a JupyterGIS TypeScript file!
+`console.log(model.sharedModel)` in a TypeScript file!
 :::
 
 
@@ -81,39 +116,42 @@ Many new features are a matter of defining a new command.
 
 ### Forms
 
-Many forms are generated from `BaseForm`, but some forms use other classes which extend
-`BaseForm`. Each of these classes accepts the relevant schema a property in order to
-generate the form on-the-fly. The correct form class is selected in `formselector.ts`.
+JupyterGIS uses automatically generated forms for creating/editing layers and
+more.
 
-_TODO: How much of this is specific to JGIS and how much is generic and could be
-extracted to a third-party package?_
+Those forms are generated from schema definitions, meaning that adding a new
+entry in the schema will automatically create user-facing UI components when
+editing layers.
 
+An example of this was [adding a new "interpolate" parameter for raster
+sources](https://github.com/geojupyter/jupytergis/pull/522/files), the only
+required changes were to add the new schema entry, and react on the
+"interpolate" value in the OpenLayers viewer.
 
-### Signals
-
-Signals are a [Lumino](https://lumino.readthedocs.io/en/latest/api/index.html) framework thing.
-
-_TODO: We need some help defining this section. Is this helping with listening to model
-changes? Do they carry CRDT payloads? Or simpler payload, e.g. `onLayerChange` signal
-carrying the layer ID of a changed layer?_
-
-Read more: https://www.youtube.com/channel/UCejhDXmzOrxhsTsQBWe-pww/videos
+Many forms are generated from `BaseForm` (the default form implementation), but
+some forms use other classes which extend `BaseForm` in order to provide more
+advanced controls.
+Each of these classes accepts the relevant schema as a property in order to
+generate the form on-the-fly. The correct form class is selected in
+`formselector.ts`.
 
 
 ### Map view
 
-Uses [OpenLayers](https://openlayers.org/doc/) as a rendering engine.
+JupyterGIS uses [OpenLayers](https://openlayers.org/doc/) as a rendering engine.
 
-
-`packages/base/src/mainview/index.ts`
+The action happens in the `@jupytergis/base` package, at
+`packages/base/src/mainview/mainView.tsx`.
 
 
 #### Swappable rendering engine?
 
 The Venn Diagram of the JavaScript map rendering engine ecosystem unfortunately looks
-like a bunch of disparate circles with few overlaps. The burden of understanding this is
-very high, and we hope to avoid shifting this burden on to our users.
+like a bunch of disparate circles with few overlaps.
+The burden of understanding this is very high, and we hope to avoid shifting
+this burden on to our users.
 
 For example, OpenLayers has excellent support for alternative map projections and
-excellent low-level API, but lacks support for visualizing huge vector datasets with the
-GPU. DeckGL can quickly render huge datasets, but lacks projection support.
+low-level API, but lacks support for visualizing huge vector datasets with the
+GPU.
+DeckGL can quickly render huge datasets, but lacks projection support.

--- a/docs/contributor_guide/architecture.md
+++ b/docs/contributor_guide/architecture.md
@@ -6,7 +6,6 @@ JupyterGIS is a JupyterLab extension (based on the structure defined by
 Its architecture is based on QuantStack's
 [JupyterCAD](https://github.com/jupytercad/JupyterCAD) architecture.
 
-
 ## JupyterLab
 
 ### About Lumino and JupyterLab
@@ -18,11 +17,9 @@ The [Lumino](https://lumino.readthedocs.io/en/latest/api/index.html) library is 
 framework used to control the UI - i.e., tracks what changes in the UI and how it should
 react to that change.
 
-
 ## JupyterGIS components and structure
 
 JupyterGIS is a monorepo containing TypeScript and Python packages.
-
 
 ### TypeScript packages
 
@@ -31,7 +28,6 @@ TypeScript packages live in the `packages/` directory.
 If you change anything about TypeScript packages, you'll need to rebuild with `jlpm run
 build`.
 
-
 ### `@jupytergis/base`
 
 This package contains everything that controls the map using
@@ -39,18 +35,17 @@ This package contains everything that controls the map using
 It is a UI library, collection of tools - but it does not do anything by itself.
 We use this package to make the JupyterLab extension.
 
-* Defines the map view. See `packages/base/src/mainview`.
-* Generates the layer gallery. See
+- Defines the map view. See `packages/base/src/mainview`.
+- Generates the layer gallery. See
   `packages/base/rasterlayer_gallery_generator.py`.
-* Defines "commands" that appear in various GUI menus and the command pallette
+- Defines "commands" that appear in various GUI menus and the command pallette
   (`CTRL+SHIFT+C`).
   See `packages/base/src/commands/`.
-  * Defines the toolbar and associated commands.
+  - Defines the toolbar and associated commands.
     See `packages/base/src/toolbar/widget.tsx`.
-* Generates forms from the schema package.
+- Generates forms from the schema package.
   See `packages/base/src/formbuilder/`.
-* Contains all logic related to adding layers and reading data.
-
+- Contains all logic related to adding layers and reading data.
 
 ### `@jupytergis/schema`
 
@@ -65,36 +60,33 @@ and
 [`datamodel-code-generator`](https://docs.pydantic.dev/latest/integrations/datamodel_code_generator/)
 for Python.
 
-* Forms: Generated from e.g. `schema/src/schema/project/layers/vectorlayer.json`
-* Project file / shared model: `schema/src/schema/project/jgis.json`
-
+- Forms: Generated from e.g. `schema/src/schema/project/layers/vectorlayer.json`
+- Project file / shared model: `schema/src/schema/project/jgis.json`
 
 ### Python packages
 
 Python packages live in the `python/` directory.
 These Python packages may include some TypeScript as well.
 
-* `jupytergis`: A metapackage including `jupytergis_core`, `jupytergis_lab`,
+- `jupytergis`: A metapackage including `jupytergis_core`, `jupytergis_lab`,
   `jupytergis_qgis`, `jupyter-collaboration`, and `jupyterlab`.
-* `jupytergis_lite`: A metapackage including `jupytergis_core` and `jupytergis_lab`.
+- `jupytergis_lite`: A metapackage including `jupytergis_core` and `jupytergis_lab`.
   For deployment and testing of JupyterGIS in JupyterLite.
-* `jupytergis_core`: Gets the UI to do things - e.g., load / create JupyterGIS files,
+- `jupytergis_core`: Gets the UI to do things - e.g., load / create JupyterGIS files,
   and work with them.
   Also includes a server endpoint for saving the created `.jgis` files to disk (not used
   in JupyterLite).
-* `jupytergis_lab`: Contains everything needed for JupyterGIS to work within a notebook,
+- `jupytergis_lab`: Contains everything needed for JupyterGIS to work within a notebook,
   **the Python API**, the notebook renderer (the part that displays the JupyterGIS
   session in the notebook).
   **Might be worth considering renaming this folder? Current name doesn't reflect what
   it does**.
-* `jupytergis_qgis`: Enables importing and exporting QGIS project files.
+- `jupytergis_qgis`: Enables importing and exporting QGIS project files.
   Requires a server component, and currently is not used in JupyterLite.
-
 
 ### "Model"
 
 Structure is defined in schema `packages/schema/src/schema/project/jgis.json`.
-
 
 #### Shared model
 
@@ -108,11 +100,9 @@ You can view the shared model in many contexts by writing
 `console.log(model.sharedModel)` in a TypeScript file!
 :::
 
-
 ### Commands
 
 Many new features are a matter of defining a new command.
-
 
 ### Forms
 
@@ -135,14 +125,12 @@ Each of these classes accepts the relevant schema as a property in order to
 generate the form on-the-fly. The correct form class is selected in
 `formselector.ts`.
 
-
 ### Map view
 
 JupyterGIS uses [OpenLayers](https://openlayers.org/doc/) as a rendering engine.
 
 The action happens in the `@jupytergis/base` package, at
 `packages/base/src/mainview/mainView.tsx`.
-
 
 #### Swappable rendering engine?
 

--- a/docs/contributor_guide/architecture.md
+++ b/docs/contributor_guide/architecture.md
@@ -4,7 +4,7 @@ JupyterGIS is a JupyterLab extension (based on the structure defined by
 [jupyterlab/extensions-cookiecutter-ts](https://github.com/jupyterlab/extension-cookiecutter-ts).
 
 Its architecture is based on QuantStack's
-[JupyterCAD](https://github.com/QuantStack/JupyterCAD) architecture.
+[JupyterCAD](https://github.com/jupytercad/JupyterCAD) architecture.
 
 
 ## JupyterLab

--- a/docs/contributor_guide/architecture.md
+++ b/docs/contributor_guide/architecture.md
@@ -1,0 +1,119 @@
+# Architecture overview
+
+JupyterGIS is a JupyterLab extension (based on the structure defined by
+[jupyterlab/extensions-cookiecutter-ts](https://github.com/jupyterlab/extension-cookiecutter-ts).
+
+Its architecture is based on QuantStack's
+[JupyterCAD](https://github.com/QuantStack/JupyterCAD) architecture.
+
+
+## JupyterLab
+
+### Backbone
+
+...
+
+
+## JupyterGIS components
+
+### Directory structure
+
+JupyterGIS is a monorepo containing TypeScript and Python packages.
+
+* `python/`: The Python packages! These may include some TypeScript as well (_TODO: why?
+  Link to JupyterLab extension doc?_).
+  * `jupytergis`: A metapackage including `jupytergis_core`, `jupytergis_lab`,
+    `jupytergis_qgis`, `jupyter-collaboration`, and `jupyterlab`.
+  * `jupytergis_core`: Python methods specific to JupyterLab (not JupyterLite).
+    * :star: `src/jgisplugin/plugins.ts`: Where all the commands we've defined are
+      registered in TypeScript land -- defines behaviors for menu items.
+    * `src/jgisplugin/plugins.ts`: Where commands are linked to layer and source context
+      menus.
+  * `jupytergis_lab`: _TODO: Ask Martin_.
+    * :star: `jupytergis_lab/notebook/gis_document.ts`: Entrypoint for Python API.
+    * `src/notebookrenderer.ts`: Enables rendering JupyterGIS in a Notebook.
+  * `jupytergis_lite`: A metapackage for deployment and testing of JupyterGIS in
+    JupyterLite.
+  * `jupytergis_qgis`: Enables importing and exporting QGIS project files.
+* `packages/`: The TypeScript packages.
+  * `base/`: 
+    * `src/index.ts`: Entrypoint for Typescript code.
+    * :star: `src/constants.ts`: Defines all the JupyterGIS command names and
+      corresponding icons.
+    * :star: `src/commands.ts`: For each command, defines the labels, the behaviors, and
+      in what contexts each command is available.
+    * :star: `src/mainview/index.ts`: Entrypoint for the main map view.
+    * `src/toolbar/widget.tsx`: Where commands are linked to the toolbar.
+    * `src/formbuilder/`: Base React components for forms.
+  * :star: `schema/`: The source of truth for data structures in JupyterGIS. Python
+    classes and Typescript types are generated from this.
+
+
+### Schema
+
+The fundamental source of truth for many other components of JupyterGIS.
+
+* Forms: Generated from e.g. `schema/src/schema/project/layers/vectorlayer.json`
+* Project file / shared model: `schema/src/schema/project/jgis.json`
+
+
+### Model
+
+Structure defined in schema `packages/schema/src/schema/project/jgis.json`.
+
+
+#### Shared model
+
+All collaborators share this and listen for changes to this. It mediates changes with
+Conflict-free Replicated Data Types (CRDTs), which is handled by `yjs`. It is the "magic
+sauce" that enables collaboration!
+
+:::tip
+You can view the shared model in many contexts by writing
+`console.log(model.sharedModel)` in a JupyterGIS TypeScript file!
+:::
+
+
+### Commands
+
+Many new features are a matter of defining a new command.
+
+
+### Forms
+
+Many forms are generated from `BaseForm`, but some forms use other classes which extend
+`BaseForm`. Each of these classes accepts the relevant schema a property in order to
+generate the form on-the-fly. The correct form class is selected in `formselector.ts`.
+
+_TODO: How much of this is specific to JGIS and how much is generic and could be
+extracted to a third-party package?_
+
+
+### Signals
+
+Signals are a [Lumino](https://lumino.readthedocs.io/en/latest/api/index.html) framework thing.
+
+_TODO: We need some help defining this section. Is this helping with listening to model
+changes? Do they carry CRDT payloads? Or simpler payload, e.g. `onLayerChange` signal
+carrying the layer ID of a changed layer?_
+
+Read more: https://www.youtube.com/channel/UCejhDXmzOrxhsTsQBWe-pww/videos
+
+
+### Map view
+
+Uses [OpenLayers](https://openlayers.org/doc/) as a rendering engine.
+
+
+`packages/base/src/mainview/index.ts`
+
+
+#### Swappable rendering engine?
+
+The Venn Diagram of the JavaScript map rendering engine ecosystem unfortunately looks
+like a bunch of disparate circles with few overlaps. The burden of understanding this is
+very high, and we hope to avoid shifting this burden on to our users.
+
+For example, OpenLayers has excellent support for alternative map projections and
+excellent low-level API, but lacks support for visualizing huge vector datasets with the
+GPU. DeckGL can quickly render huge datasets, but lacks projection support.

--- a/docs/contributor_guide/architecture.md
+++ b/docs/contributor_guide/architecture.md
@@ -31,7 +31,8 @@ build`.
 ### `@jupytergis/base`
 
 This package contains everything that controls the map using
-[OpenLayers](https://openlayers.org/doc/), panels, buttons, dialogs.
+[OpenLayers](https://openlayers.org/doc/), panels, buttons, dialogs; all as
+[React](https://react.dev/) components.
 It is a UI library, collection of tools - but it does not do anything by itself.
 We use this package to make the JupyterLab extension.
 

--- a/docs/contributor_guide/index.md
+++ b/docs/contributor_guide/index.md
@@ -10,6 +10,7 @@ To chat with other contributors, please
 :maxdepth: 2
 
 development_setup
+architecture
 how-tos/index
 testing
 code_quality


### PR DESCRIPTION
## Description

Resolves #401 

Add some docs that help newcomers dive in to the code and make changes.

@martinRenou @brichet @gjmooney @Meriem-BenIsmail would love your input on this:

* What concepts are important to cover that we've missed?
* Are the things in the doc accurate?
* Any comments or thoughts on the TODOs in the doc?


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--576.org.readthedocs.build/en/576/
💡 JupyterLite preview: https://jupytergis--576.org.readthedocs.build/en/576/lite

<!-- readthedocs-preview jupytergis end -->