### PR TITLE
Feat:- Adding key shortcut i to identity

### DIFF
--- a/packages/base/src/keybindings.json
+++ b/packages/base/src/keybindings.json
@@ -13,12 +13,12 @@
     "command": "jupytergis:identify",
     "keys": ["Escape"],
     "selector": ".data-jgis-keybinding"
-  }, 
+  },
   {
     "command": "jupytergis:identify",
     "keys": ["I"],
     "selector": ".data-jgis-keybinding"
-  },                             
+  },
   {
     "command": "jupytergis:removeSource",
     "keys": ["Delete"],

--- a/packages/base/src/keybindings.json
+++ b/packages/base/src/keybindings.json
@@ -13,7 +13,12 @@
     "command": "jupytergis:identify",
     "keys": ["Escape"],
     "selector": ".data-jgis-keybinding"
-  },
+  }, 
+  {
+    "command": "jupytergis:identify",
+    "keys": ["I"],
+    "selector": ".data-jgis-keybinding"
+  },                             
   {
     "command": "jupytergis:removeSource",
     "keys": ["Delete"],


### PR DESCRIPTION
## Description
This pr implements the 'i' key shortcut to identify command. The identify command should now activates and deactivates with 'i' key and also deactivates by 'escape' key.

## Video

https://github.com/user-attachments/assets/cbade76d-7c8c-41c9-bee0-6b72c26caea9

closes #575 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--581.org.readthedocs.build/en/581/
💡 JupyterLite preview: https://jupytergis--581.org.readthedocs.build/en/581/lite

<!-- readthedocs-preview jupytergis end -->