### PR TITLE
Add documentation build script, fix build warning, and update docs on building docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,8 +25,8 @@ build:
       # Create the env for building the docs
       - /bin/bash --login -c "micromamba env create -n jupytergis-docs -f docs/environment-docs.yml"
       # Create the isolated env for building JupyterGIS
-      - /bin/bash --login -c "micromamba create -n jupytergis-build -c conda-forge nodejs hatch pip python=3.13"
-      - /bin/bash --login -c "micromamba run -n jupytergis-build pip install 'jupyterlab==4.3' 'datamodel-code-generator>=0.23.0'"
+      # - /bin/bash --login -c "micromamba create -n jupytergis-build -c conda-forge nodejs hatch pip python=3.13"
+      # - /bin/bash --login -c "micromamba run -n jupytergis-build pip install 'jupyterlab==4.3' 'datamodel-code-generator>=0.23.0'"
 
     # Override the install step to do nothing - we already created the envs
     install:
@@ -34,16 +34,16 @@ build:
 
     # Before building the docs, build JupyterGIS in its isolated environment,
     # then install the wheels into the docs environment.
-    pre_build:
-      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm install"
-      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build"
-      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build:packages"
-      - |-
-        /bin/bash --login -c "micromamba run -n jupytergis-docs \
-          python -m pip install \
-          $(ls ./python/jupytergis_core/dist/jupytergis*.whl) \
-          $(ls ./python/jupytergis_lab/dist/jupytergis*.whl) \
-          $(ls ./python/jupytergis_qgis/dist/jupytergis*.whl)"
+    # pre_build:
+    #   - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm install"
+    #   - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build"
+    #   - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build:packages"
+    #   - |-
+    #     /bin/bash --login -c "micromamba run -n jupytergis-docs \
+    #       python -m pip install \
+    #       $(ls ./python/jupytergis_core/dist/jupytergis*.whl) \
+    #       $(ls ./python/jupytergis_lab/dist/jupytergis*.whl) \
+    #       $(ls ./python/jupytergis_qgis/dist/jupytergis*.whl)"
 
     build:
       html:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,28 +22,19 @@ build:
     create_environment:
       # Pin micromamba
       - /bin/bash --login -c "micromamba self-update --version 2.0.7"
-      # Create the env for building the docs
-      - /bin/bash --login -c "micromamba env create -n jupytergis-docs -f docs/environment-docs.yml"
       # Create the isolated env for building JupyterGIS
       - /bin/bash --login -c "micromamba create -n jupytergis-build -c conda-forge nodejs hatch pip python=3.13"
       - /bin/bash --login -c "micromamba run -n jupytergis-build pip install 'jupyterlab==4.3' 'datamodel-code-generator>=0.23.0'"
+      # Build JupyterGIS Javascript packages; required for building the docs env
+      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm install"
+      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build"
+      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build:packages"
+      # Create the env for building the docs
+      - /bin/bash --login -c "micromamba env create -n jupytergis-docs -f docs/environment-docs.yml"
 
     # Override the install step to do nothing - we already created the envs
     install:
       - "echo 'Skipping! We already have the environments we need.'"
-
-    # Before building the docs, build JupyterGIS in its isolated environment,
-    # then install the wheels into the docs environment.
-    pre_build:
-      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm install"
-      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build"
-      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build:packages"
-      - |-
-        /bin/bash --login -c "micromamba run -n jupytergis-docs \
-          python -m pip install \
-          $(ls ./python/jupytergis_core/dist/jupytergis*.whl) \
-          $(ls ./python/jupytergis_lab/dist/jupytergis*.whl) \
-          $(ls ./python/jupytergis_qgis/dist/jupytergis*.whl)"
 
     build:
       html:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,8 +25,8 @@ build:
       # Create the env for building the docs
       - /bin/bash --login -c "micromamba env create -n jupytergis-docs -f docs/environment-docs.yml"
       # Create the isolated env for building JupyterGIS
-      # - /bin/bash --login -c "micromamba create -n jupytergis-build -c conda-forge nodejs hatch pip python=3.13"
-      # - /bin/bash --login -c "micromamba run -n jupytergis-build pip install 'jupyterlab==4.3' 'datamodel-code-generator>=0.23.0'"
+      - /bin/bash --login -c "micromamba create -n jupytergis-build -c conda-forge nodejs hatch pip python=3.13"
+      - /bin/bash --login -c "micromamba run -n jupytergis-build pip install 'jupyterlab==4.3' 'datamodel-code-generator>=0.23.0'"
 
     # Override the install step to do nothing - we already created the envs
     install:
@@ -34,16 +34,16 @@ build:
 
     # Before building the docs, build JupyterGIS in its isolated environment,
     # then install the wheels into the docs environment.
-    # pre_build:
-    #   - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm install"
-    #   - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build"
-    #   - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build:packages"
-    #   - |-
-    #     /bin/bash --login -c "micromamba run -n jupytergis-docs \
-    #       python -m pip install \
-    #       $(ls ./python/jupytergis_core/dist/jupytergis*.whl) \
-    #       $(ls ./python/jupytergis_lab/dist/jupytergis*.whl) \
-    #       $(ls ./python/jupytergis_qgis/dist/jupytergis*.whl)"
+    pre_build:
+      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm install"
+      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build"
+      - /bin/bash --login -c "micromamba run -n jupytergis-build jlpm build:packages"
+      - |-
+        /bin/bash --login -c "micromamba run -n jupytergis-docs \
+          python -m pip install \
+          $(ls ./python/jupytergis_core/dist/jupytergis*.whl) \
+          $(ls ./python/jupytergis_lab/dist/jupytergis*.whl) \
+          $(ls ./python/jupytergis_qgis/dist/jupytergis*.whl)"
 
     build:
       html:

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$(dirname "$0")"; pwd -P )"
+
+# Build can fail if certain artifacts exist here:
+rm -rf "${THIS_DIR}/_build"
+
+python -m sphinx --fail-on-warning --keep-going  --nitpicky --show-traceback \
+    --builder html --doctree-dir _build/doctrees --define language=en \
+   . \
+   ./_build/html

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -5,7 +5,9 @@ THIS_DIR="$( cd "$(dirname "$0")"; pwd -P )"
 # Build can fail if certain artifacts exist here:
 rm -rf "${THIS_DIR}/_build"
 
-python -m sphinx --fail-on-warning --keep-going  --nitpicky --show-traceback \
+python -m sphinx \
+    --nitpicky --show-traceback \
+    --fail-on-warning --keep-going \
     --builder html --doctree-dir _build/doctrees --define language=en \
    . \
    ./_build/html

--- a/docs/contributor_guide/docs.md
+++ b/docs/contributor_guide/docs.md
@@ -1,6 +1,13 @@
 # Building JupyterGIS documentation locally
 
-To install a conda environment with **([Micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html))**, run the following command inside `docs/`:
+:::{important}
+Navigate to the `docs/` directory before starting any of these steps!
+:::
+
+:::{tip}
+You can use `conda` or `mamba` as drop-in replacements for `micromamba` in the steps
+below, but they will not be as fast.
+:::
 
 ## 1. Create the environment from `environment-docs.yml`
 
@@ -16,24 +23,24 @@ micromamba activate jupytergis-docs
 
 ## 3. Build the documentation
 
+:::{note}
+You may experience failure at this step. Carefully read the last message. Did the build
+fail due to warnings? You may need to search the full log output for "WARNING" to find
+the cause.
+:::
+
 ```
-make html
+./build.sh
 ```
 
 ## 4. Open the documentation
 
-Once the build is complete, open:
+Once the build is successful, open:
 
 ```
-docs/build/index.html
+_build/html/index.html
 ```
 
-## 5. Make changes and rebuild
+## 5. Repeat!
 
-After making docs edits, rerun:
-
-```
-make html
-```
-
-to regenerate the updated documentation.
+Every time you make edits to documentation, repeat steps 3 and 4.

--- a/docs/contributor_guide/docs.md
+++ b/docs/contributor_guide/docs.md
@@ -9,7 +9,16 @@ You can use `conda` or `mamba` as drop-in replacements for `micromamba` in the s
 below, but they will not be as fast.
 :::
 
-## 1. Create the environment from `environment-docs.yml`
+## 0. Build JupyterGIS JavaScript packages
+
+Follow the [development environment setup instructions](./development_setup.rst).
+From the root of the repo, run `jlpm build`.
+
+## 1. Create the docs environment from `environment-docs.yml`
+
+:::{important}
+Ensure all other environments are deactivated first!
+:::
 
 ```
 micromamba create -f environment-docs.yml

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -18,7 +18,7 @@ dependencies:
   - sphinx-togglebutton
   - myst-parser
   - xeus-python # TODO: Do we need this?
-  - pip:
-      # Install JupyterGIS so we can autodoc:
-      - ../python/jupytergis_core
-      - ../python/jupytergis_lab
+  # - pip:
+  #     # Install JupyterGIS so we can autodoc:
+  #     - ../python/jupytergis_core
+  #     - ../python/jupytergis_lab

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -18,3 +18,5 @@ dependencies:
   - sphinx-togglebutton
   - myst-parser
   - xeus-python # TODO: Do we need this?
+  - pip:
+      - ../python/jupytergis_lab  # For autodoc

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -19,4 +19,4 @@ dependencies:
   - myst-parser
   - xeus-python # TODO: Do we need this?
   - pip:
-      - ../python/jupytergis_lab  # For autodoc
+      - ../python/jupytergis_lab # For autodoc

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -19,4 +19,6 @@ dependencies:
   - myst-parser
   - xeus-python # TODO: Do we need this?
   - pip:
-      - ../python/jupytergis_lab # For autodoc
+      # Install JupyterGIS so we can autodoc:
+      - ../python/jupytergis_core
+      - ../python/jupytergis_lab

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -4,7 +4,6 @@ channels:
   - nodefaults
 dependencies:
   - python=3.12
-  - pip # Needed to install jupytergis wheels in RTD build
 
   # Build docs & JupyterLite
   - jupyterlite-core
@@ -18,7 +17,11 @@ dependencies:
   - sphinx-togglebutton
   - myst-parser
   - xeus-python # TODO: Do we need this?
-  # - pip:
-  #     # Install JupyterGIS so we can autodoc:
-  #     - ../python/jupytergis_core
-  #     - ../python/jupytergis_lab
+
+  - pip
+  - pip:
+      # Install JupyterGIS so we can autodoc.
+      # IMPORTANT: You must do `jlpm build` at the root of the repo before this can work.
+      # See: https://github.com/geojupyter/jupytergis/issues/585
+      - ../python/jupytergis_core
+      - ../python/jupytergis_lab


### PR DESCRIPTION
## Description

Local builds were failing because of a warning thrown by autodoc because `jupytergis_lab` was not installed, so `GISDocument` couldn't be found by autodoc. Edited `environment-docs.yml` to support this.

Also, the documentation documentation (:smile:) was suggesting using `make`, when we don't have a `Makefile`. I added a script instead and updated the docs correspondingly.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--584.org.readthedocs.build/en/584/
💡 JupyterLite preview: https://jupytergis--584.org.readthedocs.build/en/584/lite

<!-- readthedocs-preview jupytergis end -->