### PR TITLE
[WIP] Add "Save as..." command and toolbar button

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -279,7 +279,7 @@ export function addCommands(
       // FIXME: Saves to the currently open directory, while the above save is to the JupyterLab root directory.
       // FIXME: Get "unsaved_project" from a constant
       // FIXME: unsaved_project is getting saved even though we're trying not to!
-      if (oldFilename && oldFilename.endsWith('unsaved_project')) {
+      if (oldFilename && !oldFilename.endsWith('unsaved_project')) {
         app.serviceManager.contents.save(oldFilename, {
           content: JSON.stringify(content),
           format: 'text',

--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -11,6 +11,7 @@ export namespace CommandIDs {
   export const symbology = 'jupytergis:symbology';
   export const identify = 'jupytergis:identify';
   export const temporalController = 'jupytergis:temporalController';
+  export const saveAs = 'jupytergis:saveAs';
 
   // Layers and sources creation commands
   export const openLayerBrowser = 'jupytergis:openLayerBrowser';
@@ -106,7 +107,8 @@ const iconObject = {
   [CommandIDs.newGeoTiffEntry]: { iconClass: 'fa fa-image' },
   [CommandIDs.symbology]: { iconClass: 'fa fa-brush' },
   [CommandIDs.identify]: { iconClass: 'fa fa-info' },
-  [CommandIDs.temporalController]: { iconClass: 'fa fa-clock' }
+  [CommandIDs.temporalController]: { iconClass: 'fa fa-clock' },
+  [CommandIDs.saveAs]: {iconClass: 'fa fa-save'}
 };
 
 /**

--- a/packages/base/src/formbuilder/objectform/bufferProcessForm.tsx
+++ b/packages/base/src/formbuilder/objectform/bufferProcessForm.tsx
@@ -1,0 +1,92 @@
+import { BaseForm, IBaseFormProps, IBaseFormStates } from './baseform'; // Ensure BaseForm imports states
+import { IDict, IJupyterGISModel } from '@jupytergis/schema';
+import { IChangeEvent } from '@rjsf/core';
+// import { loadFile } from '../../tools';
+import proj4 from 'proj4';
+
+interface IBufferFormOptions extends IBaseFormProps {
+  schema: IDict;
+  sourceData: IDict;
+  title: string;
+  cancelButton: (() => void) | boolean;
+  syncData: (props: IDict) => void;
+  model: IJupyterGISModel;
+}
+
+export class BufferForm extends BaseForm {
+  private model: IJupyterGISModel;
+  private unit = '';
+
+  constructor(options: IBufferFormOptions) {
+    super(options);
+    this.model = options.model;
+
+    // Ensure initial state matches IBaseFormStates
+    this.state = {
+      schema: options.schema ?? {} // Ensure schema is never undefined
+    };
+
+    this.onFormChange = this.handleFormChange.bind(this);
+
+    this.computeDistanceUnits(options.sourceData.inputLayer);
+  }
+
+  private async computeDistanceUnits(layerId: string) {
+    const layer = this.model.getLayer(layerId);
+    if (!layer?.parameters?.source) {
+      return;
+    }
+    const source = this.model.getSource(layer.parameters.source);
+    if (!source) {
+      return;
+    }
+
+    const projection = source.parameters?.projection;
+    console.log(projection);
+
+    // TODO: how to get layer info from OpenLayers?
+    // const srs = layer.from_ol().srs;
+    const srs = 'EPSG:4326';
+
+    try {
+      // console.log(proj4, srs);
+      this.unit = (proj4(srs) as any).oProj.units;
+      debugger;
+      this.updateSchema();
+    } catch (error) {
+      console.error('Error calculating units:', error);
+    }
+  }
+
+  public handleFormChange(e: IChangeEvent) {
+    super.onFormChange(e);
+
+    if (e.formData.inputLayer) {
+      this.computeDistanceUnits(e.formData.inputLayer);
+    }
+  }
+
+  private updateSchema() {
+    this.setState(
+      (prevState: IBaseFormStates) => ({
+        schema: {
+          ...prevState.schema,
+          properties: {
+            ...prevState.schema?.properties,
+            bufferDistance: {
+              ...prevState.schema?.properties?.bufferDistance,
+              description:
+                prevState.schema?.properties?.bufferDistance.description.replace(
+                  'projection units',
+                  this.unit
+                )
+            }
+          }
+        }
+      }),
+      () => {
+        this.forceUpdate();
+      }
+    );
+  }
+}

--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -40,6 +40,14 @@ export class ToolbarWidget extends ReactiveToolbar {
 
     if (options.commands) {
       this.addItem(
+        'Save as...',
+        new CommandToolbarButton({
+          id: CommandIDs.saveAs,
+          label: '',
+          commands: options.commands
+        }),
+      );
+      this.addItem(
         'undo',
         new CommandToolbarButton({
           id: CommandIDs.undo,


### PR DESCRIPTION
## Description

We want to enable users working on nameless documents (`doc = GISDocument()`) to save that document from the UI (#594). The current "Save JGIS As..." menu entry from JupyterLab works great in a full view, but not in a widget view or sidecar view.


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
