### PR TITLE
Temporarily change identify keybinding to "Accel+I" to work around bug #592

### DIFF
--- a/packages/base/src/keybindings.json
+++ b/packages/base/src/keybindings.json
@@ -16,7 +16,7 @@
   },
   {
     "command": "jupytergis:identify",
-    "keys": ["I"],
+    "keys": ["Accel I"],
     "selector": ".data-jgis-keybinding"
   },
   {


### PR DESCRIPTION
## Description

This is a workaround only to enable users to type in Notebooks again!

See: #592 (Important: This PR does not resolve the underlying bug, do not close that issue :smile:)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--600.org.readthedocs.build/en/600/
💡 JupyterLite preview: https://jupytergis--600.org.readthedocs.build/en/600/lite

<!-- readthedocs-preview jupytergis end -->