### PR TITLE
Use only relevant selectors for keybindings to prevent conflicts

### DIFF
--- a/packages/base/src/keybindings.json
+++ b/packages/base/src/keybindings.json
@@ -16,7 +16,7 @@
   },
   {
     "command": "jupytergis:identify",
-    "keys": ["Accel I"],
+    "keys": ["I"],
     "selector": ".data-jgis-keybinding"
   },
   {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -1884,7 +1884,8 @@ export class MainView extends React.Component<IProps, IStates> {
             />
           )}
           <div
-            className="jGIS-Mainview"
+            className="jGIS-Mainview data-jgis-keybinding"
+            tabIndex={-2}
             style={{
               border: this.state.remoteUser
                 ? `solid 3px ${this.state.remoteUser.color}`

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -32,7 +32,7 @@ const LAYER_ITEM_CLASS = 'jp-gis-layerItem';
 const LAYER_CLASS = 'jp-gis-layer';
 const LAYER_TITLE_CLASS = 'jp-gis-layerTitle';
 const LAYER_ICON_CLASS = 'jp-gis-layerIcon';
-const LAYER_TEXT_CLASS = 'jp-gis-layerText';
+const LAYER_TEXT_CLASS = 'jp-gis-layerText data-jgis-keybinding';
 
 /**
  * The layers panel widget.
@@ -300,7 +300,7 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
           className={`${LAYER_GROUP_COLLAPSER_CLASS}${open ? ' jp-mod-expanded' : ''}`}
           tag={'span'}
         />
-        <span id={id} className={LAYER_TEXT_CLASS}>
+        <span id={id} className={LAYER_TEXT_CLASS} tabIndex={-2}>
           {name}
         </span>
       </div>
@@ -435,7 +435,7 @@ function LayerComponent(props: ILayerProps): JSX.Element {
           />
         )}
 
-        <span id={id} className={LAYER_TEXT_CLASS}>
+        <span id={id} className={LAYER_TEXT_CLASS} tabIndex={-2}>
           {name}
         </span>
       </div>

--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -39,6 +39,8 @@ export class LeftPanelWidget extends SidePanel {
   constructor(options: LeftPanelWidget.IOptions) {
     super();
     this.addClass('jGIS-sidepanel-widget');
+    this.addClass('data-jcad-keybinding');
+    this.node.tabIndex = 0;
 
     this._model = options.model;
     this._state = options.state;

--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -39,7 +39,7 @@ export class LeftPanelWidget extends SidePanel {
   constructor(options: LeftPanelWidget.IOptions) {
     super();
     this.addClass('jGIS-sidepanel-widget');
-    this.addClass('data-jcad-keybinding');
+    this.addClass('data-jgis-keybinding');
     this.node.tabIndex = 0;
 
     this._model = options.model;

--- a/packages/base/src/panelview/rightpanel.tsx
+++ b/packages/base/src/panelview/rightpanel.tsx
@@ -17,7 +17,7 @@ export class RightPanelWidget extends SidePanel {
   constructor(options: RightPanelWidget.IOptions) {
     super();
     this.addClass('jGIS-sidepanel-widget');
-    this.addClass('data-jcad-keybinding');
+    this.addClass('data-jgis-keybinding');
     this.node.tabIndex = 0;
 
     this._model = options.model;

--- a/packages/base/src/panelview/rightpanel.tsx
+++ b/packages/base/src/panelview/rightpanel.tsx
@@ -17,6 +17,8 @@ export class RightPanelWidget extends SidePanel {
   constructor(options: RightPanelWidget.IOptions) {
     super();
     this.addClass('jGIS-sidepanel-widget');
+    this.addClass('data-jcad-keybinding');
+    this.node.tabIndex = 0;
 
     this._model = options.model;
     this._annotationModel = options.annotationModel;

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -78,8 +78,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
       completionProviderManager
     );
 
-    app.shell.addClass('data-jgis-keybinding');
-
     // SOURCES context menu
     const newSourceSubMenu = new Menu({ commands: app.commands });
     newSourceSubMenu.title.label = translator


### PR DESCRIPTION
## Description

Fixes #592 


https://github.com/user-attachments/assets/ab1256a0-4106-4a1f-93bb-4052ab8943a3



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--603.org.readthedocs.build/en/603/
💡 JupyterLite preview: https://jupytergis--603.org.readthedocs.build/en/603/lite

<!-- readthedocs-preview jupytergis end -->