### PR TITLE
Add collaborative session creation guide

### DIFF
--- a/docs/user_guide/features/collab.md
+++ b/docs/user_guide/features/collab.md
@@ -3,3 +3,22 @@
 # Collaborative Features
 
 One of the standout features of JupyterGIS is its shared editing functionality, which **seamlessly connects users across different interfaces within the JupyterGIS ecosystem**. Whether collaborators are using the JupyterLab GIS extension, or working with the Python API in a Notebook, **any changes made to a shared document are instantly reflected for all users**.
+
+## Create Collaborative JupyterGIS Sessions
+If you are using a local installation, your JupyterLab instance is not available to the Internet by default, thus collaborators cannot join your session directly. Here are two techniques to facilitating collaboration in such instances.
+
+1. Hosting a local server using VSCode (Microsoft) or PyCharm (Jetbrains) enables real-time collaboration without exposing your server to the Internet.
+    - To use VSCode's Live Share, you can follow the steps [here](https://learn.microsoft.com/en-us/visualstudio/liveshare/use/share-server-visual-studio-code#share-a-server). 
+    - To use PyCharm's Code With Me, first you can enable [Code With Me](https://www.jetbrains.com/help/pycharm/code-with-me.html), then set up [port forwarding](https://www.jetbrains.com/help/pycharm/code-with-me.html#port_forwarding).
+   
+    In both cases, you should forward the port of the JupyterLab instance. The default port is `8888`.
+2. For a more scalable alternative, consider hosting JupyterGIS on a cloud-based or network-accessible instance. This setup allows multi-user cooperation with authentication and access restriction, without requiring a local installation. Once the instance is created using any of the options below, JupyterGIS needs to be installed on the created instance by opening a terminal window and following [the installation guide](../install.md).
+    - [JupyterHub](https://jupyter.org/hub): You can follow [the JupyterHub documentation](https://jupyter.org/hub#deploy-a-jupyterhub) for setup instructions. By default, JupyterHub creates isolated environments for each user. To enable real-time collaboration on the same environment, you can follow [this guide](https://jupyterhub.readthedocs.io/en/5.2.1/reference/sharing.html#sharing-reference).
+    - [Binder](https://mybinder.readthedocs.io/en/latest/index.html): Check out [this tutorial](https://book.the-turing-way.org/communication/binder/zero-to-binder) to start using Binder. Note that when you share the link with a collaborator, they will be asked to enter the password or token to access the session. You can find out the token by opening a terminal window and running the command 
+      ```
+      jupyter notebook list --json | python3 -c 'import json; import sys; print(json.load(sys.stdin)["token"])'
+      ```
+      Note that if you have added JupyterGIS to the `requirements.txt` file, it will be installed automatically when you create the Binder instance. In this case you do not need to follow [the installation guide](../install.md).
+    - [Amazon SageMaker AI](https://aws.amazon.com/sagemaker-ai): If you prefer to use Amazon SageMaker AI, you can follow [this tutorial](https://docs.aws.amazon.com/sagemaker/latest/dg/onboard-quick-start.html) to set up your environment. After opening SageMaker Studio, create a JupyterLab space, and make sure choosing `Share with my domain` option to enable access for your collaborators.
+
+Note that currently, real-time collaboration is not supported in [JupyterLite](https://jupytergis.readthedocs.io/en/latest/lite/lab/index.html).

--- a/docs/user_guide/features/collab.md
+++ b/docs/user_guide/features/collab.md
@@ -5,20 +5,23 @@
 One of the standout features of JupyterGIS is its shared editing functionality, which **seamlessly connects users across different interfaces within the JupyterGIS ecosystem**. Whether collaborators are using the JupyterLab GIS extension, or working with the Python API in a Notebook, **any changes made to a shared document are instantly reflected for all users**.
 
 ## Create Collaborative JupyterGIS Sessions
+
 If you are using a local installation, your JupyterLab instance is not available to the Internet by default, thus collaborators cannot join your session directly. Here are two techniques to facilitating collaboration in such instances.
 
 1. Hosting a local server using VSCode (Microsoft) or PyCharm (Jetbrains) enables real-time collaboration without exposing your server to the Internet.
-    - To use VSCode's Live Share, you can follow the steps [here](https://learn.microsoft.com/en-us/visualstudio/liveshare/use/share-server-visual-studio-code#share-a-server). 
-    - To use PyCharm's Code With Me, first you can enable [Code With Me](https://www.jetbrains.com/help/pycharm/code-with-me.html), then set up [port forwarding](https://www.jetbrains.com/help/pycharm/code-with-me.html#port_forwarding).
-   
-    In both cases, you should forward the port of the JupyterLab instance. The default port is `8888`.
+
+   - To use VSCode's Live Share, you can follow the steps [here](https://learn.microsoft.com/en-us/visualstudio/liveshare/use/share-server-visual-studio-code#share-a-server).
+   - To use PyCharm's Code With Me, first you can enable [Code With Me](https://www.jetbrains.com/help/pycharm/code-with-me.html), then set up [port forwarding](https://www.jetbrains.com/help/pycharm/code-with-me.html#port_forwarding).
+
+   In both cases, you should forward the port of the JupyterLab instance. The default port is `8888`.
+
 2. For a more scalable alternative, consider hosting JupyterGIS on a cloud-based or network-accessible instance. This setup allows multi-user cooperation with authentication and access restriction, without requiring a local installation. Once the instance is created using any of the options below, JupyterGIS needs to be installed on the created instance by opening a terminal window and following [the installation guide](../install.md).
-    - [JupyterHub](https://jupyter.org/hub): You can follow [the JupyterHub documentation](https://jupyter.org/hub#deploy-a-jupyterhub) for setup instructions. By default, JupyterHub creates isolated environments for each user. To enable real-time collaboration on the same environment, you can follow [this guide](https://jupyterhub.readthedocs.io/en/5.2.1/reference/sharing.html#sharing-reference).
-    - [Binder](https://mybinder.readthedocs.io/en/latest/index.html): Check out [this tutorial](https://book.the-turing-way.org/communication/binder/zero-to-binder) to start using Binder. Note that when you share the link with a collaborator, they will be asked to enter the password or token to access the session. You can find out the token by opening a terminal window and running the command 
-      ```
-      jupyter notebook list --json | python3 -c 'import json; import sys; print(json.load(sys.stdin)["token"])'
-      ```
-      Note that if you have added JupyterGIS to the `requirements.txt` file, it will be installed automatically when you create the Binder instance. In this case you do not need to follow [the installation guide](../install.md).
-    - [Amazon SageMaker AI](https://aws.amazon.com/sagemaker-ai): If you prefer to use Amazon SageMaker AI, you can follow [this tutorial](https://docs.aws.amazon.com/sagemaker/latest/dg/onboard-quick-start.html) to set up your environment. After opening SageMaker Studio, create a JupyterLab space, and make sure choosing `Share with my domain` option to enable access for your collaborators.
+   - [JupyterHub](https://jupyter.org/hub): You can follow [the JupyterHub documentation](https://jupyter.org/hub#deploy-a-jupyterhub) for setup instructions. By default, JupyterHub creates isolated environments for each user. To enable real-time collaboration on the same environment, you can follow [this guide](https://jupyterhub.readthedocs.io/en/5.2.1/reference/sharing.html#sharing-reference).
+   - [Binder](https://mybinder.readthedocs.io/en/latest/index.html): Check out [this tutorial](https://book.the-turing-way.org/communication/binder/zero-to-binder) to start using Binder. Note that when you share the link with a collaborator, they will be asked to enter the password or token to access the session. You can find out the token by opening a terminal window and running the command
+     ```
+     jupyter notebook list --json | python3 -c 'import json; import sys; print(json.load(sys.stdin)["token"])'
+     ```
+     Note that if you have added JupyterGIS to the `requirements.txt` file, it will be installed automatically when you create the Binder instance. In this case you do not need to follow [the installation guide](../install.md).
+   - [Amazon SageMaker AI](https://aws.amazon.com/sagemaker-ai): If you prefer to use Amazon SageMaker AI, you can follow [this tutorial](https://docs.aws.amazon.com/sagemaker/latest/dg/onboard-quick-start.html) to set up your environment. After opening SageMaker Studio, create a JupyterLab space, and make sure choosing `Share with my domain` option to enable access for your collaborators.
 
 Note that currently, real-time collaboration is not supported in [JupyterLite](https://jupytergis.readthedocs.io/en/latest/lite/lab/index.html).

--- a/docs/user_guide/features/collab.md
+++ b/docs/user_guide/features/collab.md
@@ -24,4 +24,6 @@ If you are using a local installation, your JupyterLab instance is not available
      Note that if you have added JupyterGIS to the `requirements.txt` file, it will be installed automatically when you create the Binder instance. In this case you do not need to follow [the installation guide](../install.md).
    - [Amazon SageMaker AI](https://aws.amazon.com/sagemaker-ai): If you prefer to use Amazon SageMaker AI, you can follow [this tutorial](https://docs.aws.amazon.com/sagemaker/latest/dg/onboard-quick-start.html) to set up your environment. After opening SageMaker Studio, create a JupyterLab space, and make sure choosing `Share with my domain` option to enable access for your collaborators.
 
+:::{important}
 Note that currently, real-time collaboration is not supported in [JupyterLite](https://jupytergis.readthedocs.io/en/latest/lite/lab/index.html).
+:::

--- a/docs/user_guide/tutorials/02-collaboration/index.md
+++ b/docs/user_guide/tutorials/02-collaboration/index.md
@@ -19,7 +19,7 @@ By following this tutorial, you will be able to:
 
 :::{admonition} Prerequisites
 :class: warning
-Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS. Check out [the instructions](../../features/collab.md#create-collaborative-jupytergis-sessions) for creating collaborative JupyterGIS sessions.
+Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS. Check out [the instructions](../../features/collab.md) for creating collaborative JupyterGIS sessions.
 :::
 
 ---

--- a/docs/user_guide/tutorials/02-collaboration/index.md
+++ b/docs/user_guide/tutorials/02-collaboration/index.md
@@ -19,7 +19,7 @@ By following this tutorial, you will be able to:
 
 :::{admonition} Prerequisites
 :class: warning
-Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS, for example on a [JupyterHub](https://jupyter.org/hub). Note that currently, real-time collaboration is not supported in [JupyterLite](https://jupytergis.readthedocs.io/en/latest/lite/lab/index.html).
+Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS. Check out [the instructions](../../features/collab.md#create-collaborative-jupytergis-sessions) for creating collaborative JupyterGIS sessions.
 :::
 
 ---
@@ -49,16 +49,6 @@ First, let's create a GIS file and invite collaborators to the session.
 ### Generate a Shareable Link
 
 You can invite collaborators to your session by sharing a link. Click on the **Share** button in your interface in the upper right corner, then click on the **Copy Link** button.
-
-:::{admonition} A note about local installations
-:class: warning
-
-If you are using a local installation, your JupyterLab instance is not open to the Internet by default and collaborators will not be able to join your session.
-
-In this case, we recommend [using VSCode's LiveShare functionality to share a local server](https://learn.microsoft.com/en-us/visualstudio/liveshare/use/share-server-visual-studio-code#share-a-server) with a collaborator.
-
-You can also open a new browser window and paste the share link to simulate a different user for this tutorial.
-:::
 
 ![Share](images/share.png)
 
@@ -101,7 +91,7 @@ To activate the follow mode, click on a collaborator's user icon in the upper ri
 :nonumber:
 
 1. Create a new collaborative JupyterGIS session.
-2. Share the link with a colleague. If you are using a local installation, you can open a new browser and paste the link to simulate a different user.
+2. Share the link with a colleague. If you are completing this tutorial without other collaborators, you can open a new browser and paste the link to simulate a different user.
 3. From the layer browser, add OpenStreetMap.Mapnik to your GIS file.
 4. Ask your colleague to add the World Air Quality GeoJSON layer:
     ```

--- a/docs/user_guide/tutorials/02-collaboration/index.md
+++ b/docs/user_guide/tutorials/02-collaboration/index.md
@@ -19,7 +19,7 @@ By following this tutorial, you will be able to:
 
 :::{admonition} Prerequisites
 :class: warning
-Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS. Check out [the instructions](../../features/collab.md) for creating collaborative JupyterGIS sessions.
+Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS. Your choice may have implications for collaboration, so please read our [collaboration feature overview](../../features/collab.md) for more context.
 :::
 
 ---


### PR DESCRIPTION
## Description

Added instructions to create a collaborative session in the Features page, as suggested [here](https://github.com/geojupyter/jupytergis/pull/530#issuecomment-2752542817). I did not include Google Colab since I was not able to run JupyterGIS on Google Colab.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--608.org.readthedocs.build/en/608/
💡 JupyterLite preview: https://jupytergis--608.org.readthedocs.build/en/608/lite

<!-- readthedocs-preview jupytergis end -->