### PR TITLE
Use Accel I temporarily

### DIFF
--- a/packages/base/src/keybindings.json
+++ b/packages/base/src/keybindings.json
@@ -16,7 +16,7 @@
   },
   {
     "command": "jupytergis:identify",
-    "keys": ["I"],
+    "keys": ["Accel I"],
     "selector": ".data-jgis-keybinding"
   },
   {


### PR DESCRIPTION
## Description

This bugs while trying to type I in the rightpanel

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--611.org.readthedocs.build/en/611/
💡 JupyterLite preview: https://jupytergis--611.org.readthedocs.build/en/611/lite

<!-- readthedocs-preview jupytergis end -->