### PR TITLE
Fix tabs rendering in Contributor Guide

### DIFF
--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -34,7 +34,7 @@ micromamba activate jupytergis_dev
 ``````
 
 ``````{group-tab} Plain python
-```note
+```{note}
 You may need to install some non-Python dependencies (e.g. QGIS,
 Node.js) separately when using this method.
 ```

--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -31,6 +31,7 @@ micromamba create --name jupytergis_dev -c conda-forge pip "nodejs<22" qgis
 
 # Activate it
 micromamba activate jupytergis_dev
+``````
 
 ``````{group-tab} Plain python
 ```note


### PR DESCRIPTION
## Description

Hello :wave:,

I started using JupyterGIS because I was curious about how it works with QGIS, and I found a small typo in the documentation.

Before this fix on the [online documentation](https://jupytergis.readthedocs.io/en/latest/contributor_guide/development_setup.html#create-a-virtual-environment):

![image](https://github.com/user-attachments/assets/f7f8eb69-0ea1-4234-bda6-d2df96ac7860)

With this correction:

![image](https://github.com/user-attachments/assets/b5a2f5c6-e14a-40c4-80ad-411c269aff2f)


## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--617.org.readthedocs.build/en/617/
💡 JupyterLite preview: https://jupytergis--617.org.readthedocs.build/en/617/lite

<!-- readthedocs-preview jupytergis end -->