### PR TITLE
[WIP] Add `GISDocument.path` attribute

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -106,23 +106,7 @@ class GISDocument(CommWidget):
         """
         return self._layerTree.to_py()
 
-    def save_as(self, path: str | Path) -> None:
-        """Save the document at a new path."""
-        if isinstance(path, str):
-            path = Path(path)
-
-        if path.name.lower().endswith(".qgz"):
-            _export_to_qgis(path)
-            self.path = path
-            return
-
-        if not path.name.lower().endswith(".jgis"):
-            path = Path(str(path) + ".jGIS")
-
-        path.write_text(json.dumps(self.to_py()))
-        self.path = path
-
-    def _export_to_qgis(self, path: str | Path) -> bool:
+    def export_to_qgis(self, path: str | Path) -> bool:
         # Lazy import, jupytergis_qgis of qgis may not be installed
         from jupytergis_qgis.qgis_loader import export_project_to_qgis
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -46,8 +46,6 @@ class GISDocument(CommWidget):
     :param path: the path to the file that you would like to open. If not provided, a new empty document will be created.
     """
 
-    path: Optional[Path]
-
     def __init__(
         self,
         path: Optional[str | Path] = None,
@@ -59,17 +57,16 @@ class GISDocument(CommWidget):
         pitch: Optional[float] = None,
         projection: Optional[str] = None,
     ):
-        if isinstance(path, str):
-            path = Path(path)
-
-        self.path = path
-
-        comm_metadata = GISDocument._path_to_comm(str(self.path) if self.path else None)
+        if isinstance(path, Path):
+            path = str(path)
 
         ydoc = Doc()
 
         super().__init__(
-            comm_metadata=dict(ymodel_name="@jupytergis:widget", **comm_metadata),
+            comm_metadata={
+                "ymodel_name": "@jupytergis:widget",
+                **self._path_to_comm(path),
+            },
             ydoc=ydoc,
         )
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -46,6 +46,8 @@ class GISDocument(CommWidget):
     :param path: the path to the file that you would like to open. If not provided, a new untitled document will be created.
     """
 
+    path: Path
+
     def __init__(
         self,
         path: Optional[str | Path] = None,
@@ -70,6 +72,8 @@ class GISDocument(CommWidget):
             ydoc=ydoc,
         )
 
+        self._comm.on_msg(self._handle_comm_message)
+
         self.ydoc["layers"] = self._layers = Map()
         self.ydoc["sources"] = self._sources = Map()
         self.ydoc["options"] = self._options = Map()
@@ -91,6 +95,13 @@ class GISDocument(CommWidget):
                 self._options["pitch"] = pitch
             if projection is not None:
                 self._options["projection"] = projection
+
+    def _handle_comm_message(self, content: Dict[str, Any]) -> None:
+        if content.get("method") == "update_path":
+            new_path = content.get("path")
+            if new_path:
+                self.path = Path(new_path)
+                logger.info(f"GISDocument path updated to: {self.path}")
 
     @property
     def layers(self) -> Dict:

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -43,7 +43,7 @@ class GISDocument(CommWidget):
     """
     Create a new GISDocument object.
 
-    :param path: the path to the file that you would like to open. If not provided, a new empty document will be created.
+    :param path: the path to the file that you would like to open. If not provided, a new untitled document will be created.
     """
 
     def __init__(

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -46,12 +46,11 @@ class TestLayerManipulation(TestDocument):
             self.doc.remove_layer("foo")
 
 
-def test_save_as(tmp_path):
+def test_untitled_doc(tmp_path):
     os.chdir(tmp_path)
 
     doc = GISDocument()
-    assert not list(tmp_path.iterdir())
+    assert len(list(tmp_path.iterdir())) == 1
 
-    fn = "test.jgis"
-    doc.save_as(fn)
+    fn = "untitled.jGIS"
     assert (tmp_path / fn).is_file()

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -49,8 +49,10 @@ class TestLayerManipulation(TestDocument):
 def test_untitled_doc(tmp_path):
     os.chdir(tmp_path)
 
-    doc = GISDocument()
+    GISDocument()
     assert len(list(tmp_path.iterdir())) == 1
+    assert (tmp_path / "untitled.jGIS").is_file()
 
-    fn = "untitled.jGIS"
-    assert (tmp_path / fn).is_file()
+    GISDocument()
+    assert len(list(tmp_path.iterdir())) == 2
+    assert (tmp_path / "untitled1.jGIS").is_file()

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -172,7 +172,7 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
           }
         } else {
           // If the user did not provide a path, create an untitled document
-          let model = await app.serviceManager.contents.newUntitled({
+          const model = await app.serviceManager.contents.newUntitled({
             path: PathExt.dirname(currentWidgetPath),
             type: 'file',
             ext: '.jGIS'

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -171,11 +171,13 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
             });
           }
         } else {
-          // If the user did not provide a path, do not create
-          localPath = PathExt.join(
-            PathExt.dirname(currentWidgetPath),
-            'unsaved_project'
-          );
+          // If the user did not provide a path, create an untitled document
+          let model = await app.serviceManager.contents.newUntitled({
+            path: PathExt.dirname(currentWidgetPath),
+            type: 'file',
+            ext: '.jGIS'
+          });
+          localPath = model.path;
         }
 
         const sharedModel = drive!.sharedModelFactory.createNew({


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> Depends on #630. Merge it first, then rebase this PR.

Will resolve #629 

I'm attempting to get a `GISDocument.path` attribute. This requires the JS to communicate with Python, because the `newUntitled()` method dynamically calculates a filename.

I got a rough implementation of the Python side, but I'm struggling to understand where on the JS side I can access `comm.send(...)`. It seems obvious I should be doing this in `notebookrenderer.ts` but I explored so many objects looking for `comm` and came up empty :upside_down_face:  Moving on to something else for now.

A little hand-holding would be wonderful, and I'll document what you teach me :bow:  Perhaps that documentation could live in the ypywidgets repository. @davidbrochart what do you think?



## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--631.org.readthedocs.build/en/631/
💡 JupyterLite preview: https://jupytergis--631.org.readthedocs.build/en/631/lite

<!-- readthedocs-preview jupytergis end -->