### PR TITLE
Remove work-in-progress warning from README

### DIFF
--- a/python/jupytergis/README.md
+++ b/python/jupytergis/README.md
@@ -8,8 +8,6 @@
 [docs-badge]: https://readthedocs.org/projects/jupytergis/badge/?version=latest
 [docs]: https://jupytergis.readthedocs.io
 
-⚠️ This extension is work in progress. Features and APIs are subject to change quickly. ⚠️
-
 ![jupytergis](https://github.com/geojupyter/jupytergis/blob/main/jupytergis.png)
 
 ## Features


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--633.org.readthedocs.build/en/633/
💡 JupyterLite preview: https://jupytergis--633.org.readthedocs.build/en/633/lite

<!-- readthedocs-preview jupytergis end -->