### PR TITLE
Fill vertical space in linked output & sidecar views

### DIFF
--- a/python/jupytergis_lab/style/base.css
+++ b/python/jupytergis_lab/style/base.css
@@ -417,6 +417,12 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
   height: 600px;
   width: 100%;
 }
+
+/* Support output views, created with "Create new view for cell output" context menu */
+.jp-LinkedOutputView .jupytergis-notebook-widget {
+  height: 100%;
+}
+
 .jupytergis-notebook-widget > div {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
Currently, when displaying a GISDocument widget, it will always have a fixed height of `600px`. This is problematic when opening the widget in a sidecar or a "linked output" view, as the widget will either take up a small portion of the height of the container or it will extend beyond the bottom of the container and require the user to scroll.

![image](https://github.com/user-attachments/assets/b5eefb07-e134-42b3-b304-f50ce995af87)
![image](https://github.com/user-attachments/assets/65506d83-7815-4828-9180-ae30204bd904)

This PR sets the height to 100% in both of those contexts.

"Linked output" view can be opened by right-clicking the gutter space to the left of a widget and selecting "Create new view for cell output".

Sidecar view can be opened with [jupyterlab-sidecar](https://github.com/jupyter-widgets/jupyterlab-sidecar).

Extracted from PR #340.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--643.org.readthedocs.build/en/643/
💡 JupyterLite preview: https://jupytergis--643.org.readthedocs.build/en/643/lite

<!-- readthedocs-preview jupytergis end -->