### PR TITLE
Use full height space when displaying widget in linked view or sidecar

### DIFF
--- a/python/jupytergis_lab/style/base.css
+++ b/python/jupytergis_lab/style/base.css
@@ -417,6 +417,12 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
   height: 600px;
   width: 100%;
 }
+
+/* Support sidecar / "Create new view for cell output" views */
+.jp-LinkedOutputView .jupytergis-notebook-widget {
+  height: 100%;
+}
+
 .jupytergis-notebook-widget > div {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
## Description


Currently, when displaying a GISDocument widget, it will always have a fixed height of `600px`. This is problematic when opening the widget in a sidecar or a "linked output" view, as the widget will either take up a small portion of the height of the container or it will extend beyond the bottom of the container and require the user to scroll.

This PR sets the height to 100% in both of those contexts.

"Linked output" view can be opened by right-clicking the gutter space to the left of a widget and selecting "Create new view for cell output".

Sidecar view can be opened with [jupyterlab-sidecar](https://github.com/jupyter-widgets/jupyterlab-sidecar).

Thanks @SylvainCorlay for pointing me in the right direction :rocket: 

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--645.org.readthedocs.build/en/645/
💡 JupyterLite preview: https://jupytergis--645.org.readthedocs.build/en/645/lite

<!-- readthedocs-preview jupytergis end -->