### PR TITLE
Allow initializing a `GISDocument` that has a path

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -73,21 +73,20 @@ class GISDocument(CommWidget):
         self.ydoc["layerTree"] = self._layerTree = Array()
         self.ydoc["metadata"] = self._metadata = Map()
 
-        if path is None:
-            if latitude is not None:
-                self._options["latitude"] = latitude
-            if longitude is not None:
-                self._options["longitude"] = longitude
-            if extent is not None:
-                self._options["extent"] = extent
-            if zoom is not None:
-                self._options["zoom"] = zoom
-            if bearing is not None:
-                self._options["bearing"] = bearing
-            if pitch is not None:
-                self._options["pitch"] = pitch
-            if projection is not None:
-                self._options["projection"] = projection
+        if latitude is not None:
+            self._options["latitude"] = latitude
+        if longitude is not None:
+            self._options["longitude"] = longitude
+        if extent is not None:
+            self._options["extent"] = extent
+        if zoom is not None:
+            self._options["zoom"] = zoom
+        if bearing is not None:
+            self._options["bearing"] = bearing
+        if pitch is not None:
+            self._options["pitch"] = pitch
+        if projection is not None:
+            self._options["projection"] = projection
 
     @property
     def layers(self) -> Dict:


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--666.org.readthedocs.build/en/666/
💡 JupyterLite preview: https://jupytergis--666.org.readthedocs.build/en/666/lite

<!-- readthedocs-preview jupytergis end -->