### PR TITLE
Make the console toolbar button a toggle button

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -1005,7 +1005,17 @@ export function addCommands(
         ? tracker.currentWidget.model.sharedModel.editable
         : false;
     },
-    execute: async () => await Private.toggleConsole(tracker)
+    isToggled: () => {
+      if (tracker.currentWidget instanceof JupyterGISDocumentWidget) {
+        return tracker.currentWidget?.content.consoleOpened === true;
+      } else {
+        return false;
+      }
+    },
+    execute: async () => {
+      await Private.toggleConsole(tracker);
+      commands.notifyCommandChanged(CommandIDs.toggleConsole);
+    }
   });
   commands.addCommand(CommandIDs.executeConsole, {
     label: trans.__('Execute console'),

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -158,6 +158,10 @@ export class JupyterGISPanel extends SplitPanel {
     return this._consoleView?.consolePanel;
   }
 
+  get consoleOpened(): boolean {
+    return this._consoleOpened;
+  }
+
   executeConsole() {
     if (this._consoleView) {
       this._consoleView.execute();


### PR DESCRIPTION
## Description
Transform the normal console button into a toggle one.
Fixes https://github.com/geojupyter/jupytergis/issues/675


📚 Documentation preview: [jupytergis--676.org.readthedocs.build/en/676](https://jupytergis--676.org.readthedocs.build/en/676/)
💡 JupyterLite preview: [jupytergis--676.org.readthedocs.build/en/676/lite](https://jupytergis--676.org.readthedocs.build/en/676/lite)