### PR TITLE
Add issue templates: experience report, bug, docs, blank issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-experience-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-experience-report.yml
@@ -1,11 +1,11 @@
-name: "🧪 Experience report"
-description: "Share your experience using JupyterGIS; anything goes."
+name: '🧪 Experience report'
+description: 'Share your experience using JupyterGIS; anything goes.'
 labels:
-  - "experience report"
+  - 'experience report'
 body:
-  - type: "textarea"
+  - type: 'textarea'
     attributes:
-      label: "Description"
+      label: 'Description'
       description: |
         Please describe your experience clearly.
         We'd love to hear where you experienced friction, unintuitive behavior, or joy when using JupyterGIS.

--- a/.github/ISSUE_TEMPLATE/1-experience-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-experience-report.yml
@@ -1,0 +1,13 @@
+name: "🧪 Experience report"
+description: "Share your experience using JupyterGIS; anything goes."
+labels:
+  - "experience report"
+body:
+  - type: "textarea"
+    attributes:
+      label: "Description"
+      description: |
+        Please describe your experience clearly.
+        We'd love to hear where you experienced friction, unintuitive behavior, or joy when using JupyterGIS.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug.yml
@@ -1,0 +1,34 @@
+name: "🐞 Bug"
+description: "Any behavior that is unexpected or differs from the documentation."
+labels:
+  - "bug"
+body:
+  ## Excluded for now; we're not really seeing a ton of duplicate issue
+  ## reports, and I'd love to make reporting as approachable as possible.
+  # - type: "checkboxes"
+  #   attributes:
+  #     label: "Is there an existing issue for this?"
+  #     description: |
+  #       Please [:mag: search for existing issues](https://github.com/geojupyter/jupytergis/issues?q=sort%3Aupdated-desc%20is%3Aissue)
+  #       to see if this has already been reported.
+  #     options:
+  #       - label: "I've searched existing issues"
+  #         required: true
+
+  - type: "input"
+    attributes:
+      label: "JupyterGIS version"
+      description: |
+        In which version of JupyterGIS does this issue occur?
+        You can find this information on the status bar at the bottom of the JupyterGIS window.
+      validations:
+        required: false
+
+  - type: "textarea"
+    attributes:
+      label: "Description"
+      description: |
+        Please describe the issue clearly.
+        For best results, include a reproducible example or a screenshot/video of the issue.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug.yml
@@ -1,7 +1,7 @@
-name: "🐞 Bug"
-description: "Any behavior that is unexpected or differs from the documentation."
+name: '🐞 Bug'
+description: 'Any behavior that is unexpected or differs from the documentation.'
 labels:
-  - "bug"
+  - 'bug'
 body:
   ## Excluded for now; we're not really seeing a ton of duplicate issue
   ## reports, and I'd love to make reporting as approachable as possible.
@@ -15,18 +15,18 @@ body:
   #       - label: "I've searched existing issues"
   #         required: true
 
-  - type: "input"
+  - type: 'input'
     attributes:
-      label: "JupyterGIS version"
+      label: 'JupyterGIS version'
       description: |
         In which version of JupyterGIS does this issue occur?
         You can find this information on the status bar at the bottom of the JupyterGIS window.
       validations:
         required: false
 
-  - type: "textarea"
+  - type: 'textarea'
     attributes:
-      label: "Description"
+      label: 'Description'
       description: |
         Please describe the issue clearly.
         For best results, include a reproducible example or a screenshot/video of the issue.

--- a/.github/ISSUE_TEMPLATE/3-docs.yml
+++ b/.github/ISSUE_TEMPLATE/3-docs.yml
@@ -1,0 +1,25 @@
+name: "📃 Documentation"
+description: "Anything that could be improved about our documentation."
+labels:
+  - "documentation"
+body:
+  ## Excluded for now; we're not really seeing a ton of duplicate issue
+  ## reports, and I'd love to make reporting as approachable as possible.
+  # - type: "checkboxes"
+  #   attributes:
+  #     label: "Is there an existing issue for this?"
+  #     description: |
+  #       Please [:mag: search for existing issues](https://github.com/geojupyter/jupytergis/issues?q=sort%3Aupdated-desc%20is%3Aissue)
+  #       to see if this has already been reported.
+  #     options:
+  #       - label: "I've searched existing issues"
+  #         required: true
+
+  - type: "textarea"
+    attributes:
+      label: "Description"
+      description: |
+        Please describe the issue clearly.
+        If you're reporting an issue with an existing page, please link to it.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-docs.yml
+++ b/.github/ISSUE_TEMPLATE/3-docs.yml
@@ -1,7 +1,7 @@
-name: "📃 Documentation"
-description: "Anything that could be improved about our documentation."
+name: '📃 Documentation'
+description: 'Anything that could be improved about our documentation.'
 labels:
-  - "documentation"
+  - 'documentation'
 body:
   ## Excluded for now; we're not really seeing a ton of duplicate issue
   ## reports, and I'd love to make reporting as approachable as possible.
@@ -15,9 +15,9 @@ body:
   #       - label: "I've searched existing issues"
   #         required: true
 
-  - type: "textarea"
+  - type: 'textarea'
     attributes:
-      label: "Description"
+      label: 'Description'
       description: |
         Please describe the issue clearly.
         If you're reporting an issue with an existing page, please link to it.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "🌟 Community support"
+    url: "https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter"
+    about: "Explore our open Zulip chat to ask questions, share insights, and connect with other JupyterGIS users."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: "🌟 Community support"
-    url: "https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter"
-    about: "Explore our open Zulip chat to ask questions, share insights, and connect with other JupyterGIS users."
+  - name: '🌟 Community support'
+    url: 'https://jupyter.zulipchat.com/#narrow/channel/471314-geojupyter'
+    about: 'Explore our open Zulip chat to ask questions, share insights, and connect with other JupyterGIS users.'


### PR DESCRIPTION
## Description

Issue templates help contributors feel welcome and to create good issues. Specifically, I feel "experience reports" are an important category for welcoming reports that may not fit in the usual category of "bug". Similarly, I think having blank issues is important so that folks feel welcome to report things that they feel don't fit in the existing categories.

I'm keeping the forms fairly simple; I feel overly complicated forms can drive away potential contributors.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--679.org.readthedocs.build/en/679/
💡 JupyterLite preview: https://jupytergis--679.org.readthedocs.build/en/679/lite

<!-- readthedocs-preview jupytergis end -->