### PR TITLE
Fix mistakes in explorer basemap names

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/explore.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/explore.py
@@ -16,21 +16,21 @@ BasemapChoice = Literal["light", "dark", "topo"]
 _basemaps: dict[BasemapChoice, list[Basemap]] = {
     "light": [
         Basemap(
-            name="ArcGIS dark basemap",
+            name="ArcGIS light basemap",
             url="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}.pbf",
         ),
         Basemap(
-            name="ArcGIS dark basemap reference",
+            name="ArcGIS light basemap reference",
             url="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer/tile/{z}/{y}/{x}.pbf",
         ),
     ],
     "dark": [
         Basemap(
-            name="ArcGIS light basemap",
+            name="ArcGIS dark basemap",
             url="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}.pbf",
         ),
         Basemap(
-            name="ArcGIS light basemap reference",
+            name="ArcGIS dark basemap reference",
             url="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}.pbf",
         ),
     ],


### PR DESCRIPTION
## Description

I got the labels backwards for our basemaps in the JupyterGIS explorer :)


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--680.org.readthedocs.build/en/680/
💡 JupyterLite preview: https://jupytergis--680.org.readthedocs.build/en/680/lite

<!-- readthedocs-preview jupytergis end -->