### PR TITLE
Prevent duplication of color steps when reopening the symbology panel

### DIFF
--- a/packages/base/src/dialogs/symbology/symbologyUtils.ts
+++ b/packages/base/src/dialogs/symbology/symbologyUtils.ts
@@ -59,7 +59,7 @@ export namespace VectorUtils {
     }
 
     return valueColorPairs;
-};
+  };
 
   export const buildRadiusInfo = (layer: IJGISLayer) => {
     if (!layer.parameters?.color) {

--- a/packages/base/src/dialogs/symbology/symbologyUtils.ts
+++ b/packages/base/src/dialogs/symbology/symbologyUtils.ts
@@ -18,6 +18,7 @@ export namespace VectorUtils {
 
     const keys = ['fill-color', 'circle-fill-color'];
     const valueColorPairs: IStopRow[] = [];
+    const seenPairs = new Set<string>();
 
     for (const key of keys) {
       if (!color[key]) {
@@ -31,26 +32,34 @@ export namespace VectorUtils {
           // Third is input value that stop values are compared with
           // Fourth and on is value:color pairs
           for (let i = 3; i < color[key].length; i += 2) {
-            valueColorPairs.push({
-              stop: color[key][i],
-              output: color[key][i + 1]
-            });
+            const pairKey = `${color[key][i]}-${color[key][i + 1]}`;
+            if (!seenPairs.has(pairKey)) {
+              valueColorPairs.push({
+                stop: color[key][i],
+                output: color[key][i + 1]
+              });
+              seenPairs.add(pairKey);
+            }
           }
           break;
 
         case 'case':
           for (let i = 1; i < color[key].length - 1; i += 2) {
-            valueColorPairs.push({
-              stop: color[key][i][2],
-              output: color[key][i + 1]
-            });
+            const pairKey = `${color[key][i][2]}-${color[key][i + 1]}`;
+            if (!seenPairs.has(pairKey)) {
+              valueColorPairs.push({
+                stop: color[key][i][2],
+                output: color[key][i + 1]
+              });
+              seenPairs.add(pairKey);
+            }
           }
           break;
       }
     }
 
     return valueColorPairs;
-  };
+};
 
   export const buildRadiusInfo = (layer: IJGISLayer) => {
     if (!layer.parameters?.color) {


### PR DESCRIPTION
## Description

Fix #693 

https://github.com/user-attachments/assets/5dd93912-621d-44ae-8819-24cfae24c42e

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`



<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--697.org.readthedocs.build/en/697/
💡 JupyterLite preview: https://jupytergis--697.org.readthedocs.build/en/697/lite

<!-- readthedocs-preview jupytergis end -->