### PR TITLE
Implement new "Canonical" render type for vector layers

### DIFF
--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -37,7 +37,13 @@ const VectorRendering = ({
     setSelectedRenderType(renderType);
 
     const options: Record<string, string[]> = {
-      VectorLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Canonical', 'Heatmap'],
+      VectorLayer: [
+        'Single Symbol',
+        'Graduated',
+        'Categorized',
+        'Canonical',
+        'Heatmap'
+      ],
       VectorTileLayer: ['Single Symbol'],
       HeatmapLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Heatmap']
     };

--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -5,6 +5,8 @@ import Categorized from './types/Categorized';
 import Graduated from './types/Graduated';
 import Heatmap from './types/Heatmap';
 import SimpleSymbol from './types/SimpleSymbol';
+import { useGetProperties } from '../hooks/useGetProperties';
+import { getColorCodeFeatureAttributes, getNumericFeatureAttributes } from '../../../tools';
 
 const VectorRendering = ({
   model,
@@ -29,6 +31,11 @@ const VectorRendering = ({
     return;
   }
 
+  const { featureProperties } = useGetProperties({
+    layerId,
+    model: model
+  });
+
   useEffect(() => {
     let renderType = layer.parameters?.symbologyState?.renderType;
     if (!renderType) {
@@ -36,14 +43,19 @@ const VectorRendering = ({
     }
     setSelectedRenderType(renderType);
 
+    let vectorLayerOptions = [
+      'Single Symbol',
+      'Heatmap'
+    ]
+    if (getColorCodeFeatureAttributes(featureProperties)) {
+      vectorLayerOptions.push('Canonical')
+    }
+    if (getNumericFeatureAttributes(featureProperties)) {
+      vectorLayerOptions.push('Graduated', 'Categorized')
+    }
+
     const options: Record<string, string[]> = {
-      VectorLayer: [
-        'Single Symbol',
-        'Graduated',
-        'Categorized',
-        'Canonical',
-        'Heatmap'
-      ],
+      VectorLayer: vectorLayerOptions,
       VectorTileLayer: ['Single Symbol'],
       HeatmapLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Heatmap']
     };

--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ISymbologyDialogProps } from '../symbologyDialog';
+import Canonical from './types/Canonical';
 import Categorized from './types/Categorized';
 import Graduated from './types/Graduated';
 import Heatmap from './types/Heatmap';
@@ -36,7 +37,7 @@ const VectorRendering = ({
     setSelectedRenderType(renderType);
 
     const options: Record<string, string[]> = {
-      VectorLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Heatmap'],
+      VectorLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Canonical', 'Heatmap'],
       VectorTileLayer: ['Single Symbol'],
       HeatmapLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Heatmap']
     };
@@ -70,6 +71,17 @@ const VectorRendering = ({
       case 'Categorized':
         RenderComponent = (
           <Categorized
+            model={model}
+            state={state}
+            okSignalPromise={okSignalPromise}
+            cancel={cancel}
+            layerId={layerId}
+          />
+        );
+        break;
+      case 'Canonical':
+        RenderComponent = (
+          <Canonical
             model={model}
             state={state}
             okSignalPromise={okSignalPromise}

--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -6,7 +6,10 @@ import Graduated from './types/Graduated';
 import Heatmap from './types/Heatmap';
 import SimpleSymbol from './types/SimpleSymbol';
 import { useGetProperties } from '../hooks/useGetProperties';
-import { getColorCodeFeatureAttributes, getNumericFeatureAttributes } from '../../../tools';
+import {
+  getColorCodeFeatureAttributes,
+  getNumericFeatureAttributes
+} from '../../../tools';
 
 const VectorRendering = ({
   model,
@@ -43,15 +46,17 @@ const VectorRendering = ({
     }
     setSelectedRenderType(renderType);
 
-    let vectorLayerOptions = [
-      'Single Symbol',
-      'Heatmap'
-    ]
-    if (getColorCodeFeatureAttributes(featureProperties)) {
-      vectorLayerOptions.push('Canonical')
+    const vectorLayerOptions = ['Single Symbol', 'Heatmap'];
+
+    if (
+      Object.keys(getColorCodeFeatureAttributes(featureProperties)).length > 0
+    ) {
+      vectorLayerOptions.push('Canonical');
     }
-    if (getNumericFeatureAttributes(featureProperties)) {
-      vectorLayerOptions.push('Graduated', 'Categorized')
+    if (
+      Object.keys(getNumericFeatureAttributes(featureProperties)).length > 0
+    ) {
+      vectorLayerOptions.push('Graduated', 'Categorized');
     }
 
     const options: Record<string, string[]> = {
@@ -60,7 +65,7 @@ const VectorRendering = ({
       HeatmapLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Heatmap']
     };
     setRenderTypeOptions(options[layer.type]);
-  }, []);
+  }, [featureProperties]);
 
   useEffect(() => {
     switch (selectedRenderType) {

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
@@ -43,7 +43,7 @@ const Canonical = ({
   }, [selectedValue]);
 
   useEffect(() => {
-    // Filter for hex color code attributes 
+    // Filter for hex color code attributes
     const hexAttributes = getColorCodeFeatureAttributes(featureProperties);
 
     setAttributes(hexAttributes);

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
@@ -65,14 +65,14 @@ const Canonical = ({
     }
 
     const colorExpr: ExpressionValue[] = ['get', selectedValue];
-    const newStyle = {...layer.parameters.color};
+    const newStyle = { ...layer.parameters.color };
     newStyle['fill-color'] = colorExpr;
     newStyle['stroke-color'] = colorExpr;
     newStyle['circle-fill-color'] = colorExpr;
 
     const symbologyState = {
       renderType: 'Canonical',
-      value: selectedValueRef.current,
+      value: selectedValueRef.current
     };
 
     layer.parameters.symbologyState = symbologyState;

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
@@ -1,0 +1,99 @@
+import { IVectorLayer } from '@jupytergis/schema';
+import { ExpressionValue } from 'ol/expr/expression';
+import React, { useEffect, useRef, useState } from 'react';
+import { getColorCodeFeatureAttributes } from '../../../../tools';
+import { useGetProperties } from '../../hooks/useGetProperties';
+import { ISymbologyDialogProps } from '../../symbologyDialog';
+import ValueSelect from '../components/ValueSelect';
+
+const Canonical = ({
+  model,
+  state,
+  okSignalPromise,
+  cancel,
+  layerId
+}: ISymbologyDialogProps) => {
+  const selectedValueRef = useRef<string>();
+
+  const [selectedValue, setSelectedValue] = useState('');
+  const [attributes, setAttributes] = useState<Record<string, Set<string>>>({});
+
+  if (!layerId) {
+    return;
+  }
+  const layer = model.getLayer(layerId);
+  if (!layer?.parameters) {
+    return;
+  }
+  const { featureProperties } = useGetProperties({
+    layerId,
+    model: model
+  });
+
+  useEffect(() => {
+    okSignalPromise.promise.then(okSignal => {
+      okSignal.connect(handleOk, this);
+    });
+
+    return () => {
+      okSignalPromise.promise.then(okSignal => {
+        okSignal.disconnect(handleOk, this);
+      });
+    };
+  }, [selectedValue]);
+
+  useEffect(() => {
+    // Filter for hex color code attributes 
+    const hexAttributes = getColorCodeFeatureAttributes(featureProperties);
+
+    setAttributes(hexAttributes);
+
+    const layerParams = layer.parameters as IVectorLayer;
+    const value =
+      layerParams.symbologyState?.value ?? Object.keys(hexAttributes)[0];
+
+    setSelectedValue(value);
+  }, [featureProperties]);
+
+  useEffect(() => {
+    selectedValueRef.current = selectedValue;
+  }, [selectedValue]);
+
+  const handleOk = () => {
+    if (!layer.parameters) {
+      return;
+    }
+
+    const colorExpr: ExpressionValue[] = ['get', selectedValue];
+    const newStyle = {...layer.parameters.color};
+    newStyle['fill-color'] = colorExpr;
+    newStyle['stroke-color'] = colorExpr;
+    newStyle['circle-fill-color'] = colorExpr;
+
+    const symbologyState = {
+      renderType: 'Canonical',
+      value: selectedValueRef.current,
+    };
+
+    layer.parameters.symbologyState = symbologyState;
+    layer.parameters.color = newStyle;
+    if (layer.type === 'HeatmapLayer') {
+      layer.type = 'VectorLayer';
+    }
+
+    model.sharedModel.updateLayer(layerId, layer);
+    cancel();
+  };
+
+  return (
+    <div className="jp-gis-layer-symbology-container">
+      <ValueSelect
+        featureProperties={attributes}
+        selectedValue={selectedValue}
+        setSelectedValue={setSelectedValue}
+      />
+    </div>
+  );
+};
+
+export default Canonical;

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -908,7 +908,7 @@ export const getColorCodeFeatureAttributes = (
       filteredRecord[key] = set;
     }
   }
-  
+
   return filteredRecord;
 };
 

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -857,7 +857,7 @@ export const stringToArrayBuffer = async (
 
 const getFeatureAttributes = <T>(
   featureProperties: Record<string, Set<any>>,
-  predicate: (key: string, value: any) => boolean = (key: string, value) => true,
+  predicate: (key: string, value: any) => boolean = (key: string, value) => true
 ): Record<string, Set<T>> => {
   const filteredRecord: Record<string, Set<T>> = {};
 
@@ -871,7 +871,7 @@ const getFeatureAttributes = <T>(
   }
 
   return filteredRecord;
-}
+};
 
 /**
  * Get attributes of the feature which are numeric.
@@ -882,12 +882,9 @@ const getFeatureAttributes = <T>(
 export const getNumericFeatureAttributes = (
   featureProperties: Record<string, Set<any>>
 ): Record<string, Set<number>> => {
-  return getFeatureAttributes<number>(
-    featureProperties,
-    (_: string, value) => {
-      return !(typeof value === 'string' && isNaN(Number(value)));
-    }
-  );
+  return getFeatureAttributes<number>(featureProperties, (_: string, value) => {
+    return !(typeof value === 'string' && isNaN(Number(value)));
+  });
 };
 
 /**
@@ -899,13 +896,10 @@ export const getNumericFeatureAttributes = (
 export const getColorCodeFeatureAttributes = (
   featureProperties: Record<string, Set<any>>
 ): Record<string, Set<string>> => {
-  return getFeatureAttributes<string>(
-    featureProperties,
-    (_, value) => {
-      const regex = new RegExp('^#[0-9a-f]{6}$');
-      return (typeof value === 'string' && regex.test(value));
-    }
-  );
+  return getFeatureAttributes<string>(featureProperties, (_, value) => {
+    const regex = new RegExp('^#[0-9a-f]{6}$');
+    return typeof value === 'string' && regex.test(value);
+  });
 };
 
 export function downloadFile(

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -855,6 +855,12 @@ export const stringToArrayBuffer = async (
   return await base64Response.arrayBuffer();
 };
 
+/**
+ * Get attributes of the feature which are numeric.
+ *
+ * @param featureProperties - Attributes of a feature.
+ * @returns - Attributes which are numeric.
+ */
 export const getNumericFeatureAttributes = (
   featureProperties: Record<string, Set<any>>
 ) => {
@@ -873,6 +879,36 @@ export const getNumericFeatureAttributes = (
     }
   }
 
+  return filteredRecord;
+};
+
+// TODO: Extract the outer logic of the getSomthingFeatureAttributes functions
+// to a generic function which accepts a tester function as an arg.
+
+/**
+ * Get attributes of the feature which look like hex color codes.
+ *
+ * @param featureProperties - Attributes of a feature.
+ * @returns - Attributes which look like hex color codes.
+ */
+export const getColorCodeFeatureAttributes = (
+  featureProperties: Record<string, Set<any>>
+): Record<string, Set<string>> => {
+  const filteredRecord: Record<string, Set<string>> = {};
+
+  for (const [key, set] of Object.entries(featureProperties)) {
+    const firstValue = set.values().next().value;
+
+    // Check if the first value is a string that can be parsed as a hex color code
+    const regex = new RegExp('^#[0-9a-f]{6}$')
+    const isHexCode =
+      typeof firstValue === 'string' && regex.test(firstValue)
+
+    if (isHexCode) {
+      filteredRecord[key] = set;
+    }
+  }
+  
   return filteredRecord;
 };
 


### PR DESCRIPTION
Resolves #651 

## Description

This render type uses a hex code in a vector feature's attribute to define each feature's color.

For example, this [undersea cables dataset](https://github.com/opengeos/datasets/releases/download/vector/cables.geojson) includes a bunch of lines, each containing a `color` attribute which has a hex color code value.

The new render type allows selecting from attributes with values that look like hex color codes, and using the color from that attribute to color the feature.


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--713.org.readthedocs.build/en/713/
💡 JupyterLite preview: https://jupytergis--713.org.readthedocs.build/en/713/lite

<!-- readthedocs-preview jupytergis end -->