### PR TITLE
Consistently sort and group all TS imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,17 +37,16 @@ module.exports = {
     "import/order": [
       1,
       {
-        groups: [
+        "groups": [
           "external",
           "builtin",
-          "internal",
-          "sibling",
-          "parent",
-          "index"
+          ["internal", "sibling", "parent", "index"]
         ],
-        pathGroups: [
-          {pattern: "@/*", group: "internal"}
-        ]
+        "distinctGroup": false,
+        "pathGroups": [
+          {pattern: "@/**", group: "internal", position: "before"}
+        ],
+        "newlines-between": "always"
       }
     ],
     "prefer-arrow-callback": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     "import/order": [
       1,
       {
+        "alphabetize": {"order": "asc"},
         "groups": [
           "external",
           "builtin",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
     "curly": ["error", "all"],
     "eqeqeq": "error",
     "import/order": [
-      1,
+      "error",
       {
         "alphabetize": {"order": "asc"},
         "groups": [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     project: "tsconfig.eslint.json",
     sourceType: "module",
   },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "import"],
   rules: {
     "@typescript-eslint/naming-convention": [
       "error",
@@ -32,8 +32,24 @@ module.exports = {
       "single",
       { avoidEscape: true, allowTemplateLiterals: false },
     ],
-    curly: ["error", "all"],
-    eqeqeq: "error",
+    "curly": ["error", "all"],
+    "eqeqeq": "error",
+    "import/order": [
+      1,
+      {
+        groups: [
+          "external",
+          "builtin",
+          "internal",
+          "sibling",
+          "parent",
+          "index"
+        ],
+        pathGroups: [
+          {pattern: "@/*", group: "internal"}
+        ]
+      }
+    ],
     "prefer-arrow-callback": "error",
     "no-duplicate-imports": "error",
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "copy-webpack-plugin": "^10.0.0",
     "eslint": "^8.36.0",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.0.1",
     "lerna": "^8.1.9",
     "npm-run-all": "^4.1.5",

--- a/packages/base/src/annotations/components/Annotation.tsx
+++ b/packages/base/src/annotations/components/Annotation.tsx
@@ -8,8 +8,9 @@ import { IAnnotationModel, IJupyterGISModel } from '@jupytergis/schema';
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 import { Button } from '@jupyterlab/ui-components';
 import React, { useMemo, useState } from 'react';
-import { Message } from './Message';
+
 import { IControlPanelModel } from '@/src/types';
+import { Message } from './Message';
 
 export interface IAnnotationProps {
   itemId: string;

--- a/packages/base/src/annotations/components/AnnotationFloater.tsx
+++ b/packages/base/src/annotations/components/AnnotationFloater.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
 import { faWindowMinimize } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { useState } from 'react';
+
 import Annotation, { IAnnotationProps } from './Annotation';
 
 const AnnotationFloater = ({

--- a/packages/base/src/classificationModes.ts
+++ b/packages/base/src/classificationModes.ts
@@ -1,6 +1,7 @@
 // Adapted from https://github.com/qgis/QGIS/blob/master/src/core/classification/
 
 import { Pool, fromUrl, TypedArray } from 'geotiff';
+
 import { InterpolationType } from './dialogs/symbology/tiff_layer/types/SingleBandPseudoColor';
 
 export namespace VectorClassifications {

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -17,23 +17,24 @@ import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator } from '@jupyterlab/translation';
 import { CommandRegistry } from '@lumino/commands';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
+import { Coordinate } from 'ol/coordinate';
+import { fromLonLat } from 'ol/proj';
+
 import { CommandIDs, icons } from './constants';
-import { LayerCreationFormDialog } from './dialogs/layerCreationFormDialog';
-import { LayerBrowserWidget } from './dialogs/layerBrowserDialog';
-import { SymbologyWidget } from './dialogs/symbology/symbologyDialog';
-import keybindings from './keybindings.json';
-import { JupyterGISTracker } from './types';
-import { JupyterGISDocumentWidget } from './widget';
-import { getGeoJSONDataFromLayerSource, downloadFile } from './tools';
 import { ProcessingFormDialog } from './dialogs/ProcessingFormDialog';
+import { LayerBrowserWidget } from './dialogs/layerBrowserDialog';
+import { LayerCreationFormDialog } from './dialogs/layerCreationFormDialog';
+import { SymbologyWidget } from './dialogs/symbology/symbologyDialog';
+import { targetWithCenterIcon } from './icons';
+import keybindings from './keybindings.json';
 import {
   getSingleSelectedLayer,
   selectedLayerIsOfType,
   processSelectedLayer
 } from './processing';
-import { fromLonLat } from 'ol/proj';
-import { Coordinate } from 'ol/coordinate';
-import { targetWithCenterIcon } from './icons';
+import { getGeoJSONDataFromLayerSource, downloadFile } from './tools';
+import { JupyterGISTracker } from './types';
+import { JupyterGISDocumentWidget } from './widget';
 
 interface ICreateEntry {
   tracker: JupyterGISTracker;

--- a/packages/base/src/console/consoleview.ts
+++ b/packages/base/src/console/consoleview.ts
@@ -1,9 +1,7 @@
-import { ConsolePanel } from '@jupyterlab/console';
-import { ServiceManager } from '@jupyterlab/services';
-import { BoxPanel, Widget } from '@lumino/widgets';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
-import { debounce } from '@/src/tools';
+import { ConsolePanel } from '@jupyterlab/console';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ServiceManager } from '@jupyterlab/services';
 import {
   closeIcon,
   CommandToolbarButton,
@@ -11,6 +9,9 @@ import {
   Toolbar
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
+import { BoxPanel, Widget } from '@lumino/widgets';
+
+import { debounce } from '@/src/tools';
 
 export class ConsoleView extends BoxPanel {
   constructor(options: ConsoleView.IOptions) {

--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -1,4 +1,5 @@
 import { LabIcon, redoIcon, undoIcon } from '@jupyterlab/ui-components';
+
 import {
   bookOpenIcon,
   clockIcon,

--- a/packages/base/src/dialogs/ProcessingFormDialog.tsx
+++ b/packages/base/src/dialogs/ProcessingFormDialog.tsx
@@ -1,13 +1,14 @@
 import { IDict, IJupyterGISModel } from '@jupytergis/schema';
 import { Dialog } from '@jupyterlab/apputils';
+import { PromiseDelegate } from '@lumino/coreutils';
+import { Signal } from '@lumino/signaling';
 import * as React from 'react';
+
 import {
   BaseForm,
   IBaseFormProps
 } from '@/src/formbuilder/objectform/baseform';
 import { DissolveForm } from '@/src/formbuilder/objectform/process';
-import { Signal } from '@lumino/signaling';
-import { PromiseDelegate } from '@lumino/coreutils';
 
 export interface IProcessingFormDialogOptions extends IBaseFormProps {
   formContext: 'update' | 'create';

--- a/packages/base/src/dialogs/layerBrowserDialog.tsx
+++ b/packages/base/src/dialogs/layerBrowserDialog.tsx
@@ -14,8 +14,8 @@ import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import React, { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
 
-import CUSTOM_RASTER_IMAGE from '../../rasterlayer_gallery/custom_raster.png';
 import { CreationFormWrapper } from './layerCreationFormDialog';
+import CUSTOM_RASTER_IMAGE from '../../rasterlayer_gallery/custom_raster.png';
 
 interface ILayerBrowserDialogProps {
   model: IJupyterGISModel;

--- a/packages/base/src/dialogs/layerCreationFormDialog.tsx
+++ b/packages/base/src/dialogs/layerCreationFormDialog.tsx
@@ -1,10 +1,10 @@
 import { IDict } from '@jupytergis/schema';
 import { Dialog } from '@jupyterlab/apputils';
+import { PromiseDelegate } from '@lumino/coreutils';
+import { Signal } from '@lumino/signaling';
 import * as React from 'react';
 
 import { CreationForm, ICreationFormProps } from '@/src/formbuilder';
-import { Signal } from '@lumino/signaling';
-import { PromiseDelegate } from '@lumino/coreutils';
 
 export interface ICreationFormWrapperProps extends ICreationFormProps {
   /**

--- a/packages/base/src/dialogs/symbology/classificationModes.ts
+++ b/packages/base/src/dialogs/symbology/classificationModes.ts
@@ -1,6 +1,7 @@
 // Adapted from https://github.com/qgis/QGIS/blob/master/src/core/classification/
 
 import { Pool, fromUrl, TypedArray } from 'geotiff';
+
 import { InterpolationType } from './tiff_layer/types/SingleBandPseudoColor';
 
 export namespace VectorClassifications {

--- a/packages/base/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@jupyterlab/ui-components';
 import colormap from 'colormap';
 import React, { useEffect, useRef, useState } from 'react';
+
 import ColorRampEntry from './ColorRampEntry';
 
 export interface IColorMap {

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
@@ -1,10 +1,11 @@
-import { Button } from '@jupyterlab/ui-components';
-import React, { useEffect, useState } from 'react';
-import CanvasSelectComponent from './CanvasSelectComponent';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import ModeSelectRow from './ModeSelectRow';
 import { IDict } from '@jupytergis/schema';
+import { Button } from '@jupyterlab/ui-components';
+import React, { useEffect, useState } from 'react';
+
+import CanvasSelectComponent from './CanvasSelectComponent';
+import ModeSelectRow from './ModeSelectRow';
 
 interface IColorRampProps {
   modeOptions: string[];

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampEntry.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampEntry.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+
 import { IColorMap } from './CanvasSelectComponent';
 
 interface IColorRampEntryProps {

--- a/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import { Button } from '@jupyterlab/ui-components';
+import React from 'react';
+
 import { IStopRow } from '@/src/dialogs/symbology/symbologyDialog';
 import StopRow from './StopRow';
 

--- a/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
@@ -2,6 +2,7 @@ import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@jupyterlab/ui-components';
 import React, { useEffect, useRef } from 'react';
+
 import { IStopRow } from '@/src/dialogs/symbology/symbologyDialog';
 
 const StopRow = ({

--- a/packages/base/src/dialogs/symbology/hooks/useGetBandInfo.ts
+++ b/packages/base/src/dialogs/symbology/hooks/useGetBandInfo.ts
@@ -1,6 +1,7 @@
 import { IJGISLayer, IJupyterGISModel } from '@jupytergis/schema';
-import { useEffect, useState } from 'react';
 import { fromUrl, fromBlob } from 'geotiff';
+import { useEffect, useState } from 'react';
+
 import { loadFile } from '@/src/tools';
 
 export interface IBandHistogram {

--- a/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
+++ b/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
@@ -2,6 +2,7 @@
 
 import { GeoJSONFeature1, IJupyterGISModel } from '@jupytergis/schema';
 import { useEffect, useState } from 'react';
+
 import { loadFile } from '@/src/tools';
 
 interface IUseGetPropertiesProps {

--- a/packages/base/src/dialogs/symbology/symbologyDialog.tsx
+++ b/packages/base/src/dialogs/symbology/symbologyDialog.tsx
@@ -4,6 +4,7 @@ import { IStateDB } from '@jupyterlab/statedb';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import React, { useEffect, useState } from 'react';
+
 import TiffRendering from './tiff_layer/TiffRendering';
 import VectorRendering from './vector_layer/VectorRendering';
 

--- a/packages/base/src/dialogs/symbology/symbologyUtils.ts
+++ b/packages/base/src/dialogs/symbology/symbologyUtils.ts
@@ -1,6 +1,7 @@
 import { IJGISLayer } from '@jupytergis/schema';
-import { IStopRow } from './symbologyDialog';
 import colormap from 'colormap';
+
+import { IStopRow } from './symbologyDialog';
 
 export namespace VectorUtils {
   export const buildColorInfo = (layer: IJGISLayer) => {

--- a/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
+
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
-import SingleBandPseudoColor from './types/SingleBandPseudoColor';
 import MultibandColor from './types/MultibandColor';
+import SingleBandPseudoColor from './types/SingleBandPseudoColor';
 
 const TiffRendering = ({
   model,

--- a/packages/base/src/dialogs/symbology/tiff_layer/components/BandRow.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/components/BandRow.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import { IBandRow } from '@/src/dialogs/symbology/hooks/useGetBandInfo';
 
 interface IBandRowProps {

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
@@ -1,10 +1,11 @@
 import { IWebGlLayer } from '@jupytergis/schema';
 import { ExpressionValue } from 'ol/expr/expression';
 import React, { useEffect, useRef, useState } from 'react';
-import { Spinner } from '@/src/mainview/spinner';
+
 import useGetBandInfo from '@/src/dialogs/symbology/hooks/useGetBandInfo';
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 import BandRow from '@/src/dialogs/symbology/tiff_layer/components/BandRow';
+import { Spinner } from '@/src/mainview/spinner';
 
 interface ISelectedBands {
   red: number;

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
@@ -3,8 +3,7 @@ import { Button } from '@jupyterlab/ui-components';
 import { ReadonlyJSONObject } from '@lumino/coreutils';
 import { ExpressionValue } from 'ol/expr/expression';
 import React, { useEffect, useRef, useState } from 'react';
-import { Spinner } from '@/src/mainview/spinner';
-import { GlobalStateDbManager } from '@/src/store';
+
 import { GeoTiffClassifications } from '@/src/dialogs/symbology/classificationModes';
 import ColorRamp, {
   ColorRampOptions
@@ -19,6 +18,8 @@ import {
 } from '@/src/dialogs/symbology/symbologyDialog';
 import { Utils } from '@/src/dialogs/symbology/symbologyUtils';
 import BandRow from '@/src/dialogs/symbology/tiff_layer/components/BandRow';
+import { Spinner } from '@/src/mainview/spinner';
+import { GlobalStateDbManager } from '@/src/store';
 
 export type InterpolationType = 'discrete' | 'linear' | 'exact';
 

--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -1,15 +1,16 @@
 import React, { useEffect, useState } from 'react';
+
+import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
+import {
+  getColorCodeFeatureAttributes,
+  getNumericFeatureAttributes
+} from '@/src/tools';
 import Canonical from './types/Canonical';
 import Categorized from './types/Categorized';
 import Graduated from './types/Graduated';
 import Heatmap from './types/Heatmap';
 import SimpleSymbol from './types/SimpleSymbol';
-import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
-import {
-  getColorCodeFeatureAttributes,
-  getNumericFeatureAttributes
-} from '@/src/tools';
 
 const VectorRendering = ({
   model,

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
@@ -1,10 +1,11 @@
 import { IVectorLayer } from '@jupytergis/schema';
 import { ExpressionValue } from 'ol/expr/expression';
 import React, { useEffect, useRef, useState } from 'react';
-import { getColorCodeFeatureAttributes } from '@/src/tools';
+
 import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
+import { getColorCodeFeatureAttributes } from '@/src/tools';
 
 const Canonical = ({
   model,

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
@@ -2,7 +2,7 @@ import { IVectorLayer } from '@jupytergis/schema';
 import { ReadonlyJSONObject } from '@lumino/coreutils';
 import { ExpressionValue } from 'ol/expr/expression';
 import React, { useEffect, useRef, useState } from 'react';
-import { getNumericFeatureAttributes } from '@/src/tools';
+
 import ColorRamp from '@/src/dialogs/symbology/components/color_ramp/ColorRamp';
 import StopContainer from '@/src/dialogs/symbology/components/color_stops/StopContainer';
 import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
@@ -12,6 +12,7 @@ import {
 } from '@/src/dialogs/symbology/symbologyDialog';
 import { Utils, VectorUtils } from '@/src/dialogs/symbology/symbologyUtils';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
+import { getNumericFeatureAttributes } from '@/src/tools';
 
 const Categorized = ({
   model,

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
@@ -1,7 +1,7 @@
 import { IVectorLayer } from '@jupytergis/schema';
 import { ExpressionValue } from 'ol/expr/expression';
 import React, { useEffect, useRef, useState } from 'react';
-import { getNumericFeatureAttributes } from '@/src/tools';
+
 import { VectorClassifications } from '@/src/dialogs/symbology/classificationModes';
 import ColorRamp, {
   ColorRampOptions
@@ -14,6 +14,7 @@ import {
 } from '@/src/dialogs/symbology/symbologyDialog';
 import { Utils, VectorUtils } from '@/src/dialogs/symbology/symbologyUtils';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
+import { getNumericFeatureAttributes } from '@/src/tools';
 
 const Graduated = ({
   model,

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
@@ -1,5 +1,6 @@
 import colormap from 'colormap';
 import React, { useEffect, useRef, useState } from 'react';
+
 import CanvasSelectComponent from '@/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent';
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 

--- a/packages/base/src/dialogs/symbology/vector_layer/types/SimpleSymbol.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/SimpleSymbol.tsx
@@ -1,7 +1,8 @@
 import { FlatStyle } from 'ol/style/flat';
 import React, { useEffect, useRef, useState } from 'react';
-import { IParsedStyle, parseColor } from '@/src/tools';
+
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
+import { IParsedStyle, parseColor } from '@/src/tools';
 
 const SimpleSymbol = ({
   model,

--- a/packages/base/src/formbuilder/creationform.tsx
+++ b/packages/base/src/formbuilder/creationform.tsx
@@ -7,13 +7,12 @@ import {
   LayerType,
   SourceType
 } from '@jupytergis/schema';
-
-import { deepCopy } from '@/src/tools';
-
 import { Dialog } from '@jupyterlab/apputils';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import * as React from 'react';
+
+import { deepCopy } from '@/src/tools';
 import { getLayerTypeForm, getSourceTypeForm } from './formselectors';
 
 export interface ICreationFormProps {

--- a/packages/base/src/formbuilder/formselectors.ts
+++ b/packages/base/src/formbuilder/formselectors.ts
@@ -1,11 +1,5 @@
 import { LayerType, SourceType } from '@jupytergis/schema';
-import {
-  GeoJSONSourcePropertiesForm,
-  GeoTiffSourcePropertiesForm,
-  PathBasedSourcePropertiesForm,
-  TileSourcePropertiesForm,
-  SourcePropertiesForm
-} from './objectform/source';
+
 import {
   HeatmapLayerPropertiesForm,
   HillshadeLayerPropertiesForm,
@@ -13,6 +7,13 @@ import {
   VectorLayerPropertiesForm,
   WebGlLayerPropertiesForm
 } from './objectform/layer';
+import {
+  GeoJSONSourcePropertiesForm,
+  GeoTiffSourcePropertiesForm,
+  PathBasedSourcePropertiesForm,
+  TileSourcePropertiesForm,
+  SourcePropertiesForm
+} from './objectform/source';
 
 export function getLayerTypeForm(
   layerType: LayerType

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -6,6 +6,7 @@ import { Signal } from '@lumino/signaling';
 import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
 import validatorAjv8 from '@rjsf/validator-ajv8';
 import * as React from 'react';
+
 import { deepCopy } from '@/src/tools';
 import { IDict } from '@/src/types';
 

--- a/packages/base/src/formbuilder/objectform/fileselectorwidget.tsx
+++ b/packages/base/src/formbuilder/objectform/fileselectorwidget.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { FileDialog } from '@jupyterlab/filebrowser';
 import { Dialog } from '@jupyterlab/apputils';
-import { LayerCreationFormDialog } from '@/src/dialogs/layerCreationFormDialog';
 import { PathExt } from '@jupyterlab/coreutils';
+import { FileDialog } from '@jupyterlab/filebrowser';
+import React, { useState, useEffect, useRef } from 'react';
+
+import { LayerCreationFormDialog } from '@/src/dialogs/layerCreationFormDialog';
 
 export const FileSelectorWidget = (props: any) => {
   const { options } = props;

--- a/packages/base/src/formbuilder/objectform/layer/heatmapLayerForm.ts
+++ b/packages/base/src/formbuilder/objectform/layer/heatmapLayerForm.ts
@@ -1,5 +1,6 @@
 import { IDict, IGeoJSONSource, IHeatmapLayer } from '@jupytergis/schema';
 import { IChangeEvent } from '@rjsf/core';
+
 import { loadFile } from '@/src/tools';
 import { ILayerProps, LayerPropertiesForm } from './layerform';
 

--- a/packages/base/src/formbuilder/objectform/layer/hillshadeLayerForm.ts
+++ b/packages/base/src/formbuilder/objectform/layer/hillshadeLayerForm.ts
@@ -1,4 +1,5 @@
 import { IDict } from '@jupytergis/schema';
+
 import { LayerPropertiesForm } from './layerform';
 
 /**

--- a/packages/base/src/formbuilder/objectform/layer/layerform.ts
+++ b/packages/base/src/formbuilder/objectform/layer/layerform.ts
@@ -1,10 +1,11 @@
 import { IDict, SourceType } from '@jupytergis/schema';
+import { Signal } from '@lumino/signaling';
+import { IChangeEvent } from '@rjsf/core';
+
 import {
   BaseForm,
   IBaseFormProps
 } from '@/src/formbuilder/objectform/baseform';
-import { Signal } from '@lumino/signaling';
-import { IChangeEvent } from '@rjsf/core';
 
 export interface ILayerProps extends IBaseFormProps {
   /**

--- a/packages/base/src/formbuilder/objectform/layer/vectorlayerform.ts
+++ b/packages/base/src/formbuilder/objectform/layer/vectorlayerform.ts
@@ -1,5 +1,6 @@
 import { IDict, IVectorLayer } from '@jupytergis/schema';
 import { IChangeEvent } from '@rjsf/core';
+
 import { ILayerProps, LayerPropertiesForm } from './layerform';
 
 /**

--- a/packages/base/src/formbuilder/objectform/layer/webGlLayerForm.tsx
+++ b/packages/base/src/formbuilder/objectform/layer/webGlLayerForm.tsx
@@ -1,4 +1,5 @@
 import { IDict } from '@jupytergis/schema';
+
 import { LayerPropertiesForm } from './layerform';
 
 /**

--- a/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
+++ b/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
@@ -1,10 +1,11 @@
+import { IDict, IJupyterGISModel, IGeoJSONSource } from '@jupytergis/schema';
+import { IChangeEvent } from '@rjsf/core';
+
 import {
   BaseForm,
   IBaseFormProps,
   IBaseFormStates
 } from '@/src/formbuilder/objectform/baseform'; // Ensure BaseForm imports states
-import { IDict, IJupyterGISModel, IGeoJSONSource } from '@jupytergis/schema';
-import { IChangeEvent } from '@rjsf/core';
 import { loadFile } from '@/src/tools';
 
 interface IDissolveFormOptions extends IBaseFormProps {

--- a/packages/base/src/formbuilder/objectform/source/geojsonsource.ts
+++ b/packages/base/src/formbuilder/objectform/source/geojsonsource.ts
@@ -1,9 +1,9 @@
 import { IDict } from '@jupytergis/schema';
-import { Ajv, ValidateFunction } from 'ajv';
 import * as geojson from '@jupytergis/schema/src/schema/geojson.json';
+import { Ajv, ValidateFunction } from 'ajv';
 
-import { PathBasedSourcePropertiesForm } from './pathbasedsource';
 import { loadFile } from '@/src/tools';
+import { PathBasedSourcePropertiesForm } from './pathbasedsource';
 import { ISourceFormProps } from './sourceform';
 
 /**

--- a/packages/base/src/formbuilder/objectform/source/geotiffsource.ts
+++ b/packages/base/src/formbuilder/objectform/source/geotiffsource.ts
@@ -2,9 +2,9 @@ import { IDict } from '@jupytergis/schema';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
 
+import { FileSelectorWidget } from '@/src/formbuilder/objectform/fileselectorwidget';
 import { getMimeType } from '@/src/tools';
 import { ISourceFormProps, SourcePropertiesForm } from './sourceform';
-import { FileSelectorWidget } from '@/src/formbuilder/objectform/fileselectorwidget';
 
 /**
  * The form to modify a GeoTiff source.

--- a/packages/base/src/formbuilder/objectform/source/pathbasedsource.ts
+++ b/packages/base/src/formbuilder/objectform/source/pathbasedsource.ts
@@ -2,8 +2,8 @@ import { IDict } from '@jupytergis/schema';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
 
-import { loadFile } from '@/src/tools';
 import { FileSelectorWidget } from '@/src/formbuilder/objectform/fileselectorwidget';
+import { loadFile } from '@/src/tools';
 import { ISourceFormProps, SourcePropertiesForm } from './sourceform';
 
 /**

--- a/packages/base/src/formbuilder/objectform/source/sourceform.ts
+++ b/packages/base/src/formbuilder/objectform/source/sourceform.ts
@@ -1,10 +1,11 @@
 import { IDict, SourceType } from '@jupytergis/schema';
+import { Signal } from '@lumino/signaling';
+import { IChangeEvent } from '@rjsf/core';
+
 import {
   BaseForm,
   IBaseFormProps
 } from '@/src/formbuilder/objectform/baseform';
-import { Signal } from '@lumino/signaling';
-import { IChangeEvent } from '@rjsf/core';
 
 export interface ISourceFormProps extends IBaseFormProps {
   /**

--- a/packages/base/src/formbuilder/objectform/source/tilesourceform.ts
+++ b/packages/base/src/formbuilder/objectform/source/tilesourceform.ts
@@ -1,4 +1,5 @@
 import { IDict } from '@jupytergis/schema';
+
 import { SourcePropertiesForm } from './sourceform';
 
 export class TileSourcePropertiesForm extends SourcePropertiesForm {

--- a/packages/base/src/icons.ts
+++ b/packages/base/src/icons.ts
@@ -6,23 +6,24 @@
 // This file is based on iconimports.ts in @jupyterlab/ui-components, but is manually generated.
 
 import { LabIcon } from '@jupyterlab/ui-components';
+
+import bookOpenSvgStr from '../style/icons/book_open.svg';
+import clockSvgStr from '../style/icons/clock-solid.svg';
+import geoJsonSvgStr from '../style/icons/geojson.svg';
+import geolocationSvgStr from '../style/icons/geolocation.svg';
+import infoSvgStr from '../style/icons/info-solid.svg';
 import logoSvgStr from '../style/icons/logo.svg';
 import logoMiniSvgStr from '../style/icons/logo_mini.svg';
 import logoMiniAlternativeSvgStr from '../style/icons/logo_mini_alternative.svg';
-import rasterSvgStr from '../style/icons/raster.svg';
-import visibilitySvgStr from '../style/icons/visibility.svg';
-import nonVisibilitySvgStr from '../style/icons/nonvisibility.svg';
-import geoJsonSvgStr from '../style/icons/geojson.svg';
-import moundSvgStr from '../style/icons/mound.svg';
 import logoMiniQGZ from '../style/icons/logo_mini_qgz.svg';
-import bookOpenSvgStr from '../style/icons/book_open.svg';
-import vectorSquareSvgStr from '../style/icons/vector_square.svg';
-import infoSvgStr from '../style/icons/info-solid.svg';
-import clockSvgStr from '../style/icons/clock-solid.svg';
-import terminalToolbarSvgStr from '../style/icons/terminal_toolbar.svg';
-import geolocationSvgStr from '../style/icons/geolocation.svg';
-import targetWithoutCenterSvgStr from '../style/icons/target_without_center.svg';
+import moundSvgStr from '../style/icons/mound.svg';
+import nonVisibilitySvgStr from '../style/icons/nonvisibility.svg';
+import rasterSvgStr from '../style/icons/raster.svg';
 import targetWithCenterSvgStr from '../style/icons/target_with_center.svg';
+import targetWithoutCenterSvgStr from '../style/icons/target_without_center.svg';
+import terminalToolbarSvgStr from '../style/icons/terminal_toolbar.svg';
+import vectorSquareSvgStr from '../style/icons/vector_square.svg';
+import visibilitySvgStr from '../style/icons/visibility.svg';
 
 export const logoIcon = new LabIcon({
   name: 'jupytergis::logo',

--- a/packages/base/src/mainview/FollowIndicator.tsx
+++ b/packages/base/src/mainview/FollowIndicator.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { User } from '@jupyterlab/services';
+import React from 'react';
 
 interface IFollowIndicatorProps {
   remoteUser: User.IIdentity | null | undefined;

--- a/packages/base/src/mainview/TemporalSlider.tsx
+++ b/packages/base/src/mainview/TemporalSlider.tsx
@@ -19,6 +19,7 @@ import {
   minutesInMonth
 } from 'date-fns/constants';
 import React, { useEffect, useRef, useState } from 'react';
+
 import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
 
 interface ITemporalSliderProps {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -36,13 +36,12 @@ import { CommandRegistry } from '@lumino/commands';
 import { JSONValue, UUID } from '@lumino/coreutils';
 import { ContextMenu } from '@lumino/widgets';
 import { Collection, MapBrowserEvent, Map as OlMap, View, getUid } from 'ol';
-//@ts-expect-error no types for ol-pmtiles
-import { PMTilesRasterSource, PMTilesVectorSource } from 'ol-pmtiles';
 import Feature, { FeatureLike } from 'ol/Feature';
 import { ScaleLine } from 'ol/control';
 import { Coordinate } from 'ol/coordinate';
 import { singleClick } from 'ol/events/condition';
 import { GeoJSON, MVT } from 'ol/format';
+import { Geometry, Point } from 'ol/geom';
 import { DragAndDrop, Select } from 'ol/interaction';
 import {
   Heatmap as HeatmapLayer,
@@ -59,8 +58,8 @@ import {
   toLonLat,
   transformExtent
 } from 'ol/proj';
-import { get as getProjection } from 'ol/proj.js';
 import { register } from 'ol/proj/proj4.js';
+import { get as getProjection } from 'ol/proj.js';
 import RenderFeature from 'ol/render/Feature';
 import {
   GeoTIFF as GeoTIFFSource,
@@ -73,9 +72,12 @@ import Static from 'ol/source/ImageStatic';
 import TileSource from 'ol/source/Tile';
 import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { Rule } from 'ol/style/flat';
+//@ts-expect-error no types for ol-pmtiles
+import { PMTilesRasterSource, PMTilesVectorSource } from 'ol-pmtiles';
 import proj4 from 'proj4';
 import proj4list from 'proj4-list';
 import * as React from 'react';
+
 import AnnotationFloater from '@/src/annotations/components/AnnotationFloater';
 import { CommandIDs } from '@/src/constants';
 import StatusBar from '@/src/statusbar/StatusBar';
@@ -85,7 +87,6 @@ import { FollowIndicator } from './FollowIndicator';
 import TemporalSlider from './TemporalSlider';
 import { MainViewModel } from './mainviewmodel';
 import { Spinner } from './spinner';
-import { Geometry, Point } from 'ol/geom';
 
 interface IProps {
   viewModel: MainViewModel;

--- a/packages/base/src/menus.ts
+++ b/packages/base/src/menus.ts
@@ -1,5 +1,5 @@
-import { Menu } from '@lumino/widgets';
 import { CommandRegistry } from '@lumino/commands';
+import { Menu } from '@lumino/widgets';
 
 import { CommandIDs } from './constants';
 import { rasterIcon } from './icons';

--- a/packages/base/src/panelview/annotationPanel.tsx
+++ b/packages/base/src/panelview/annotationPanel.tsx
@@ -1,6 +1,7 @@
+import { IAnnotationModel } from '@jupytergis/schema';
 import { PanelWithToolbar, ReactWidget } from '@jupyterlab/ui-components';
 import React, { Component } from 'react';
-import { IAnnotationModel } from '@jupytergis/schema';
+
 import Annotation from '@/src/annotations/components/Annotation';
 import { IControlPanelModel } from '@/src/types';
 

--- a/packages/base/src/panelview/components/filter-panel/Filter.tsx
+++ b/packages/base/src/panelview/components/filter-panel/Filter.tsx
@@ -9,6 +9,7 @@ import { Button, ReactWidget } from '@jupyterlab/ui-components';
 import { Panel } from '@lumino/widgets';
 import { cloneDeep } from 'lodash';
 import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+
 import { debounce, loadFile } from '@/src/tools';
 import { IControlPanelModel } from '@/src/types';
 import FilterRow from './FilterRow';

--- a/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
+++ b/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
@@ -1,17 +1,17 @@
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   IDict,
   IJupyterGISClientState,
   IJupyterGISModel,
   IJupyterGISTracker
 } from '@jupytergis/schema';
+import { User } from '@jupyterlab/services';
 import { LabIcon, ReactWidget, caretDownIcon } from '@jupyterlab/ui-components';
 import { Panel } from '@lumino/widgets';
 import React, { useEffect, useRef, useState } from 'react';
-import { IControlPanelModel } from '@/src/types';
-import { User } from '@jupyterlab/services';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { IControlPanelModel } from '@/src/types';
 
 export class IdentifyPanel extends Panel {
   constructor(options: IdentifyPanel.IOptions) {

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -19,13 +19,14 @@ import React, {
   useEffect,
   useState
 } from 'react';
+
 import { icons } from '@/src/constants';
 import { nonVisibilityIcon, visibilityIcon } from '@/src/icons';
-import { IControlPanelModel } from '@/src/types';
 import {
   ILayerPanelOptions,
   ILeftPanelClickHandlerParams
 } from '@/src/panelview/leftpanel';
+import { IControlPanelModel } from '@/src/types';
 
 const LAYERS_PANEL_CLASS = 'jp-gis-layerPanel';
 const LAYER_GROUP_CLASS = 'jp-gis-layerGroup';

--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -6,14 +6,15 @@ import {
 } from '@jupytergis/schema';
 import { IStateDB } from '@jupyterlab/statedb';
 import { SidePanel } from '@jupyterlab/ui-components';
+import { CommandRegistry } from '@lumino/commands';
 import { Message } from '@lumino/messaging';
 import { MouseEvent as ReactMouseEvent } from 'react';
+
+import { CommandIDs } from '@/src/constants';
 import { IControlPanelModel } from '@/src/types';
+import { FilterPanel } from './components/filter-panel/Filter';
 import { LayersPanel } from './components/layers';
 import { ControlPanelHeader } from './header';
-import { FilterPanel } from './components/filter-panel/Filter';
-import { CommandRegistry } from '@lumino/commands';
-import { CommandIDs } from '@/src/constants';
 
 /**
  * Options of the left panel widget.

--- a/packages/base/src/panelview/objectproperties.tsx
+++ b/packages/base/src/panelview/objectproperties.tsx
@@ -10,8 +10,8 @@ import { Panel } from '@lumino/widgets';
 import * as React from 'react';
 import { v4 as uuid } from 'uuid';
 
-import { IControlPanelModel } from '@/src/types';
 import { EditForm } from '@/src/formbuilder/editform';
+import { IControlPanelModel } from '@/src/types';
 
 export class ObjectProperties extends PanelWithToolbar {
   constructor(params: ObjectProperties.IOptions) {

--- a/packages/base/src/panelview/rightpanel.tsx
+++ b/packages/base/src/panelview/rightpanel.tsx
@@ -8,10 +8,10 @@ import {
 import { SidePanel } from '@jupyterlab/ui-components';
 
 import { IControlPanelModel } from '@/src/types';
-import { ControlPanelHeader } from './header';
-import { ObjectProperties } from './objectproperties';
 import { Annotations } from './annotationPanel';
 import IdentifyPanel from './components/identify-panel/IdentifyPanel';
+import { ControlPanelHeader } from './header';
+import { ObjectProperties } from './objectproperties';
 
 export class RightPanelWidget extends SidePanel {
   constructor(options: RightPanelWidget.IOptions) {

--- a/packages/base/src/processing.ts
+++ b/packages/base/src/processing.ts
@@ -6,12 +6,13 @@ import {
   IJGISFormSchemaRegistry,
   LayerType
 } from '@jupytergis/schema';
-import { getGdal } from './gdal';
-import { JupyterGISTracker } from './types';
-import { UUID } from '@lumino/coreutils';
-import { ProcessingFormDialog } from './dialogs/ProcessingFormDialog';
-import { getGeoJSONDataFromLayerSource } from './tools';
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { UUID } from '@lumino/coreutils';
+
+import { ProcessingFormDialog } from './dialogs/ProcessingFormDialog';
+import { getGdal } from './gdal';
+import { getGeoJSONDataFromLayerSource } from './tools';
+import { JupyterGISTracker } from './types';
 
 /**
  * Get the currently selected layer from the shared model. Returns null if there is no selection or multiple layer is selected.

--- a/packages/base/src/statusbar/StatusBar.tsx
+++ b/packages/base/src/statusbar/StatusBar.tsx
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Progress } from '@jupyter/react-components';
 import { IJupyterGISModel, JgisCoordinates } from '@jupytergis/schema';
 import React, { useEffect, useState } from 'react';
+
 import { version } from '@/package.json';
 
 interface IStatusBarProps {

--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -1,3 +1,4 @@
+import { UsersItem } from '@jupyter/collaboration';
 import { IJGISExternalCommand, JupyterGISModel } from '@jupytergis/schema';
 import { CommandToolbarButton } from '@jupyterlab/apputils';
 import {
@@ -12,12 +13,11 @@ import {
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
-
 import * as React from 'react';
+
 import { CommandIDs } from '@/src/constants';
 import { terminalToolbarIcon } from '@/src/icons';
 import { rasterSubMenu, vectorSubMenu } from '@/src/menus';
-import { UsersItem } from '@jupyter/collaboration';
 
 export const TOOLBAR_SEPARATOR_CLASS = 'jGIS-Toolbar-Separator';
 export const TOOLBAR_GROUPNAME_CLASS = 'jGIS-Toolbar-GroupName';

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -1,14 +1,3 @@
-import Protobuf from 'pbf';
-
-import { VectorTile } from '@mapbox/vector-tile';
-
-import { PathExt, URLExt } from '@jupyterlab/coreutils';
-import { Contents, ServerConnection } from '@jupyterlab/services';
-import { showErrorMessage } from '@jupyterlab/apputils';
-import * as d3Color from 'd3-color';
-import shp from 'shpjs';
-import { getGdal } from '@/src/gdal';
-
 import {
   IDict,
   IJGISLayerBrowserRegistry,
@@ -18,7 +7,16 @@ import {
   IRasterLayerGalleryEntry,
   SourceType
 } from '@jupytergis/schema';
+import { showErrorMessage } from '@jupyterlab/apputils';
+import { PathExt, URLExt } from '@jupyterlab/coreutils';
+import { Contents, ServerConnection } from '@jupyterlab/services';
+import { VectorTile } from '@mapbox/vector-tile';
+import * as d3Color from 'd3-color';
+import Protobuf from 'pbf';
+import shp from 'shpjs';
+
 import RASTER_LAYER_GALLERY from '@/rasterlayer_gallery/raster_layer_gallery.json';
+import { getGdal } from '@/src/gdal';
 
 export const debounce = (
   func: CallableFunction,

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -7,12 +7,12 @@ import { MainAreaWidget } from '@jupyterlab/apputils';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
+import { CommandRegistry } from '@lumino/commands';
 import { JSONValue } from '@lumino/coreutils';
+import { MessageLoop } from '@lumino/messaging';
 import { ISignal, Signal } from '@lumino/signaling';
 import { SplitPanel, Widget } from '@lumino/widgets';
 
-import { CommandRegistry } from '@lumino/commands';
-import { MessageLoop } from '@lumino/messaging';
 import { ConsoleView } from './console';
 import { JupyterGISMainViewPanel } from './mainview';
 import { MainViewModel } from './mainview/mainviewmodel';

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -1,7 +1,6 @@
 import { Delta, MapChange, YDocument } from '@jupyter/ydoc';
 import { JSONExt, JSONObject } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
-import { SCHEMA_VERSION } from './_interface/version';
 import * as Y from 'yjs';
 
 import {
@@ -13,6 +12,7 @@ import {
   IJGISSource,
   IJGISSources
 } from './_interface/project/jgis';
+import { SCHEMA_VERSION } from './_interface/version';
 import {
   IDict,
   IJGISLayerDocChange,

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -2,9 +2,11 @@ import { MapChange } from '@jupyter/ydoc';
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Contents } from '@jupyterlab/services';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { PartialJSONObject } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import Ajv from 'ajv';
+
 import {
   IJGISContent,
   IJGISLayer,
@@ -34,7 +36,6 @@ import {
   IJupyterGISSettings
 } from './interfaces';
 import jgisSchema from './schema/project/jgis.json';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 const SETTINGS_ID = '@jupytergis/jupytergis-core:jupytergis-settings';
 

--- a/python/jupytergis_core/src/factory.ts
+++ b/python/jupytergis_core/src/factory.ts
@@ -1,21 +1,20 @@
-import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { ICollaborativeDrive } from '@jupyter/collaborative-drive';
-import {
-  JupyterGISModel,
-  IJupyterGISTracker,
-  IJGISExternalCommandRegistry
-} from '@jupytergis/schema';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
-import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
-import { CommandRegistry } from '@lumino/commands';
-
 import {
   JupyterGISPanel,
   JupyterGISDocumentWidget,
   ToolbarWidget
 } from '@jupytergis/base';
+import {
+  JupyterGISModel,
+  IJupyterGISTracker,
+  IJGISExternalCommandRegistry
+} from '@jupytergis/schema';
+import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
+import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
+import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { Contents, ServiceManager } from '@jupyterlab/services';
+import { CommandRegistry } from '@lumino/commands';
 
 interface IOptions extends DocumentRegistry.IWidgetFactoryOptions {
   tracker: IJupyterGISTracker;

--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -2,6 +2,7 @@ import {
   ICollaborativeDrive,
   SharedDocumentFactory
 } from '@jupyter/collaborative-drive';
+import { CommandIDs, logoIcon, logoMiniIcon } from '@jupytergis/base';
 import {
   IAnnotationModel,
   IAnnotationToken,
@@ -24,15 +25,14 @@ import {
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { PageConfig } from '@jupyterlab/coreutils';
+import { MimeDocumentFactory } from '@jupyterlab/docregistry';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
-import { CommandIDs, logoIcon, logoMiniIcon } from '@jupytergis/base';
 import { JupyterGISDocumentWidgetFactory } from '../factory';
 import { JupyterGISModelFactory } from './modelfactory';
-import { MimeDocumentFactory } from '@jupyterlab/docregistry';
 
 const FACTORY = 'JupyterGIS .jgis Viewer';
 const CONTENT_TYPE = 'jgis';

--- a/python/jupytergis_core/src/plugin.ts
+++ b/python/jupytergis_core/src/plugin.ts
@@ -17,9 +17,9 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { WidgetTracker } from '@jupyterlab/apputils';
+import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { ITranslator } from '@jupyterlab/translation';
-import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import { JupyterGISExternalCommandRegistry } from './externalcommand';
 import { JupyterGISLayerBrowserRegistry } from './layerBrowserRegistry';

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -33,6 +33,7 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { ContextMenu, Menu } from '@lumino/widgets';
+
 import { notebookRendererPlugin } from './notebookrenderer';
 
 const NAME_SPACE = 'jupytergis';

--- a/python/jupytergis_qgis/src/plugins.ts
+++ b/python/jupytergis_qgis/src/plugins.ts
@@ -3,6 +3,13 @@ import {
   SharedDocumentFactory
 } from '@jupyter/collaborative-drive';
 import {
+  JupyterGISDocumentWidget,
+  logoMiniIcon,
+  logoMiniIconQGZ,
+  requestAPI
+} from '@jupytergis/base';
+import { JupyterGISDocumentWidgetFactory } from '@jupytergis/jupytergis-core';
+import {
   IJGISExternalCommandRegistry,
   IJGISExternalCommandRegistryToken,
   JupyterGISDoc,
@@ -28,16 +35,9 @@ import { IEditorServices } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { PathExt } from '@jupyterlab/coreutils';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { Widget } from '@lumino/widgets';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { Widget } from '@lumino/widgets';
 
-import {
-  JupyterGISDocumentWidget,
-  logoMiniIcon,
-  logoMiniIconQGZ,
-  requestAPI
-} from '@jupytergis/base';
-import { JupyterGISDocumentWidgetFactory } from '@jupytergis/jupytergis-core';
 import { QGSModelFactory, QGZModelFactory } from './modelfactory';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,6 +921,7 @@ __metadata:
     copy-webpack-plugin: ^10.0.0
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
+    eslint-plugin-import: ^2.31.0
     eslint-plugin-prettier: ^5.0.1
     lerna: ^8.1.9
     npm-run-all: ^4.1.5
@@ -2644,6 +2645,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rtsao/scc@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@rtsao/scc@npm:1.1.0"
+  checksum: 17d04adf404e04c1e61391ed97bca5117d4c2767a76ae3e879390d6dec7b317fcae68afbf9e98badee075d0b64fa60f287729c4942021b4d19cd01db77385c01
+  languageName: node
+  linkType: hard
+
 "@sigstore/bundle@npm:^2.3.2":
   version: 2.3.2
   resolution: "@sigstore/bundle@npm:2.3.2"
@@ -2806,6 +2814,13 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
+  languageName: node
+  linkType: hard
+
+"@types/json5@npm:^0.0.29":
+  version: 0.0.29
+  resolution: "@types/json5@npm:0.0.29"
+  checksum: e60b153664572116dfea673c5bda7778dbff150498f44f998e34b5886d8afc47f16799280e4b6e241c0472aef1bc36add771c569c68fc5125fc2ae519a3eb9ac
   languageName: node
   linkType: hard
 
@@ -3585,6 +3600,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-includes@npm:^3.1.8":
+  version: 3.1.9
+  resolution: "array-includes@npm:3.1.9"
+  dependencies:
+    call-bind: ^1.0.8
+    call-bound: ^1.0.4
+    define-properties: ^1.2.1
+    es-abstract: ^1.24.0
+    es-object-atoms: ^1.1.1
+    get-intrinsic: ^1.3.0
+    is-string: ^1.1.1
+    math-intrinsics: ^1.1.0
+  checksum: b58dc526fe415252e50319eaf88336e06e75aa673e3b58d252414739a4612dbe56e7b613fdcc7c90561dc9cf9202bbe5ca029ccd8c08362746459475ae5a8f3e
+  languageName: node
+  linkType: hard
+
 "array-union@npm:^2.1.0":
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
@@ -3596,6 +3627,45 @@ __metadata:
   version: 3.0.1
   resolution: "array-union@npm:3.0.1"
   checksum: 47b29f88258e8f37ffb93ddaa327d4308edd950b52943c172b73558afdd3fa74cfd68816ba5aa4b894242cf281fa3c6d0362ae057e4a18bddbaedbe46ebe7112
+  languageName: node
+  linkType: hard
+
+"array.prototype.findlastindex@npm:^1.2.5":
+  version: 1.2.6
+  resolution: "array.prototype.findlastindex@npm:1.2.6"
+  dependencies:
+    call-bind: ^1.0.8
+    call-bound: ^1.0.4
+    define-properties: ^1.2.1
+    es-abstract: ^1.23.9
+    es-errors: ^1.3.0
+    es-object-atoms: ^1.1.1
+    es-shim-unscopables: ^1.1.0
+  checksum: bd2665bd51f674d4e1588ce5d5848a8adb255f414070e8e652585598b801480516df2c6cef2c60b6ea1a9189140411c49157a3f112d52e9eabb4e9fc80936ea6
+  languageName: node
+  linkType: hard
+
+"array.prototype.flat@npm:^1.3.2":
+  version: 1.3.3
+  resolution: "array.prototype.flat@npm:1.3.3"
+  dependencies:
+    call-bind: ^1.0.8
+    define-properties: ^1.2.1
+    es-abstract: ^1.23.5
+    es-shim-unscopables: ^1.0.2
+  checksum: 5d5a7829ab2bb271a8d30a1c91e6271cef0ec534593c0fe6d2fb9ebf8bb62c1e5326e2fddcbbcbbe5872ca04f5e6b54a1ecf092e0af704fb538da9b2bfd95b40
+  languageName: node
+  linkType: hard
+
+"array.prototype.flatmap@npm:^1.3.2":
+  version: 1.3.3
+  resolution: "array.prototype.flatmap@npm:1.3.3"
+  dependencies:
+    call-bind: ^1.0.8
+    define-properties: ^1.2.1
+    es-abstract: ^1.23.5
+    es-shim-unscopables: ^1.0.2
+  checksum: 11b4de09b1cf008be6031bb507d997ad6f1892e57dc9153583de6ebca0f74ea403fffe0f203461d359de05048d609f3f480d9b46fed4099652d8b62cc972f284
   languageName: node
   linkType: hard
 
@@ -4569,6 +4639,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "debug@npm:3.2.7"
+  dependencies:
+    ms: ^2.1.1
+  checksum: b3d8c5940799914d30314b7c3304a43305fd0715581a919dacb8b3176d024a782062368405b47491516d2091d6462d4d11f2f4974a405048094f8bfebfa3071c
+  languageName: node
+  linkType: hard
+
 "decamelize-keys@npm:^1.1.0":
   version: 1.1.1
   resolution: "decamelize-keys@npm:1.1.1"
@@ -4691,6 +4770,15 @@ __metadata:
   dependencies:
     path-type: ^4.0.0
   checksum: fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
+  languageName: node
+  linkType: hard
+
+"doctrine@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "doctrine@npm:2.1.0"
+  dependencies:
+    esutils: ^2.0.2
+  checksum: a45e277f7feaed309fe658ace1ff286c6e2002ac515af0aaf37145b8baa96e49899638c7cd47dccf84c3d32abfc113246625b3ac8f552d1046072adee13b0dc8
   languageName: node
   linkType: hard
 
@@ -4941,7 +5029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.9":
+"es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.9, es-abstract@npm:^1.24.0":
   version: 1.24.0
   resolution: "es-abstract@npm:1.24.0"
   dependencies:
@@ -5045,6 +5133,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-shim-unscopables@npm:^1.0.2, es-shim-unscopables@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "es-shim-unscopables@npm:1.1.0"
+  dependencies:
+    hasown: ^2.0.2
+  checksum: 33cfb1ebcb2f869f0bf528be1a8660b4fe8b6cec8fc641f330e508db2284b58ee2980fad6d0828882d22858c759c0806076427a3673b6daa60f753e3b558ee15
+  languageName: node
+  linkType: hard
+
 "es-to-primitive@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-to-primitive@npm:1.3.0"
@@ -5130,6 +5227,58 @@ __metadata:
   bin:
     eslint-config-prettier: bin/cli.js
   checksum: 153266badd477e49b0759816246b2132f1dbdb6c7f313ca60a9af5822fd1071c2bc5684a3720d78b725452bbac04bb130878b2513aea5e72b1b792de5a69fec8
+  languageName: node
+  linkType: hard
+
+"eslint-import-resolver-node@npm:^0.3.9":
+  version: 0.3.9
+  resolution: "eslint-import-resolver-node@npm:0.3.9"
+  dependencies:
+    debug: ^3.2.7
+    is-core-module: ^2.13.0
+    resolve: ^1.22.4
+  checksum: 439b91271236b452d478d0522a44482e8c8540bf9df9bd744062ebb89ab45727a3acd03366a6ba2bdbcde8f9f718bab7fe8db64688aca75acf37e04eafd25e22
+  languageName: node
+  linkType: hard
+
+"eslint-module-utils@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "eslint-module-utils@npm:2.12.0"
+  dependencies:
+    debug: ^3.2.7
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: be3ac52e0971c6f46daeb1a7e760e45c7c45f820c8cc211799f85f10f04ccbf7afc17039165d56cb2da7f7ca9cec2b3a777013cddf0b976784b37eb9efa24180
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-import@npm:^2.31.0":
+  version: 2.31.0
+  resolution: "eslint-plugin-import@npm:2.31.0"
+  dependencies:
+    "@rtsao/scc": ^1.1.0
+    array-includes: ^3.1.8
+    array.prototype.findlastindex: ^1.2.5
+    array.prototype.flat: ^1.3.2
+    array.prototype.flatmap: ^1.3.2
+    debug: ^3.2.7
+    doctrine: ^2.1.0
+    eslint-import-resolver-node: ^0.3.9
+    eslint-module-utils: ^2.12.0
+    hasown: ^2.0.2
+    is-core-module: ^2.15.1
+    is-glob: ^4.0.3
+    minimatch: ^3.1.2
+    object.fromentries: ^2.0.8
+    object.groupby: ^1.0.3
+    object.values: ^1.2.0
+    semver: ^6.3.1
+    string.prototype.trimend: ^1.0.8
+    tsconfig-paths: ^3.15.0
+  peerDependencies:
+    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+  checksum: b1d2ac268b3582ff1af2a72a2c476eae4d250c100f2e335b6e102036e4a35efa530b80ec578dfc36761fabb34a635b9bf5ab071abe9d4404a4bb054fdf22d415
   languageName: node
   linkType: hard
 
@@ -6509,7 +6658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.16.0, is-core-module@npm:^2.5.0":
+"is-core-module@npm:^2.13.0, is-core-module@npm:^2.15.1, is-core-module@npm:^2.16.0, is-core-module@npm:^2.5.0":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -7083,6 +7232,17 @@ __metadata:
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
   checksum: 48ec0adad5280b8a96bb93f4563aa1667fd7a36334f79149abd42446d0989f2ddc58274b479f4819f1f00617957e6344c886c55d05a4e15ebb4ab931e4a6a8ee
+  languageName: node
+  linkType: hard
+
+"json5@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "json5@npm:1.0.2"
+  dependencies:
+    minimist: ^1.2.0
+  bin:
+    json5: lib/cli.js
+  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
   languageName: node
   linkType: hard
 
@@ -7869,7 +8029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.3":
+"ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -8307,6 +8467,41 @@ __metadata:
     has-symbols: ^1.1.0
     object-keys: ^1.1.1
   checksum: 60e07d2651cf4f5528c485f1aa4dbded9b384c47d80e8187cefd11320abb1aebebf78df5483451dfa549059f8281c21f7b4bf7d19e9e5e97d8d617df0df298de
+  languageName: node
+  linkType: hard
+
+"object.fromentries@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "object.fromentries@npm:2.0.8"
+  dependencies:
+    call-bind: ^1.0.7
+    define-properties: ^1.2.1
+    es-abstract: ^1.23.2
+    es-object-atoms: ^1.0.0
+  checksum: 29b2207a2db2782d7ced83f93b3ff5d425f901945f3665ffda1821e30a7253cd1fd6b891a64279976098137ddfa883d748787a6fea53ecdb51f8df8b8cec0ae1
+  languageName: node
+  linkType: hard
+
+"object.groupby@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "object.groupby@npm:1.0.3"
+  dependencies:
+    call-bind: ^1.0.7
+    define-properties: ^1.2.1
+    es-abstract: ^1.23.2
+  checksum: 0d30693ca3ace29720bffd20b3130451dca7a56c612e1926c0a1a15e4306061d84410bdb1456be2656c5aca53c81b7a3661eceaa362db1bba6669c2c9b6d1982
+  languageName: node
+  linkType: hard
+
+"object.values@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "object.values@npm:1.2.1"
+  dependencies:
+    call-bind: ^1.0.8
+    call-bound: ^1.0.3
+    define-properties: ^1.2.1
+    es-object-atoms: ^1.0.0
+  checksum: f9b9a2a125ccf8ded29414d7c056ae0d187b833ee74919821fc60d7e216626db220d9cb3cf33f965c84aaaa96133626ca13b80f3c158b673976dc8cfcfcd26bb
   languageName: node
   linkType: hard
 
@@ -9411,7 +9606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.20.0, resolve@npm:^1.22.2":
+"resolve@npm:^1.10.0, resolve@npm:^1.20.0, resolve@npm:^1.22.2, resolve@npm:^1.22.4":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -9424,7 +9619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#~builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -9633,6 +9828,15 @@ __metadata:
   bin:
     semver: bin/semver
   checksum: fb4ab5e0dd1c22ce0c937ea390b4a822147a9c53dbd2a9a0132f12fe382902beef4fbf12cf51bb955248d8d15874ce8cd89532569756384f994309825f10b686
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "semver@npm:6.3.1"
+  bin:
+    semver: bin/semver.js
+  checksum: ae47d06de28836adb9d3e25f22a92943477371292d9b665fb023fae278d345d508ca1958232af086d85e0155aee22e313e100971898bbb8d5d89b8b1d4054ca2
   languageName: node
   linkType: hard
 
@@ -10091,7 +10295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string.prototype.trimend@npm:^1.0.9":
+"string.prototype.trimend@npm:^1.0.8, string.prototype.trimend@npm:^1.0.9":
   version: 1.0.9
   resolution: "string.prototype.trimend@npm:1.0.9"
   dependencies:
@@ -10525,6 +10729,18 @@ __metadata:
     ts-patch: bin/ts-patch.js
     tspc: bin/tspc.js
   checksum: b9c85e338406ae75a306d0e12d9968ee3819922f996cecc5d7176842d2e5cb5f194bd651a85098b0a5b6c432fb29f0305e57003d4920ff0a5dfa5b111b9d3e7c
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "tsconfig-paths@npm:3.15.0"
+  dependencies:
+    "@types/json5": ^0.0.29
+    json5: ^1.0.2
+    minimist: ^1.2.6
+    strip-bom: ^3.0.0
+  checksum: 59f35407a390d9482b320451f52a411a256a130ff0e7543d18c6f20afab29ac19fbe55c360a93d6476213cc335a4d76ce90f67df54c4e9037f7d240920832201
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #728 , merge that first.

Sort and group imports in our TS following the same pattern as our Python code using eslint plugin.

First builtin, then third-party, then local imports.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--730.org.readthedocs.build/en/730/
💡 JupyterLite preview: https://jupytergis--730.org.readthedocs.build/en/730/lite

<!-- readthedocs-preview jupytergis end -->