### PR TITLE
Update prettier config to always use trailing commas

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "singleQuote": true,
-  "trailingComma": "none",
+  "trailingComma": "all",
   "arrowParens": "avoid",
   "endOfLine": "auto"
 }

--- a/docs/contributor_guide/how-tos/commands/index.md
+++ b/docs/contributor_guide/how-tos/commands/index.md
@@ -24,7 +24,7 @@ is a behavior that can be triggered from a menu in the JupyterGIS UI.
   ```typescript
   const iconObject = {
     // ...
-    [CommandIDs.myNewCommand]: { iconClass: 'fas fa-question' }
+    [CommandIDs.myNewCommand]: { iconClass: 'fas fa-question' },
     // ...
   };
   ```
@@ -46,7 +46,7 @@ is a behavior that can be triggered from a menu in the JupyterGIS UI.
       execute: (): void => {
         // ...
       },
-      ...icons.get(CommandIDs.myNewCommand)
+      ...icons.get(CommandIDs.myNewCommand),
     });
 
     // ...
@@ -80,8 +80,8 @@ is a behavior that can be triggered from a menu in the JupyterGIS UI.
           new CommandToolbarButton({
             id: CommandIDs.myNewCommand,
             label: '',
-            commands: options.commands
-          })
+            commands: options.commands,
+          }),
         );
 
         // ...

--- a/packages/base/src/annotations/components/Annotation.tsx
+++ b/packages/base/src/annotations/components/Annotation.tsx
@@ -1,7 +1,7 @@
 import {
   faTrash,
   faPaperPlane,
-  faArrowsToDot
+  faArrowsToDot,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IAnnotationModel, IJupyterGISModel } from '@jupytergis/schema';
@@ -23,11 +23,11 @@ const Annotation = ({
   itemId,
   annotationModel,
   rightPanelModel,
-  children
+  children,
 }: IAnnotationProps) => {
   const [messageContent, setMessageContent] = useState('');
   const [jgisModel, setJgisModel] = useState<IJupyterGISModel | undefined>(
-    rightPanelModel?.jGISModel
+    rightPanelModel?.jGISModel,
   );
 
   const annotation = annotationModel.getAnnotation(itemId);
@@ -55,7 +55,7 @@ const Annotation = ({
     const result = await showDialog({
       title: 'Delete Annotation',
       body: 'Are you sure you want to delete this annotation?',
-      buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Delete' })]
+      buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Delete' })],
     });
 
     if (result.button.accept) {

--- a/packages/base/src/annotations/components/AnnotationFloater.tsx
+++ b/packages/base/src/annotations/components/AnnotationFloater.tsx
@@ -6,7 +6,7 @@ import Annotation, { IAnnotationProps } from './Annotation';
 
 const AnnotationFloater = ({
   itemId,
-  annotationModel: model
+  annotationModel: model,
 }: IAnnotationProps) => {
   const annotation = model.getAnnotation(itemId);
   const [isOpen, setIsOpen] = useState(annotation?.open);

--- a/packages/base/src/annotations/components/Message.tsx
+++ b/packages/base/src/annotations/components/Message.tsx
@@ -28,13 +28,13 @@ export const Message = (props: IProps): JSX.Element => {
     <div
       className="jGIS-Annotation-Message"
       style={{
-        flexFlow: self ? 'row' : 'row-reverse'
+        flexFlow: self ? 'row' : 'row-reverse',
       }}
     >
       <div
         className="jGIS-Annotation-User-Icon"
         style={{
-          backgroundColor: color
+          backgroundColor: color,
         }}
         title={author}
       >

--- a/packages/base/src/annotations/model.ts
+++ b/packages/base/src/annotations/model.ts
@@ -2,7 +2,7 @@ import {
   IAnnotation,
   IAnnotationContent,
   IAnnotationModel,
-  IJupyterGISModel
+  IJupyterGISModel,
 } from '@jupytergis/schema';
 import { User } from '@jupyterlab/services';
 import { ISignal, Signal } from '@lumino/signaling';
@@ -80,13 +80,13 @@ export class AnnotationModel implements IAnnotationModel {
   addContent(id: string, value: string): void {
     const newContent: IAnnotationContent = {
       value,
-      user: this._user
+      user: this._user,
     };
     const currentAnnotation = this.getAnnotation(id);
     if (currentAnnotation) {
       const newAnnotation: IAnnotation = {
         ...currentAnnotation,
-        contents: [...currentAnnotation.contents, newContent]
+        contents: [...currentAnnotation.contents, newContent],
       };
 
       this._model?.sharedModel.setMetadata(id, newAnnotation);

--- a/packages/base/src/classificationModes.ts
+++ b/packages/base/src/classificationModes.ts
@@ -7,7 +7,7 @@ import { InterpolationType } from './dialogs/symbology/tiff_layer/types/SingleBa
 export namespace VectorClassifications {
   export const calculateQuantileBreaks = (
     values: number[],
-    nClasses: number
+    nClasses: number,
   ) => {
     // q-th quantile of a data set:
     // value where q fraction of data is below and (1-q) fraction is above this value
@@ -48,7 +48,7 @@ export namespace VectorClassifications {
 
   export const calculateEqualIntervalBreaks = (
     values: number[],
-    nClasses: number
+    nClasses: number,
   ) => {
     const minimum = Math.min(...values);
     const maximum = Math.max(...values);
@@ -87,10 +87,10 @@ export namespace VectorClassifications {
     const n = sample.length;
 
     const matrixOne = Array.from({ length: n + 1 }, () =>
-      Array(nClasses + 1).fill(0)
+      Array(nClasses + 1).fill(0),
     );
     const matrixTwo = Array.from({ length: n + 1 }, () =>
-      Array(nClasses + 1).fill(Number.MAX_VALUE)
+      Array(nClasses + 1).fill(Number.MAX_VALUE),
     );
 
     for (let i = 1; i <= nClasses; i++) {
@@ -265,7 +265,7 @@ export namespace VectorClassifications {
 
   export const calculateLogarithmicBreaks = (
     values: number[],
-    nClasses: number
+    nClasses: number,
   ) => {
     const minimum = Math.min(...values);
     const maximum = Math.max(...values);
@@ -302,7 +302,7 @@ export namespace GeoTiffClassifications {
     nClasses: number,
     bandNumber: number,
     url: string,
-    colorRampType: string
+    colorRampType: string,
   ) => {
     const breaks: number[] = [];
     const isDiscrete = colorRampType === 'discrete';
@@ -364,7 +364,7 @@ export namespace GeoTiffClassifications {
     nClasses: number,
     minimumValue: number,
     maximumValue: number,
-    colorRampType: InterpolationType
+    colorRampType: InterpolationType,
   ) => {
     const min = minimumValue;
     const max = maximumValue;
@@ -404,7 +404,7 @@ export namespace GeoTiffClassifications {
     nClasses: number,
     minimumValue: number,
     maximumValue: number,
-    colorRampType: InterpolationType
+    colorRampType: InterpolationType,
   ) => {
     const min = minimumValue;
     const max = maximumValue;

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -8,7 +8,7 @@ import {
   JgisCoordinates,
   LayerType,
   SelectionType,
-  SourceType
+  SourceType,
 } from '@jupytergis/schema';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { showErrorMessage } from '@jupyterlab/apputils';
@@ -30,7 +30,7 @@ import keybindings from './keybindings.json';
 import {
   getSingleSelectedLayer,
   selectedLayerIsOfType,
-  processSelectedLayer
+  processSelectedLayer,
 } from './processing';
 import { getGeoJSONDataFromLayerSource, downloadFile } from './tools';
 import { JupyterGISTracker } from './types';
@@ -53,7 +53,7 @@ function loadKeybindings(commands: CommandRegistry, keybindings: any[]) {
     commands.addKeyBinding({
       command: binding.command,
       keys: binding.keys,
-      selector: binding.selector
+      selector: binding.selector,
     });
   });
 }
@@ -68,7 +68,7 @@ export function addCommands(
   formSchemaRegistry: IJGISFormSchemaRegistry,
   layerBrowserRegistry: IJGISLayerBrowserRegistry,
   state: IStateDB,
-  completionProviderManager: ICompletionProviderManager | undefined
+  completionProviderManager: ICompletionProviderManager | undefined,
 ): void {
   const trans = translator.load('jupyterlab');
   const { commands } = app;
@@ -101,14 +101,14 @@ export function addCommands(
         'VectorLayer',
         'VectorTileLayer',
         'WebGlLayer',
-        'HeatmapLayer'
+        'HeatmapLayer',
       ].includes(layer.type);
 
       return isValidLayer;
     },
     execute: Private.createSymbologyDialog(tracker, state),
 
-    ...icons.get(CommandIDs.symbology)
+    ...icons.get(CommandIDs.symbology),
   });
 
   commands.addCommand(CommandIDs.redo, {
@@ -125,7 +125,7 @@ export function addCommands(
         return current.model.sharedModel.redo();
       }
     },
-    ...icons.get(CommandIDs.redo)?.icon
+    ...icons.get(CommandIDs.redo)?.icon,
   });
 
   commands.addCommand(CommandIDs.undo, {
@@ -142,7 +142,7 @@ export function addCommands(
         return current.model.sharedModel.undo();
       }
     },
-    ...icons.get(CommandIDs.undo)
+    ...icons.get(CommandIDs.undo),
   });
 
   commands.addCommand(CommandIDs.identify, {
@@ -160,7 +160,7 @@ export function addCommands(
       const canIdentify = [
         'VectorLayer',
         'ShapefileLayer',
-        'WebGlLayer'
+        'WebGlLayer',
       ].includes(selectedLayer.type);
       const isIdentifying = current.model.isIdentifying;
 
@@ -178,7 +178,7 @@ export function addCommands(
         return false;
       }
       return ['VectorLayer', 'ShapefileLayer', 'WebGlLayer'].includes(
-        selectedLayer.type
+        selectedLayer.type,
       );
     },
     execute: args => {
@@ -205,7 +205,7 @@ export function addCommands(
       current.model.toggleIdentify();
       commands.notifyCommandChanged(CommandIDs.identify);
     },
-    ...icons.get(CommandIDs.identify)
+    ...icons.get(CommandIDs.identify),
   });
 
   commands.addCommand(CommandIDs.temporalController, {
@@ -254,7 +254,7 @@ export function addCommands(
       current.model.toggleTemporalController();
       commands.notifyCommandChanged(CommandIDs.temporalController);
     },
-    ...icons.get(CommandIDs.temporalController)
+    ...icons.get(CommandIDs.temporalController),
   });
 
   /**
@@ -270,9 +270,9 @@ export function addCommands(
     execute: Private.createLayerBrowser(
       tracker,
       layerBrowserRegistry,
-      formSchemaRegistry
+      formSchemaRegistry,
     ),
-    ...icons.get(CommandIDs.openLayerBrowser)
+    ...icons.get(CommandIDs.openLayerBrowser),
   });
 
   /**
@@ -293,13 +293,13 @@ export function addCommands(
       createSource: true,
       sourceData: {
         minZoom: 0,
-        maxZoom: 24
+        maxZoom: 24,
       },
       layerData: { name: 'Custom Raster Tile Layer' },
       sourceType: 'RasterSource',
-      layerType: 'RasterLayer'
+      layerType: 'RasterLayer',
     }),
-    ...icons.get(CommandIDs.newRasterEntry)
+    ...icons.get(CommandIDs.newRasterEntry),
   });
 
   commands.addCommand(CommandIDs.newVectorTileEntry, {
@@ -318,9 +318,9 @@ export function addCommands(
       sourceData: { minZoom: 0, maxZoom: 24 },
       layerData: { name: 'Custom Vector Tile Layer' },
       sourceType: 'VectorTileSource',
-      layerType: 'VectorTileLayer'
+      layerType: 'VectorTileLayer',
     }),
-    ...icons.get(CommandIDs.newVectorTileEntry)
+    ...icons.get(CommandIDs.newVectorTileEntry),
   });
 
   commands.addCommand(CommandIDs.buffer, {
@@ -344,12 +344,12 @@ export function addCommands(
             'SQLITE',
             '-sql',
             sqlQuery,
-            'output.geojson'
-          ]
+            'output.geojson',
+          ],
         },
-        app
+        app,
       );
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.dissolve, {
@@ -374,12 +374,12 @@ export function addCommands(
             'SQLITE',
             '-sql',
             sqlQuery,
-            'output.geojson'
-          ]
+            'output.geojson',
+          ],
         },
-        app
+        app,
       );
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.newGeoJSONEntry, {
@@ -397,9 +397,9 @@ export function addCommands(
       createSource: true,
       layerData: { name: 'Custom GeoJSON Layer' },
       sourceType: 'GeoJSONSource',
-      layerType: 'VectorLayer'
+      layerType: 'VectorLayer',
     }),
-    ...icons.get(CommandIDs.newGeoJSONEntry)
+    ...icons.get(CommandIDs.newGeoJSONEntry),
   });
 
   commands.addCommand(CommandIDs.newHillshadeEntry, {
@@ -417,9 +417,9 @@ export function addCommands(
       createSource: true,
       layerData: { name: 'Custom Hillshade Layer' },
       sourceType: 'RasterDemSource',
-      layerType: 'HillshadeLayer'
+      layerType: 'HillshadeLayer',
     }),
-    ...icons.get(CommandIDs.newHillshadeEntry)
+    ...icons.get(CommandIDs.newHillshadeEntry),
   });
 
   commands.addCommand(CommandIDs.newImageEntry, {
@@ -442,14 +442,14 @@ export function addCommands(
           [-80.425, 46.437],
           [-71.516, 46.437],
           [-71.516, 37.936],
-          [-80.425, 37.936]
-        ]
+          [-80.425, 37.936],
+        ],
       },
       layerData: { name: 'Custom Image Layer' },
       sourceType: 'ImageSource',
-      layerType: 'ImageLayer'
+      layerType: 'ImageLayer',
     }),
-    ...icons.get(CommandIDs.newImageEntry)
+    ...icons.get(CommandIDs.newImageEntry),
   });
 
   commands.addCommand(CommandIDs.newVideoEntry, {
@@ -469,20 +469,20 @@ export function addCommands(
         name: 'Custom Video Source',
         urls: [
           'https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4',
-          'https://static-assets.mapbox.com/mapbox-gl-js/drone.webm'
+          'https://static-assets.mapbox.com/mapbox-gl-js/drone.webm',
         ],
         coordinates: [
           [-122.51596391201019, 37.56238816766053],
           [-122.51467645168304, 37.56410183312965],
           [-122.51309394836426, 37.563391708549425],
-          [-122.51423120498657, 37.56161849366671]
-        ]
+          [-122.51423120498657, 37.56161849366671],
+        ],
       },
       layerData: { name: 'Custom Video Layer' },
       sourceType: 'VideoSource',
-      layerType: 'RasterLayer'
+      layerType: 'RasterLayer',
     }),
-    ...icons.get(CommandIDs.newVideoEntry)
+    ...icons.get(CommandIDs.newVideoEntry),
   });
 
   commands.addCommand(CommandIDs.newGeoTiffEntry, {
@@ -500,13 +500,13 @@ export function addCommands(
       createSource: true,
       sourceData: {
         name: 'Custom GeoTiff Source',
-        urls: [{}]
+        urls: [{}],
       },
       layerData: { name: 'Custom GeoTiff Layer' },
       sourceType: 'GeoTiffSource',
-      layerType: 'WebGlLayer'
+      layerType: 'WebGlLayer',
     }),
-    ...icons.get(CommandIDs.newGeoTiffEntry)
+    ...icons.get(CommandIDs.newGeoTiffEntry),
   });
 
   commands.addCommand(CommandIDs.newShapefileEntry, {
@@ -525,9 +525,9 @@ export function addCommands(
       sourceData: { name: 'Custom Shapefile Source' },
       layerData: { name: 'Custom Shapefile Layer' },
       sourceType: 'ShapefileSource',
-      layerType: 'VectorLayer'
+      layerType: 'VectorLayer',
     }),
-    ...icons.get(CommandIDs.newShapefileEntry)
+    ...icons.get(CommandIDs.newShapefileEntry),
   });
 
   /**
@@ -544,7 +544,7 @@ export function addCommands(
           model?.sharedModel.updateLayer(layerId, layer);
         }
       });
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.removeLayer, {
@@ -554,7 +554,7 @@ export function addCommands(
       Private.removeSelectedItems(model, 'layer', selection => {
         model?.removeLayer(selection);
       });
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.renameGroup, {
@@ -564,7 +564,7 @@ export function addCommands(
       await Private.renameSelectedItem(model, 'group', (groupName, newName) => {
         model?.renameLayerGroup(groupName, newName);
       });
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.removeGroup, {
@@ -574,7 +574,7 @@ export function addCommands(
       Private.removeSelectedItems(model, 'group', selection => {
         model?.removeLayerGroup(selection);
       });
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.moveLayersToGroup, {
@@ -591,7 +591,7 @@ export function addCommands(
       }
 
       model.moveItemsToGroup(Object.keys(selectedLayers), groupName);
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.moveLayerToNewGroup, {
@@ -650,11 +650,11 @@ export function addCommands(
 
       const newLayerGroup: IJGISLayerGroup = {
         name: newName,
-        layers: layers
+        layers: layers,
       };
 
       model.addNewLayerGroup(selectedLayers, newLayerGroup);
-    }
+    },
   });
 
   /**
@@ -671,7 +671,7 @@ export function addCommands(
           model?.sharedModel.updateSource(sourceId, source);
         }
       });
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.removeSource, {
@@ -684,11 +684,11 @@ export function addCommands(
         } else {
           showErrorMessage(
             'Remove source error',
-            'The source is used by a layer.'
+            'The source is used by a layer.',
           );
         }
       });
-    }
+    },
   });
 
   // Console commands
@@ -710,7 +710,7 @@ export function addCommands(
     execute: async () => {
       await Private.toggleConsole(tracker);
       commands.notifyCommandChanged(CommandIDs.toggleConsole);
-    }
+    },
   });
   commands.addCommand(CommandIDs.executeConsole, {
     label: trans.__('Execute console'),
@@ -720,7 +720,7 @@ export function addCommands(
         ? tracker.currentWidget.model.sharedModel.editable
         : false;
     },
-    execute: () => Private.executeConsole(tracker)
+    execute: () => Private.executeConsole(tracker),
   });
   commands.addCommand(CommandIDs.removeConsole, {
     label: trans.__('Remove console'),
@@ -730,7 +730,7 @@ export function addCommands(
         ? tracker.currentWidget.model.sharedModel.editable
         : false;
     },
-    execute: () => Private.removeConsole(tracker)
+    execute: () => Private.removeConsole(tracker),
   });
 
   commands.addCommand(CommandIDs.invokeCompleter, {
@@ -749,7 +749,7 @@ export function addCommands(
       if (id) {
         return completionProviderManager.invoke(id);
       }
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.selectCompleter, {
@@ -768,7 +768,7 @@ export function addCommands(
       if (id) {
         return completionProviderManager.select(id);
       }
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.zoomToLayer, {
@@ -788,7 +788,7 @@ export function addCommands(
 
       const layerId = Object.keys(selectedItems)[0];
       model.centerOnPosition(layerId);
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.downloadGeoJSON, {
@@ -808,7 +808,9 @@ export function addCommands(
       const sources = model.sharedModel.sources ?? {};
 
       const exportSchema = {
-        ...(formSchemaRegistry.getSchemas().get('ExportGeoJSONSchema') as IDict)
+        ...(formSchemaRegistry
+          .getSchemas()
+          .get('ExportGeoJSONSchema') as IDict),
       };
 
       const formValues = await new Promise<IDict>(resolve => {
@@ -822,7 +824,7 @@ export function addCommands(
           syncData: (props: IDict) => {
             resolve(props);
             dialog.dispose();
-          }
+          },
         });
 
         dialog.launch();
@@ -844,9 +846,9 @@ export function addCommands(
       downloadFile(
         geojsonString,
         `${exportFileName}.geojson`,
-        'application/geo+json'
+        'application/geo+json',
       );
-    }
+    },
   });
 
   commands.addCommand(CommandIDs.getGeolocation, {
@@ -856,16 +858,16 @@ export function addCommands(
       const options = {
         enableHighAccuracy: true,
         timeout: 5000,
-        maximumAge: 0
+        maximumAge: 0,
       };
       const success = (pos: any) => {
         const location: Coordinate = fromLonLat([
           pos.coords.longitude,
-          pos.coords.latitude
+          pos.coords.latitude,
         ]);
         const Jgislocation: JgisCoordinates = {
           x: location[0],
-          y: location[1]
+          y: location[1],
         };
         if (viewModel) {
           viewModel.geolocationChanged.emit(Jgislocation);
@@ -876,7 +878,7 @@ export function addCommands(
       };
       navigator.geolocation.getCurrentPosition(success, error, options);
     },
-    icon: targetWithCenterIcon
+    icon: targetWithCenterIcon,
   });
 
   loadKeybindings(commands, keybindings);
@@ -886,7 +888,7 @@ namespace Private {
   export function createLayerBrowser(
     tracker: JupyterGISTracker,
     layerBrowserRegistry: IJGISLayerBrowserRegistry,
-    formSchemaRegistry: IJGISFormSchemaRegistry
+    formSchemaRegistry: IJGISFormSchemaRegistry,
   ) {
     return async () => {
       const current = tracker.currentWidget;
@@ -898,7 +900,7 @@ namespace Private {
       const dialog = new LayerBrowserWidget({
         model: current.model,
         registry: layerBrowserRegistry.getRegistryLayers(),
-        formSchemaRegistry
+        formSchemaRegistry,
       });
       await dialog.launch();
     };
@@ -906,7 +908,7 @@ namespace Private {
 
   export function createSymbologyDialog(
     tracker: JupyterGISTracker,
-    state: IStateDB
+    state: IStateDB,
   ) {
     return async () => {
       const current = tracker.currentWidget;
@@ -917,7 +919,7 @@ namespace Private {
 
       const dialog = new SymbologyWidget({
         model: current.model,
-        state
+        state,
       });
       await dialog.launch();
     };
@@ -932,7 +934,7 @@ namespace Private {
     sourceData,
     layerData,
     sourceType,
-    layerType
+    layerType,
   }: ICreateEntry) {
     return async () => {
       const current = tracker.currentWidget;
@@ -950,7 +952,7 @@ namespace Private {
         sourceType,
         layerData,
         layerType,
-        formSchemaRegistry
+        formSchemaRegistry,
       });
       await dialog.launch();
     };
@@ -959,7 +961,7 @@ namespace Private {
   export async function getUserInputForRename(
     text: HTMLElement,
     input: HTMLInputElement,
-    original: string
+    original: string,
   ): Promise<string> {
     const parent = text.parentElement as HTMLElement;
     parent.replaceChild(input, text);
@@ -992,7 +994,7 @@ namespace Private {
   export function removeSelectedItems(
     model: IJupyterGISModel | undefined,
     itemTypeToRemove: SelectionType,
-    removeFunction: (id: string) => void
+    removeFunction: (id: string) => void,
   ) {
     const selected = model?.localState?.selected?.value;
 
@@ -1011,7 +1013,7 @@ namespace Private {
   export async function renameSelectedItem(
     model: IJupyterGISModel | undefined,
     itemType: SelectionType,
-    callback: (itemId: string, newName: string) => void
+    callback: (itemId: string, newName: string) => void,
   ) {
     const selectedItems = model?.localState?.selected.value;
 
@@ -1051,7 +1053,7 @@ namespace Private {
     const newName = await Private.getUserInputForRename(
       node,
       edit,
-      originalName
+      originalName,
     );
 
     if (!newName) {
@@ -1082,7 +1084,7 @@ namespace Private {
   }
 
   export async function toggleConsole(
-    tracker: JupyterGISTracker
+    tracker: JupyterGISTracker,
   ): Promise<void> {
     const current = tracker.currentWidget;
 

--- a/packages/base/src/console/consoleview.ts
+++ b/packages/base/src/console/consoleview.ts
@@ -6,7 +6,7 @@ import {
   closeIcon,
   CommandToolbarButton,
   expandIcon,
-  Toolbar
+  Toolbar,
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { BoxPanel, Widget } from '@lumino/widgets';
@@ -24,7 +24,7 @@ export class ConsoleView extends BoxPanel {
       contentFactory,
       mimeTypeService,
       rendermime: clonedRendermime,
-      kernelPreference: { name: 'python3', shutdownOnDispose: true }
+      kernelPreference: { name: 'python3', shutdownOnDispose: true },
     });
     this._consolePanel.console.node.dataset.jpInteractionMode = 'notebook';
     this.addWidget(this._consolePanel);
@@ -38,8 +38,8 @@ export class ConsoleView extends BoxPanel {
         label: '',
         icon: expandIcon,
         id: 'jupytergis:toggleConsole',
-        commands: options.commandRegistry
-      })
+        commands: options.commandRegistry,
+      }),
     );
     this._consolePanel.toolbar.addItem(
       'close',
@@ -47,8 +47,8 @@ export class ConsoleView extends BoxPanel {
         label: '',
         icon: closeIcon,
         id: 'jupytergis:removeConsole',
-        commands: options.commandRegistry
-      })
+        commands: options.commandRegistry,
+      }),
     );
   }
 

--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -7,7 +7,7 @@ import {
   infoIcon,
   moundIcon,
   rasterIcon,
-  vectorSquareIcon
+  vectorSquareIcon,
 } from './icons';
 
 /**
@@ -99,12 +99,12 @@ const iconObject = {
   [CommandIDs.newGeoTiffEntry]: { iconClass: 'fa fa-image' },
   [CommandIDs.symbology]: { iconClass: 'fa fa-brush' },
   [CommandIDs.identify]: { icon: infoIcon },
-  [CommandIDs.temporalController]: { icon: clockIcon }
+  [CommandIDs.temporalController]: { icon: clockIcon },
 };
 
 /**
  * The registered icons
  */
 export const icons = new Map<string, IRegisteredIcon>(
-  Object.entries(iconObject)
+  Object.entries(iconObject),
 );

--- a/packages/base/src/dialogs/ProcessingFormDialog.tsx
+++ b/packages/base/src/dialogs/ProcessingFormDialog.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import {
   BaseForm,
-  IBaseFormProps
+  IBaseFormProps,
 } from '@/src/formbuilder/objectform/baseform';
 import { DissolveForm } from '@/src/formbuilder/objectform/process';
 
@@ -19,7 +19,7 @@ export interface IProcessingFormDialogOptions extends IBaseFormProps {
   syncSelectedPropField?: (
     id: string | null,
     value: any,
-    parentType: 'dialog' | 'panel'
+    parentType: 'dialog' | 'panel',
   ) => void;
   model: IJupyterGISModel;
   processingType: 'Buffer' | 'Dissolve' | 'Export';
@@ -42,7 +42,7 @@ const ProcessingFormWrapper = (props: IProcessingFormWrapperProps) => {
 
   Promise.all([
     props.okSignalPromise.promise,
-    props.formErrorSignalPromise?.promise
+    props.formErrorSignalPromise?.promise,
   ]).then(([ok, formChanged]) => {
     okSignal.current = ok;
     formErrorSignal.current = formChanged;
@@ -85,17 +85,17 @@ export class ProcessingFormDialog extends Dialog<IDict> {
     const layers = options.model.sharedModel.layers ?? {};
     const layerOptions = Object.keys(layers).map(layerId => ({
       value: layerId,
-      label: layers[layerId].name
+      label: layers[layerId].name,
     }));
 
     // Modify schema to include layer options and layer name field
     if (options.schema) {
       if (options.schema.properties?.inputLayer) {
         options.schema.properties.inputLayer.enum = layerOptions.map(
-          option => option.value
+          option => option.value,
         );
         options.schema.properties.inputLayer.enumNames = layerOptions.map(
-          option => option.label
+          option => option.label,
         );
       }
 
@@ -103,7 +103,7 @@ export class ProcessingFormDialog extends Dialog<IDict> {
       if (!options.schema.properties?.outputLayerName) {
         options.schema.properties.outputLayerName = {
           type: 'string',
-          title: 'outputLayerName'
+          title: 'outputLayerName',
           // default: ''
         };
       }
@@ -147,7 +147,7 @@ export class ProcessingFormDialog extends Dialog<IDict> {
     super({
       title: options.title,
       body,
-      buttons: [Dialog.cancelButton(), Dialog.okButton()]
+      buttons: [Dialog.cancelButton(), Dialog.okButton()],
     });
 
     this.okSignal = new Signal(this);

--- a/packages/base/src/dialogs/layerBrowserDialog.tsx
+++ b/packages/base/src/dialogs/layerBrowserDialog.tsx
@@ -7,7 +7,7 @@ import {
   IJGISLayerDocChange,
   IJGISSource,
   IJupyterGISModel,
-  IRasterLayerGalleryEntry
+  IRasterLayerGalleryEntry,
 } from '@jupytergis/schema';
 import { Dialog } from '@jupyterlab/apputils';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
@@ -30,7 +30,7 @@ export const LayerBrowserComponent = ({
   registry,
   formSchemaRegistry,
   okSignalPromise,
-  cancel
+  cancel,
 }: ILayerBrowserDialogProps) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [activeLayers, setActiveLayers] = useState<string[]>([]);
@@ -44,7 +44,7 @@ export const LayerBrowserComponent = ({
   const providers = [...new Set(registry.map(item => item.source.provider))];
 
   const filteredGallery = galleryWithCategory.filter(item =>
-    item.name.toLowerCase().includes(searchTerm)
+    item.name.toLowerCase().includes(searchTerm),
   );
 
   useEffect(() => {
@@ -62,8 +62,8 @@ export const LayerBrowserComponent = ({
     // The split is to get rid of the 'Layer' part of the name to match the names in the gallery
     setActiveLayers(
       Object.values(model.sharedModel.layers).map(
-        layer => layer.name.split(' ')[0]
-      )
+        layer => layer.name.split(' ')[0],
+      ),
     );
   };
 
@@ -81,7 +81,7 @@ export const LayerBrowserComponent = ({
     const filteredGallery = sameAsOld
       ? registry
       : registry.filter(item =>
-          item.source.provider?.includes(categoryTab.innerText)
+          item.source.provider?.includes(categoryTab.innerText),
         );
 
     setGalleryWithCategory(filteredGallery);
@@ -103,16 +103,16 @@ export const LayerBrowserComponent = ({
     const sourceModel: IJGISSource = {
       type: 'RasterSource',
       name: tile.name,
-      parameters: tile.source
+      parameters: tile.source,
     };
 
     const layerModel: IJGISLayer = {
       type: 'RasterLayer',
       parameters: {
-        source: sourceId
+        source: sourceId,
       },
       visible: true,
-      name: tile.name + ' Layer'
+      name: tile.name + ' Layer',
     };
 
     model.sharedModel.addSource(sourceId, sourceModel);
@@ -135,13 +135,13 @@ export const LayerBrowserComponent = ({
           layerType={'RasterLayer'}
           sourceType={'RasterSource'}
           layerData={{
-            name: 'Custom Raster'
+            name: 'Custom Raster',
           }}
           sourceData={{
             url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             maxZoom: 24,
             minZoom: 0,
-            attribution: '(C) OpenStreetMap contributors'
+            attribution: '(C) OpenStreetMap contributors',
           }}
           okSignalPromise={okSignalPromise}
           cancel={cancel}

--- a/packages/base/src/dialogs/layerCreationFormDialog.tsx
+++ b/packages/base/src/dialogs/layerCreationFormDialog.tsx
@@ -37,7 +37,7 @@ export const CreationFormWrapper = (props: ICreationFormWrapperProps) => {
 
   Promise.all([
     props.okSignalPromise.promise,
-    props.formErrorSignalPromise?.promise
+    props.formErrorSignalPromise?.promise,
   ]).then(([ok, formChanged]) => {
     okSignal.current = ok;
     formErrorSignal.current = formChanged;
@@ -102,7 +102,7 @@ export class LayerCreationFormDialog extends Dialog<IDict> {
     super({
       title: options.title,
       body,
-      buttons: [Dialog.cancelButton(), Dialog.okButton()]
+      buttons: [Dialog.cancelButton(), Dialog.okButton()],
     });
 
     this.okSignal = new Signal(this);

--- a/packages/base/src/dialogs/symbology/classificationModes.ts
+++ b/packages/base/src/dialogs/symbology/classificationModes.ts
@@ -7,7 +7,7 @@ import { InterpolationType } from './tiff_layer/types/SingleBandPseudoColor';
 export namespace VectorClassifications {
   export const calculateQuantileBreaks = (
     values: number[],
-    nClasses: number
+    nClasses: number,
   ) => {
     // q-th quantile of a data set:
     // value where q fraction of data is below and (1-q) fraction is above this value
@@ -48,7 +48,7 @@ export namespace VectorClassifications {
 
   export const calculateEqualIntervalBreaks = (
     values: number[],
-    nClasses: number
+    nClasses: number,
   ) => {
     const minimum = Math.min(...values);
     const maximum = Math.max(...values);
@@ -87,10 +87,10 @@ export namespace VectorClassifications {
     const n = sample.length;
 
     const matrixOne = Array.from({ length: n + 1 }, () =>
-      Array(nClasses + 1).fill(0)
+      Array(nClasses + 1).fill(0),
     );
     const matrixTwo = Array.from({ length: n + 1 }, () =>
-      Array(nClasses + 1).fill(Number.MAX_VALUE)
+      Array(nClasses + 1).fill(Number.MAX_VALUE),
     );
 
     for (let i = 1; i <= nClasses; i++) {
@@ -265,7 +265,7 @@ export namespace VectorClassifications {
 
   export const calculateLogarithmicBreaks = (
     values: number[],
-    nClasses: number
+    nClasses: number,
   ) => {
     const minimum = Math.min(...values);
     const maximum = Math.max(...values);
@@ -302,7 +302,7 @@ export namespace GeoTiffClassifications {
     nClasses: number,
     bandNumber: number,
     url: string,
-    colorRampType: string
+    colorRampType: string,
   ) => {
     const breaks: number[] = [];
     const isDiscrete = colorRampType === 'discrete';
@@ -364,7 +364,7 @@ export namespace GeoTiffClassifications {
     nClasses: number,
     minimumValue: number,
     maximumValue: number,
-    colorRampType: InterpolationType
+    colorRampType: InterpolationType,
   ) => {
     const min = minimumValue;
     const max = maximumValue;
@@ -404,7 +404,7 @@ export namespace GeoTiffClassifications {
     nClasses: number,
     minimumValue: number,
     maximumValue: number,
-    colorRampType: InterpolationType
+    colorRampType: InterpolationType,
   ) => {
     const min = minimumValue;
     const max = maximumValue;

--- a/packages/base/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent.tsx
@@ -16,7 +16,7 @@ interface ICanvasSelectComponentProps {
 
 const CanvasSelectComponent = ({
   selectedRamp,
-  setSelected
+  setSelected,
 }: ICanvasSelectComponentProps) => {
   const colorRampNames = [
     'jet',
@@ -60,7 +60,7 @@ const CanvasSelectComponent = ({
     'temperature',
     'turbidity',
     'velocity-blue',
-    'velocity-green'
+    'velocity-green',
     // 'cubehelix' 16 steps min
   ];
 
@@ -75,7 +75,7 @@ const CanvasSelectComponent = ({
       const colorRamp = colormap({
         colormap: name,
         nshades: 255,
-        format: 'rgbaString'
+        format: 'rgbaString',
       });
       const colorMap = { name: name, colors: colorRamp };
       colorMapList.push(colorMap);

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
@@ -14,7 +14,7 @@ interface IColorRampProps {
     selectedMode: string,
     numberOfShades: string,
     selectedRamp: string,
-    setIsLoading: (isLoading: boolean) => void
+    setIsLoading: (isLoading: boolean) => void,
   ) => void;
   showModeRow: boolean;
 }
@@ -29,7 +29,7 @@ const ColorRamp = ({
   layerParams,
   modeOptions,
   classifyFunc,
-  showModeRow
+  showModeRow,
 }: IColorRampProps) => {
   const [selectedRamp, setSelectedRamp] = useState('');
   const [selectedMode, setSelectedMode] = useState('');
@@ -81,7 +81,7 @@ const ColorRamp = ({
               selectedMode,
               numberOfShades,
               selectedRamp,
-              setIsLoading
+              setIsLoading,
             )
           }
         >

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ModeSelectRow.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ModeSelectRow.tsx
@@ -11,7 +11,7 @@ const ModeSelectRow = ({
   setNumberOfShades,
   selectedMode,
   setSelectedMode,
-  modeOptions
+  modeOptions,
 }: IModeSelectRowProps) => {
   return (
     <div className="jp-gis-symbology-row">

--- a/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
@@ -13,15 +13,15 @@ interface IStopContainerProps {
 const StopContainer = ({
   selectedMethod,
   stopRows,
-  setStopRows
+  setStopRows,
 }: IStopContainerProps) => {
   const addStopRow = () => {
     setStopRows([
       {
         stop: 0,
-        output: [0, 0, 0, 1]
+        output: [0, 0, 0, 1],
       },
-      ...stopRows
+      ...stopRows,
     ]);
   };
 

--- a/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
@@ -12,7 +12,7 @@ const StopRow = ({
   stopRows,
   setStopRows,
   deleteRow,
-  useNumber
+  useNumber,
 }: {
   index: number;
   value: number;
@@ -56,7 +56,7 @@ const StopRow = ({
       parseInt(result[1], 16),
       parseInt(result[2], 16),
       parseInt(result[3], 16),
-      1 // TODO: Make alpha customizable?
+      1, // TODO: Make alpha customizable?
     ];
 
     return rgbValues;

--- a/packages/base/src/dialogs/symbology/hooks/useGetBandInfo.ts
+++ b/packages/base/src/dialogs/symbology/hooks/useGetBandInfo.ts
@@ -52,7 +52,7 @@ const useGetBandInfo = (model: IJupyterGISModel, layer: IJGISLayer) => {
         const preloadedFile = await loadFile({
           filepath: sourceInfo.url,
           type: 'GeoTiffSource',
-          model
+          model,
         });
 
         if (!preloadedFile.file) {
@@ -72,8 +72,8 @@ const useGetBandInfo = (model: IJupyterGISModel, layer: IJGISLayer) => {
           band: i,
           stats: {
             minimum: sourceInfo.min ?? 0,
-            maximum: sourceInfo.max ?? 100
-          }
+            maximum: sourceInfo.max ?? 100,
+          },
         });
       }
 

--- a/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
+++ b/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
@@ -18,7 +18,7 @@ interface IUseGetPropertiesResult {
 
 export const useGetProperties = ({
   layerId,
-  model
+  model,
 }: IUseGetPropertiesProps): IUseGetPropertiesResult => {
   const [featureProperties, setFeatureProperties] = useState<any>({});
   const [isLoading, setIsLoading] = useState(true);
@@ -40,7 +40,7 @@ export const useGetProperties = ({
       const data = await loadFile({
         filepath: source.parameters?.path,
         type: 'GeoJSONSource',
-        model: model
+        model: model,
       });
 
       if (!data) {

--- a/packages/base/src/dialogs/symbology/symbologyDialog.tsx
+++ b/packages/base/src/dialogs/symbology/symbologyDialog.tsx
@@ -30,7 +30,7 @@ const SymbologyDialog = ({
   model,
   state,
   okSignalPromise,
-  cancel
+  cancel,
 }: ISymbologyDialogProps) => {
   const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
   const [componentToRender, setComponentToRender] = useState<any>(null);

--- a/packages/base/src/dialogs/symbology/symbologyUtils.ts
+++ b/packages/base/src/dialogs/symbology/symbologyUtils.ts
@@ -37,7 +37,7 @@ export namespace VectorUtils {
             if (!seenPairs.has(pairKey)) {
               valueColorPairs.push({
                 stop: color[key][i],
-                output: color[key][i + 1]
+                output: color[key][i + 1],
               });
               seenPairs.add(pairKey);
             }
@@ -50,7 +50,7 @@ export namespace VectorUtils {
             if (!seenPairs.has(pairKey)) {
               valueColorPairs.push({
                 stop: color[key][i][2],
-                output: color[key][i + 1]
+                output: color[key][i + 1],
               });
               seenPairs.add(pairKey);
             }
@@ -79,7 +79,7 @@ export namespace VectorUtils {
     for (let i = 3; i < color['circle-radius'].length; i += 2) {
       const obj: IStopRow = {
         stop: color['circle-radius'][i],
-        output: color['circle-radius'][i + 1]
+        output: color['circle-radius'][i + 1],
       };
       stopOutputPairs.push(obj);
     }
@@ -92,12 +92,12 @@ export namespace Utils {
   export const getValueColorPairs = (
     stops: number[],
     selectedRamp: string,
-    nClasses: number
+    nClasses: number,
   ) => {
     let colorMap = colormap({
       colormap: selectedRamp,
       nshades: nClasses > 9 ? nClasses : 9,
-      format: 'rgba'
+      format: 'rgba',
     });
 
     const valueColorPairs: IStopRow[] = [];
@@ -112,7 +112,7 @@ export namespace Utils {
 
       // Get the last n/2 elements from the second array
       const secondPart = colorMap.slice(
-        colorMap.length - (stops.length - firstPart.length)
+        colorMap.length - (stops.length - firstPart.length),
       );
 
       // Create the new array by combining the first and last parts

--- a/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
@@ -9,7 +9,7 @@ const TiffRendering = ({
   state,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   const renderTypes = ['Singleband Pseudocolor', 'Multiband Color'];
   const [selectedRenderType, setSelectedRenderType] = useState<string>();

--- a/packages/base/src/dialogs/symbology/tiff_layer/components/BandRow.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/components/BandRow.tsx
@@ -29,7 +29,7 @@ const BandRow = ({
   bandRows,
   setSelectedBand,
   setBandRows,
-  isMultibandColor
+  isMultibandColor,
 }: IBandRowProps) => {
   const [minValue, setMinValue] = useState(bandRow?.stats.minimum);
   const [maxValue, setMaxValue] = useState(bandRow?.stats.maximum);
@@ -96,7 +96,7 @@ const BandRow = ({
             style={{
               display: 'flex',
               justifyContent: 'space-between',
-              width: '50%'
+              width: '50%',
             }}
           >
             <label htmlFor="band-min" style={{ alignSelf: 'center' }}>
@@ -115,7 +115,7 @@ const BandRow = ({
               display: 'flex',
               justifyContent: 'space-between',
               width: '50%',
-              paddingRight: '2px'
+              paddingRight: '2px',
             }}
           >
             <label htmlFor="band-max" style={{ alignSelf: 'center' }}>

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
@@ -20,7 +20,7 @@ const MultibandColor = ({
   model,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   if (!layerId) {
     return;
@@ -36,7 +36,7 @@ const MultibandColor = ({
     red: 1,
     green: 2,
     blue: 3,
-    alpha: 4
+    alpha: 4,
   });
 
   const numOfBandsRef = useRef(0);
@@ -44,7 +44,7 @@ const MultibandColor = ({
     red: selectedBands.red,
     green: selectedBands.green,
     blue: selectedBands.blue,
-    alpha: selectedBands.alpha
+    alpha: selectedBands.alpha,
   });
 
   useEffect(() => {
@@ -82,7 +82,7 @@ const MultibandColor = ({
   const updateBand = (color: rgbEnum, value: number) => {
     setSelectedBands(prevBands => ({
       ...prevBands,
-      [color]: value
+      [color]: value,
     }));
   };
 
@@ -112,7 +112,7 @@ const MultibandColor = ({
       redBand: selectedBandsRef.current.red,
       greenBand: selectedBandsRef.current.green,
       blueBand: selectedBandsRef.current.blue,
-      alphaBand: selectedBandsRef.current.alpha
+      alphaBand: selectedBandsRef.current.alpha,
     };
 
     layer.parameters.symbologyState = symbologyState;

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
@@ -6,15 +6,15 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { GeoTiffClassifications } from '@/src/dialogs/symbology/classificationModes';
 import ColorRamp, {
-  ColorRampOptions
+  ColorRampOptions,
 } from '@/src/dialogs/symbology/components/color_ramp/ColorRamp';
 import StopRow from '@/src/dialogs/symbology/components/color_stops/StopRow';
 import useGetBandInfo, {
-  IBandRow
+  IBandRow,
 } from '@/src/dialogs/symbology/hooks/useGetBandInfo';
 import {
   IStopRow,
-  ISymbologyDialogProps
+  ISymbologyDialogProps,
 } from '@/src/dialogs/symbology/symbologyDialog';
 import { Utils } from '@/src/dialogs/symbology/symbologyUtils';
 import BandRow from '@/src/dialogs/symbology/tiff_layer/components/BandRow';
@@ -27,7 +27,7 @@ const SingleBandPseudoColor = ({
   model,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   if (!layerId) {
     return;
@@ -87,7 +87,7 @@ const SingleBandPseudoColor = ({
 
   const populateOptions = async () => {
     const layerState = (await stateDb?.fetch(
-      `jupytergis:${layerId}`
+      `jupytergis:${layerId}`,
     )) as ReadonlyJSONObject;
 
     setLayerState(layerState);
@@ -129,7 +129,7 @@ const SingleBandPseudoColor = ({
         for (let i = 5; i < color.length; i += 2) {
           const obj: IStopRow = {
             stop: scaleValue(color[i], isQuantile),
-            output: color[i + 1]
+            output: color[i + 1],
           };
           valueColorPairs.push(obj);
         }
@@ -146,7 +146,7 @@ const SingleBandPseudoColor = ({
         for (let i = 3; i < color.length - 1; i += 2) {
           const obj: IStopRow = {
             stop: scaleValue(color[i][2], isQuantile),
-            output: color[i + 1]
+            output: color[i + 1],
           };
           valueColorPairs.push(obj);
         }
@@ -216,7 +216,7 @@ const SingleBandPseudoColor = ({
           colorExpr.push([
             '<=',
             ['band', selectedBand],
-            unscaleValue(stop.stop, isQuantile)
+            unscaleValue(stop.stop, isQuantile),
           ]);
           colorExpr.push(stop.output);
         });
@@ -236,7 +236,7 @@ const SingleBandPseudoColor = ({
           colorExpr.push([
             '==',
             ['band', selectedBand],
-            unscaleValue(stop.stop, isQuantile)
+            unscaleValue(stop.stop, isQuantile),
           ]);
           colorExpr.push(stop.output);
         });
@@ -253,7 +253,7 @@ const SingleBandPseudoColor = ({
       interpolation: selectedFunctionRef.current,
       colorRamp: colorRampOptionsRef.current?.selectedRamp,
       nClasses: colorRampOptionsRef.current?.numberOfShades,
-      mode: colorRampOptionsRef.current?.selectedMode
+      mode: colorRampOptionsRef.current?.selectedMode,
     };
 
     layer.parameters.symbologyState = symbologyState;
@@ -268,9 +268,9 @@ const SingleBandPseudoColor = ({
     setStopRows([
       {
         stop: 0,
-        output: [0, 0, 0, 1]
+        output: [0, 0, 0, 1],
       },
-      ...stopRows
+      ...stopRows,
     ]);
   };
 
@@ -285,13 +285,13 @@ const SingleBandPseudoColor = ({
     selectedMode: string,
     numberOfShades: string,
     selectedRamp: string,
-    setIsLoading: (isLoading: boolean) => void
+    setIsLoading: (isLoading: boolean) => void,
   ) => {
     // Update layer state with selected options
     setColorRampOptions({
       selectedRamp,
       numberOfShades,
-      selectedMode
+      selectedMode,
     });
 
     let stops: number[] = [];
@@ -308,7 +308,7 @@ const SingleBandPseudoColor = ({
           nClasses,
           selectedBand,
           sourceInfo.url,
-          selectedFunction
+          selectedFunction,
         );
         break;
       case 'continuous':
@@ -316,7 +316,7 @@ const SingleBandPseudoColor = ({
           nClasses,
           currentBand.stats.minimum,
           currentBand.stats.maximum,
-          selectedFunction
+          selectedFunction,
         );
         break;
       case 'equal interval':
@@ -324,7 +324,7 @@ const SingleBandPseudoColor = ({
           nClasses,
           currentBand.stats.minimum,
           currentBand.stats.maximum,
-          selectedFunction
+          selectedFunction,
         );
         break;
       default:
@@ -336,7 +336,7 @@ const SingleBandPseudoColor = ({
     const valueColorPairs = Utils.getValueColorPairs(
       stops,
       selectedRamp,
-      nClasses
+      nClasses,
     );
 
     setStopRows(valueColorPairs);

--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -4,7 +4,7 @@ import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 import {
   getColorCodeFeatureAttributes,
-  getNumericFeatureAttributes
+  getNumericFeatureAttributes,
 } from '@/src/tools';
 import Canonical from './types/Canonical';
 import Categorized from './types/Categorized';
@@ -17,12 +17,12 @@ const VectorRendering = ({
   state,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   const [selectedRenderType, setSelectedRenderType] = useState('');
   const [componentToRender, setComponentToRender] = useState<any>(null);
   const [renderTypeOptions, setRenderTypeOptions] = useState<string[]>([
-    'Single Symbol'
+    'Single Symbol',
   ]);
 
   let RenderComponent;
@@ -37,7 +37,7 @@ const VectorRendering = ({
 
   const { featureProperties } = useGetProperties({
     layerId,
-    model: model
+    model: model,
   });
 
   useEffect(() => {
@@ -63,7 +63,7 @@ const VectorRendering = ({
     const options: Record<string, string[]> = {
       VectorLayer: vectorLayerOptions,
       VectorTileLayer: ['Single Symbol'],
-      HeatmapLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Heatmap']
+      HeatmapLayer: ['Single Symbol', 'Graduated', 'Categorized', 'Heatmap'],
     };
     setRenderTypeOptions(options[layer.type]);
   }, [featureProperties]);

--- a/packages/base/src/dialogs/symbology/vector_layer/components/ValueSelect.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/components/ValueSelect.tsx
@@ -9,7 +9,7 @@ interface IValueSelectProps {
 const ValueSelect = ({
   featureProperties,
   selectedValue,
-  setSelectedValue
+  setSelectedValue,
 }: IValueSelectProps) => {
   return (
     <div className="jp-gis-symbology-row">

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
@@ -12,7 +12,7 @@ const Canonical = ({
   state,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   const selectedValueRef = useRef<string>();
 
@@ -28,7 +28,7 @@ const Canonical = ({
   }
   const { featureProperties } = useGetProperties({
     layerId,
-    model: model
+    model: model,
   });
 
   useEffect(() => {
@@ -73,7 +73,7 @@ const Canonical = ({
 
     const symbologyState = {
       renderType: 'Canonical',
-      value: selectedValueRef.current
+      value: selectedValueRef.current,
     };
 
     layer.parameters.symbologyState = symbologyState;

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
@@ -8,7 +8,7 @@ import StopContainer from '@/src/dialogs/symbology/components/color_stops/StopCo
 import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
 import {
   IStopRow,
-  ISymbologyDialogProps
+  ISymbologyDialogProps,
 } from '@/src/dialogs/symbology/symbologyDialog';
 import { Utils, VectorUtils } from '@/src/dialogs/symbology/symbologyUtils';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
@@ -19,7 +19,7 @@ const Categorized = ({
   state,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   const selectedValueRef = useRef<string>();
   const stopRowsRef = useRef<IStopRow[]>();
@@ -41,7 +41,7 @@ const Categorized = ({
   }
   const { featureProperties } = useGetProperties({
     layerId,
-    model: model
+    model: model,
   });
 
   useEffect(() => {
@@ -83,13 +83,13 @@ const Categorized = ({
     selectedMode: string,
     numberOfShades: string,
     selectedRamp: string,
-    setIsLoading: (isLoading: boolean) => void
+    setIsLoading: (isLoading: boolean) => void,
   ) => {
     setColorRampOptions({
       selectedFunction: '',
       selectedRamp,
       numberOfShades: '',
-      selectedMode: ''
+      selectedMode: '',
     });
 
     const stops = Array.from(features[selectedValue]).sort((a, b) => a - b);
@@ -97,7 +97,7 @@ const Categorized = ({
     const valueColorPairs = Utils.getValueColorPairs(
       stops,
       selectedRamp,
-      stops.length
+      stops.length,
     );
 
     setStopRows(valueColorPairs);
@@ -131,7 +131,7 @@ const Categorized = ({
       value: selectedValueRef.current,
       colorRamp: colorRampOptionsRef.current?.selectedRamp,
       nClasses: colorRampOptionsRef.current?.numberOfShades,
-      mode: colorRampOptionsRef.current?.selectedMode
+      mode: colorRampOptionsRef.current?.selectedMode,
     };
 
     layer.parameters.symbologyState = symbologyState;

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
@@ -4,13 +4,13 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { VectorClassifications } from '@/src/dialogs/symbology/classificationModes';
 import ColorRamp, {
-  ColorRampOptions
+  ColorRampOptions,
 } from '@/src/dialogs/symbology/components/color_ramp/ColorRamp';
 import StopContainer from '@/src/dialogs/symbology/components/color_stops/StopContainer';
 import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
 import {
   IStopRow,
-  ISymbologyDialogProps
+  ISymbologyDialogProps,
 } from '@/src/dialogs/symbology/symbologyDialog';
 import { Utils, VectorUtils } from '@/src/dialogs/symbology/symbologyUtils';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
@@ -21,14 +21,14 @@ const Graduated = ({
   state,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   const modeOptions = [
     'quantile',
     'equal interval',
     'jenks',
     'pretty',
-    'logarithmic'
+    'logarithmic',
   ];
 
   const selectedValueRef = useRef<string>();
@@ -55,7 +55,7 @@ const Graduated = ({
 
   const { featureProperties } = useGetProperties({
     layerId,
-    model: model
+    model: model,
   });
 
   useEffect(() => {
@@ -170,7 +170,7 @@ const Graduated = ({
       method: selectedMethodRef.current,
       colorRamp: colorRampOptionsRef.current?.selectedRamp,
       nClasses: colorRampOptionsRef.current?.numberOfShades,
-      mode: colorRampOptionsRef.current?.selectedMode
+      mode: colorRampOptionsRef.current?.selectedMode,
     };
 
     layer.parameters.symbologyState = symbologyState;
@@ -186,12 +186,12 @@ const Graduated = ({
   const buildColorInfoFromClassification = (
     selectedMode: string,
     numberOfShades: string,
-    selectedRamp: string
+    selectedRamp: string,
   ) => {
     setColorRampOptions({
       selectedRamp,
       numberOfShades,
-      selectedMode
+      selectedMode,
     });
 
     let stops;
@@ -202,31 +202,31 @@ const Graduated = ({
       case 'quantile':
         stops = VectorClassifications.calculateQuantileBreaks(
           values,
-          +numberOfShades
+          +numberOfShades,
         );
         break;
       case 'equal interval':
         stops = VectorClassifications.calculateEqualIntervalBreaks(
           values,
-          +numberOfShades
+          +numberOfShades,
         );
         break;
       case 'jenks':
         stops = VectorClassifications.calculateJenksBreaks(
           values,
-          +numberOfShades
+          +numberOfShades,
         );
         break;
       case 'pretty':
         stops = VectorClassifications.calculatePrettyBreaks(
           values,
-          +numberOfShades
+          +numberOfShades,
         );
         break;
       case 'logarithmic':
         stops = VectorClassifications.calculateLogarithmicBreaks(
           values,
-          +numberOfShades
+          +numberOfShades,
         );
         break;
       default:
@@ -243,7 +243,7 @@ const Graduated = ({
       stopOutputPairs = Utils.getValueColorPairs(
         stops,
         selectedRamp,
-        +numberOfShades
+        +numberOfShades,
       );
     }
 

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
@@ -9,7 +9,7 @@ const Heatmap = ({
   state,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   if (!layerId) {
     return;
@@ -21,12 +21,12 @@ const Heatmap = ({
   const [selectedRamp, setSelectedRamp] = useState('');
   const [heatmapOptions, setHetamapOptions] = useState({
     radius: 8,
-    blur: 15
+    blur: 15,
   });
   const selectedRampRef = useRef('cool');
   const heatmapOptionsRef = useRef({
     radius: 8,
-    blur: 15
+    blur: 15,
   });
 
   useEffect(() => {
@@ -66,12 +66,12 @@ const Heatmap = ({
     const colorMap = colormap({
       colormap: selectedRampRef.current,
       nshades: 9,
-      format: 'hex'
+      format: 'hex',
     });
 
     const symbologyState = {
       renderType: 'Heatmap',
-      colorRamp: selectedRampRef.current
+      colorRamp: selectedRampRef.current,
     };
 
     layer.parameters.symbologyState = symbologyState;
@@ -103,7 +103,7 @@ const Heatmap = ({
           onChange={event =>
             setHetamapOptions(prevState => ({
               ...prevState,
-              radius: +event.target.value
+              radius: +event.target.value,
             }))
           }
         />
@@ -117,7 +117,7 @@ const Heatmap = ({
           onChange={event =>
             setHetamapOptions(prevState => ({
               ...prevState,
-              blur: +event.target.value
+              blur: +event.target.value,
             }))
           }
         />

--- a/packages/base/src/dialogs/symbology/vector_layer/types/SimpleSymbol.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/SimpleSymbol.tsx
@@ -9,7 +9,7 @@ const SimpleSymbol = ({
   state,
   okSignalPromise,
   cancel,
-  layerId
+  layerId,
 }: ISymbologyDialogProps) => {
   const styleRef = useRef<IParsedStyle>();
 
@@ -19,7 +19,7 @@ const SimpleSymbol = ({
     strokeColor: '#3399CC',
     capStyle: 'round',
     strokeWidth: 1.25,
-    radius: 5
+    radius: 5,
   });
 
   const joinStyleOptions = ['bevel', 'round', 'miter'];
@@ -87,11 +87,11 @@ const SimpleSymbol = ({
       'stroke-color': styleRef.current?.strokeColor,
       'stroke-width': styleRef.current?.strokeWidth,
       'stroke-line-join': styleRef.current?.joinStyle,
-      'stroke-line-cap': styleRef.current?.capStyle
+      'stroke-line-cap': styleRef.current?.capStyle,
     };
 
     const symbologyState = {
-      renderType: 'Single Symbol'
+      renderType: 'Single Symbol',
     };
 
     layer.parameters.symbologyState = symbologyState;
@@ -115,7 +115,7 @@ const SimpleSymbol = ({
           onChange={event =>
             setStyle(prevState => ({
               ...prevState,
-              radius: +event.target.value
+              radius: +event.target.value,
             }))
           }
         />
@@ -129,7 +129,7 @@ const SimpleSymbol = ({
           onChange={event =>
             setStyle(prevState => ({
               ...prevState,
-              fillColor: event.target.value
+              fillColor: event.target.value,
             }))
           }
         />
@@ -143,7 +143,7 @@ const SimpleSymbol = ({
           onChange={event =>
             setStyle(prevState => ({
               ...prevState,
-              strokeColor: event.target.value
+              strokeColor: event.target.value,
             }))
           }
         />
@@ -157,7 +157,7 @@ const SimpleSymbol = ({
           onChange={event =>
             setStyle(prevState => ({
               ...prevState,
-              strokeWidth: +event.target.value
+              strokeWidth: +event.target.value,
             }))
           }
         />
@@ -170,7 +170,7 @@ const SimpleSymbol = ({
             onChange={event =>
               setStyle(prevState => ({
                 ...prevState,
-                joinStyle: event.target.value
+                joinStyle: event.target.value,
               }))
             }
             className="jp-mod-styled"
@@ -192,7 +192,7 @@ const SimpleSymbol = ({
             onChange={event =>
               setStyle(prevState => ({
                 ...prevState,
-                capStyle: event.target.value
+                capStyle: event.target.value,
               }))
             }
             className="jp-mod-styled"

--- a/packages/base/src/formbuilder/creationform.tsx
+++ b/packages/base/src/formbuilder/creationform.tsx
@@ -5,7 +5,7 @@ import {
   IJGISSource,
   IJupyterGISModel,
   LayerType,
-  SourceType
+  SourceType,
 } from '@jupytergis/schema';
 import { Dialog } from '@jupyterlab/apputils';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
@@ -95,7 +95,7 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
       }
 
       layerSchema = deepCopy(
-        this.props.formSchemaRegistry.getSchemas().get(this.props.layerType)
+        this.props.formSchemaRegistry.getSchemas().get(this.props.layerType),
       );
 
       if (!layerSchema) {
@@ -111,17 +111,17 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
       layerSchema['required'] = ['name', ...layerSchema['required']];
       layerSchema['properties'] = {
         name: { type: 'string', description: 'The name of the layer' },
-        ...layerSchema['properties']
+        ...layerSchema['properties'],
       };
     }
 
     let sourceSchema: IDict | undefined = undefined;
     const SourceForm = getSourceTypeForm(
-      this.props.sourceType || 'RasterSource'
+      this.props.sourceType || 'RasterSource',
     );
     if (this.props.sourceType) {
       sourceSchema = deepCopy(
-        this.props.formSchemaRegistry.getSchemas().get(this.props.sourceType)
+        this.props.formSchemaRegistry.getSchemas().get(this.props.sourceType),
       );
 
       if (!sourceSchema) {
@@ -133,7 +133,7 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
         sourceSchema['required'] = ['name', ...sourceSchema['required']];
         sourceSchema['properties'] = {
           name: { type: 'string', description: 'The name of the source' },
-          ...sourceSchema['properties']
+          ...sourceSchema['properties'],
         };
       }
     }
@@ -164,7 +164,7 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
         const sourceModel: IJGISSource = {
           type: this.props.sourceType || 'RasterSource',
           name: actualName,
-          parameters: sourceData
+          parameters: sourceData,
         };
 
         this.jGISModel.sharedModel.addSource(sourceId, sourceModel);
@@ -184,7 +184,7 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
           type: this.props.layerType || 'RasterLayer',
           parameters: layerData,
           visible: true,
-          name: actualName
+          name: actualName,
         };
 
         this.jGISModel.addLayer(UUID.uuid4(), layerModel);

--- a/packages/base/src/formbuilder/editform.tsx
+++ b/packages/base/src/formbuilder/editform.tsx
@@ -2,7 +2,7 @@ import {
   IDict,
   IJGISFormSchemaRegistry,
   IJGISSource,
-  IJupyterGISModel
+  IJupyterGISModel,
 } from '@jupytergis/schema';
 import { Signal } from '@lumino/signaling';
 import * as React from 'react';
@@ -33,7 +33,7 @@ export interface IEditFormProps {
 export class EditForm extends React.Component<IEditFormProps, any> {
   async syncObjectProperties(
     id: string | undefined,
-    properties: { [key: string]: any }
+    properties: { [key: string]: any },
   ) {
     if (!id) {
       return;
@@ -55,7 +55,7 @@ export class EditForm extends React.Component<IEditFormProps, any> {
       LayerForm = getLayerTypeForm(layer?.type || 'RasterLayer');
       layerData = deepCopy(layer?.parameters || {});
       layerSchema = deepCopy(
-        this.props.formSchemaRegistry.getSchemas().get(layer.type)
+        this.props.formSchemaRegistry.getSchemas().get(layer.type),
       );
 
       if (!layerSchema) {
@@ -77,7 +77,7 @@ export class EditForm extends React.Component<IEditFormProps, any> {
       SourceForm = getSourceTypeForm(source?.type || 'RasterSource');
       sourceData = deepCopy(source?.parameters || {});
       sourceSchema = deepCopy(
-        this.props.formSchemaRegistry.getSchemas().get(source.type)
+        this.props.formSchemaRegistry.getSchemas().get(source.type),
       );
 
       if (!sourceSchema) {

--- a/packages/base/src/formbuilder/formselectors.ts
+++ b/packages/base/src/formbuilder/formselectors.ts
@@ -5,18 +5,18 @@ import {
   HillshadeLayerPropertiesForm,
   LayerPropertiesForm,
   VectorLayerPropertiesForm,
-  WebGlLayerPropertiesForm
+  WebGlLayerPropertiesForm,
 } from './objectform/layer';
 import {
   GeoJSONSourcePropertiesForm,
   GeoTiffSourcePropertiesForm,
   PathBasedSourcePropertiesForm,
   TileSourcePropertiesForm,
-  SourcePropertiesForm
+  SourcePropertiesForm,
 } from './objectform/source';
 
 export function getLayerTypeForm(
-  layerType: LayerType
+  layerType: LayerType,
 ): typeof LayerPropertiesForm {
   let LayerForm = LayerPropertiesForm;
 
@@ -40,7 +40,7 @@ export function getLayerTypeForm(
 }
 
 export function getSourceTypeForm(
-  sourceType: SourceType
+  sourceType: SourceType,
 ): typeof SourcePropertiesForm {
   let SourceForm = SourcePropertiesForm;
   switch (sourceType) {

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -76,7 +76,7 @@ const WrappedFormComponent = (props: any): JSX.Element => {
       {...rest}
       validator={validatorAjv8}
       fields={{
-        ...fields
+        ...fields,
       }}
     />
   );
@@ -93,13 +93,13 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
     this.currentFormData = deepCopy(this.props.sourceData);
     this.state = {
       schema: props.schema,
-      extraErrors: {}
+      extraErrors: {},
     };
   }
 
   componentDidUpdate(
     prevProps: IBaseFormProps,
-    prevState: IBaseFormStates
+    prevState: IBaseFormStates,
   ): void {
     if (prevProps.sourceData !== this.props.sourceData) {
       this.currentFormData = deepCopy(this.props.sourceData);
@@ -119,7 +119,7 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ): void {
     if (!schema['properties']) {
       return;
@@ -134,9 +134,9 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
           'ui:options': {
             orderable: false,
             removable: false,
-            addable: false
+            addable: false,
           },
-          ...uiSchema[k]
+          ...uiSchema[k],
         };
 
         if (v['items']['type'] === 'array') {
@@ -145,12 +145,12 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
               'ui:options': {
                 orderable: false,
                 removable: false,
-                addable: false
+                addable: false,
               },
-              ...uiSchema[k]['items']
+              ...uiSchema[k]['items'],
             },
 
-            ...uiSchema[k]
+            ...uiSchema[k],
           };
         }
       }
@@ -163,7 +163,7 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
         uiSchema[k] = {
           'ui:field': (props: any) => {
             const [inputValue, setInputValue] = React.useState(
-              props.formData.toFixed(1)
+              props.formData.toFixed(1),
             );
 
             React.useEffect(() => {
@@ -180,7 +180,7 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
             };
 
             const handleInputChange = (
-              event: React.ChangeEvent<HTMLInputElement>
+              event: React.ChangeEvent<HTMLInputElement>,
             ) => {
               const value = event.target.value;
               setInputValue(value);
@@ -219,12 +219,12 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
                     border: '1px solid #ccc',
                     borderRadius: '4px',
                     padding: '4px',
-                    marginBottom: '5px'
+                    marginBottom: '5px',
                   }}
                 />
               </div>
             );
-          }
+          },
         };
       }
 
@@ -252,7 +252,7 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
     entry: string,
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     if (data) {
       delete data[entry];
@@ -308,8 +308,8 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
       const uiSchema = {
         additionalProperties: {
           'ui:label': false,
-          classNames: 'jGIS-hidden-field'
-        }
+          classNames: 'jGIS-hidden-field',
+        },
       };
       this.processSchema(formData, schema, uiSchema);
 

--- a/packages/base/src/formbuilder/objectform/fileselectorwidget.tsx
+++ b/packages/base/src/formbuilder/objectform/fileselectorwidget.tsx
@@ -31,11 +31,11 @@ export const FileSelectorWidget = (props: any) => {
   const handleBrowseServerFiles = async () => {
     try {
       const dialogElement = document.querySelector(
-        'dialog[aria-modal="true"]'
+        'dialog[aria-modal="true"]',
       ) as HTMLDialogElement;
       if (dialogElement) {
         const dialogInstance = Dialog.tracker.find(
-          dialog => dialog.node === dialogElement
+          dialog => dialog.node === dialogElement,
         );
 
         if (dialogInstance) {
@@ -47,7 +47,7 @@ export const FileSelectorWidget = (props: any) => {
 
       const output = await FileDialog.getOpenFiles({
         title: `Select ${formOptions.sourceType.split('Source')[0]} File`,
-        manager: docManager
+        manager: docManager,
       });
 
       if (output.value && output.value.length > 0) {
@@ -55,7 +55,7 @@ export const FileSelectorWidget = (props: any) => {
 
         const relativePath = PathExt.relative(
           PathExt.dirname(formOptions.filePath),
-          selectedFilePath
+          selectedFilePath,
         );
 
         setServerFilePath(relativePath);
@@ -70,27 +70,27 @@ export const FileSelectorWidget = (props: any) => {
                 (urlObject: any) => {
                   return {
                     ...urlObject,
-                    url: relativePath
+                    url: relativePath,
                   };
-                }
-              )
+                },
+              ),
             };
           } else {
             formOptions.dialogOptions.sourceData = {
               ...formOptions.sourceData,
-              path: relativePath
+              path: relativePath,
             };
           }
 
           const formDialog = new LayerCreationFormDialog({
-            ...formOptions.dialogOptions
+            ...formOptions.dialogOptions,
           });
           await formDialog.launch();
         }
       } else {
         if (dialogElement) {
           const formDialog = new LayerCreationFormDialog({
-            ...formOptions.dialogOptions
+            ...formOptions.dialogOptions,
           });
           await formDialog.launch();
         }

--- a/packages/base/src/formbuilder/objectform/layer/heatmapLayerForm.ts
+++ b/packages/base/src/formbuilder/objectform/layer/heatmapLayerForm.ts
@@ -18,7 +18,7 @@ export class HeatmapLayerPropertiesForm extends LayerPropertiesForm {
         if (this.props.sourceType === 'GeoJSONSource') {
           this.fetchFeatureNames(
             this.currentFormData,
-            sourceData as IGeoJSONSource
+            sourceData as IGeoJSONSource,
           );
         }
       });
@@ -35,14 +35,14 @@ export class HeatmapLayerPropertiesForm extends LayerPropertiesForm {
 
     this.fetchFeatureNames(
       this.currentFormData,
-      source.parameters as IGeoJSONSource
+      source.parameters as IGeoJSONSource,
     );
   }
 
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     this.removeFormEntry('color', data, schema, uiSchema);
     this.removeFormEntry('symbologyState', data, schema, uiSchema);
@@ -59,7 +59,7 @@ export class HeatmapLayerPropertiesForm extends LayerPropertiesForm {
 
   private async fetchFeatureNames(
     data: IHeatmapLayer,
-    sourceData?: IGeoJSONSource
+    sourceData?: IGeoJSONSource,
   ) {
     if (data && data.source) {
       if (!sourceData) {
@@ -83,7 +83,7 @@ export class HeatmapLayerPropertiesForm extends LayerPropertiesForm {
     const jsonData = await loadFile({
       filepath: source.parameters.path,
       type: 'GeoJSONSource',
-      model: this.props.model
+      model: this.props.model,
     });
 
     const featureProps = jsonData.features[0].properties;

--- a/packages/base/src/formbuilder/objectform/layer/hillshadeLayerForm.ts
+++ b/packages/base/src/formbuilder/objectform/layer/hillshadeLayerForm.ts
@@ -9,11 +9,11 @@ export class HillshadeLayerPropertiesForm extends LayerPropertiesForm {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     super.processSchema(data, schema, uiSchema);
     uiSchema['shadowColor'] = {
-      'ui:widget': 'color'
+      'ui:widget': 'color',
     };
   }
 }

--- a/packages/base/src/formbuilder/objectform/layer/layerform.ts
+++ b/packages/base/src/formbuilder/objectform/layer/layerform.ts
@@ -4,7 +4,7 @@ import { IChangeEvent } from '@rjsf/core';
 
 import {
   BaseForm,
-  IBaseFormProps
+  IBaseFormProps,
 } from '@/src/formbuilder/objectform/baseform';
 
 export interface ILayerProps extends IBaseFormProps {
@@ -38,7 +38,7 @@ export class LayerPropertiesForm extends BaseForm {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ): void {
     super.processSchema(data, schema, uiSchema);
 
@@ -48,7 +48,7 @@ export class LayerPropertiesForm extends BaseForm {
 
     // Replace the source text box by a dropdown menu
     const availableSources = this.props.model.getSourcesByType(
-      this.props.sourceType
+      this.props.sourceType,
     );
 
     schema.properties.source.enumNames = Object.values(availableSources);

--- a/packages/base/src/formbuilder/objectform/layer/vectorlayerform.ts
+++ b/packages/base/src/formbuilder/objectform/layer/vectorlayerform.ts
@@ -31,7 +31,7 @@ export class VectorLayerPropertiesForm extends LayerPropertiesForm {
   protected processSchema(
     data: IVectorLayer | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     this.removeFormEntry('color', data, schema, uiSchema);
     this.removeFormEntry('symbologyState', data, schema, uiSchema);

--- a/packages/base/src/formbuilder/objectform/layer/webGlLayerForm.tsx
+++ b/packages/base/src/formbuilder/objectform/layer/webGlLayerForm.tsx
@@ -9,7 +9,7 @@ export class WebGlLayerPropertiesForm extends LayerPropertiesForm {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     this.removeFormEntry('color', data, schema, uiSchema);
     this.removeFormEntry('symbologyState', data, schema, uiSchema);

--- a/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
+++ b/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
@@ -4,7 +4,7 @@ import { IChangeEvent } from '@rjsf/core';
 import {
   BaseForm,
   IBaseFormProps,
-  IBaseFormStates
+  IBaseFormStates,
 } from '@/src/formbuilder/objectform/baseform'; // Ensure BaseForm imports states
 import { loadFile } from '@/src/tools';
 
@@ -27,7 +27,7 @@ export class DissolveForm extends BaseForm {
 
     // Ensure initial state matches IBaseFormStates
     this.state = {
-      schema: options.schema ?? {} // Ensure schema is never undefined
+      schema: options.schema ?? {}, // Ensure schema is never undefined
     };
 
     this.onFormChange = this.handleFormChange.bind(this);
@@ -55,7 +55,7 @@ export class DissolveForm extends BaseForm {
       const jsonData = await loadFile({
         filepath: sourceData.path,
         type: 'GeoJSONSource',
-        model: this.model
+        model: this.model,
       });
 
       if (!jsonData?.features?.length) {
@@ -86,14 +86,14 @@ export class DissolveForm extends BaseForm {
             ...prevState.schema?.properties,
             dissolveField: {
               ...prevState.schema?.properties?.dissolveField,
-              enum: [...this.features]
-            }
-          }
-        }
+              enum: [...this.features],
+            },
+          },
+        },
       }),
       () => {
         this.forceUpdate();
-      }
+      },
     );
   }
 }

--- a/packages/base/src/formbuilder/objectform/source/geojsonsource.ts
+++ b/packages/base/src/formbuilder/objectform/source/geojsonsource.ts
@@ -22,7 +22,7 @@ export class GeoJSONSourcePropertiesForm extends PathBasedSourcePropertiesForm {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     if (data?.path !== '') {
       this.removeFormEntry('data', data, schema, uiSchema);
@@ -46,7 +46,7 @@ export class GeoJSONSourcePropertiesForm extends PathBasedSourcePropertiesForm {
         const geoJSONData = await loadFile({
           filepath: path,
           type: this.props.sourceType,
-          model: this.props.model
+          model: this.props.model,
         });
         valid = this._validate(geoJSONData);
         if (!valid) {
@@ -61,7 +61,7 @@ export class GeoJSONSourcePropertiesForm extends PathBasedSourcePropertiesForm {
 
     if (!valid) {
       extraErrors.path = {
-        __errors: [error]
+        __errors: [error],
       };
       this._validate.errors?.reverse().forEach(error => {
         extraErrors.path.__errors.push(error.message);
@@ -71,7 +71,7 @@ export class GeoJSONSourcePropertiesForm extends PathBasedSourcePropertiesForm {
     } else {
       this.setState(old => ({
         ...old,
-        extraErrors: { ...extraErrors, path: { __errors: [] } }
+        extraErrors: { ...extraErrors, path: { __errors: [] } },
       }));
     }
 

--- a/packages/base/src/formbuilder/objectform/source/geotiffsource.ts
+++ b/packages/base/src/formbuilder/objectform/source/geotiffsource.ts
@@ -22,7 +22,7 @@ export class GeoTiffSourcePropertiesForm extends SourcePropertiesForm {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     super.processSchema(data, schema, uiSchema);
     if (!schema.properties || !data) {
@@ -42,10 +42,10 @@ export class GeoTiffSourcePropertiesForm extends SourcePropertiesForm {
             'ui:widget': FileSelectorWidget,
             'ui:options': {
               docManager,
-              formOptions: this.props
-            }
-          }
-        }
+              formOptions: this.props,
+            },
+          },
+        },
       };
     }
 
@@ -100,27 +100,27 @@ export class GeoTiffSourcePropertiesForm extends SourcePropertiesForm {
           if (!mimeType || !mimeType.startsWith('image/tiff')) {
             valid = false;
             errors.push(
-              `"${url}" is not a valid ${this.props.sourceType} file.`
+              `"${url}" is not a valid ${this.props.sourceType} file.`,
             );
           }
         } else {
           if (!url || typeof url !== 'string' || url.trim() === '') {
             valid = false;
             errors.push(
-              `URL at index ${i} is required and must be a valid string.`
+              `URL at index ${i} is required and must be a valid string.`,
             );
           }
 
           if (min === undefined || typeof min !== 'number') {
             errors.push(
-              `Min value at index ${i} is required and must be a number.`
+              `Min value at index ${i} is required and must be a number.`,
             );
             valid = false;
           }
 
           if (max === undefined || typeof max !== 'number') {
             errors.push(
-              `Max value at index ${i} is required and must be a number.`
+              `Max value at index ${i} is required and must be a number.`,
             );
             valid = false;
           }
@@ -143,12 +143,12 @@ export class GeoTiffSourcePropertiesForm extends SourcePropertiesForm {
     if (!valid) {
       this.setState(old => ({
         ...old,
-        extraErrors: { ...extraErrors, urls: { __errors: errors } }
+        extraErrors: { ...extraErrors, urls: { __errors: errors } },
       }));
     } else {
       this.setState(old => ({
         ...old,
-        extraErrors: { ...extraErrors, urls: { __errors: [] } }
+        extraErrors: { ...extraErrors, urls: { __errors: [] } },
       }));
     }
 

--- a/packages/base/src/formbuilder/objectform/source/pathbasedsource.ts
+++ b/packages/base/src/formbuilder/objectform/source/pathbasedsource.ts
@@ -21,7 +21,7 @@ export class PathBasedSourcePropertiesForm extends SourcePropertiesForm {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     super.processSchema(data, schema, uiSchema);
     if (!schema.properties || !data) {
@@ -37,8 +37,8 @@ export class PathBasedSourcePropertiesForm extends SourcePropertiesForm {
         'ui:widget': FileSelectorWidget,
         'ui:options': {
           docManager,
-          formOptions: this.props
-        }
+          formOptions: this.props,
+        },
       };
     }
     // This is not user-editable
@@ -87,7 +87,7 @@ export class PathBasedSourcePropertiesForm extends SourcePropertiesForm {
         await loadFile({
           filepath: path,
           type: this.props.sourceType,
-          model: this.props.model
+          model: this.props.model,
         });
       } catch (e) {
         valid = false;
@@ -97,14 +97,14 @@ export class PathBasedSourcePropertiesForm extends SourcePropertiesForm {
 
     if (!valid) {
       extraErrors.path = {
-        __errors: [error]
+        __errors: [error],
       };
 
       this.setState(old => ({ ...old, extraErrors }));
     } else {
       this.setState(old => ({
         ...old,
-        extraErrors: { ...extraErrors, path: { __errors: [] } }
+        extraErrors: { ...extraErrors, path: { __errors: [] } },
       }));
     }
 

--- a/packages/base/src/formbuilder/objectform/source/sourceform.ts
+++ b/packages/base/src/formbuilder/objectform/source/sourceform.ts
@@ -4,7 +4,7 @@ import { IChangeEvent } from '@rjsf/core';
 
 import {
   BaseForm,
-  IBaseFormProps
+  IBaseFormProps,
 } from '@/src/formbuilder/objectform/baseform';
 
 export interface ISourceFormProps extends IBaseFormProps {

--- a/packages/base/src/formbuilder/objectform/source/tilesourceform.ts
+++ b/packages/base/src/formbuilder/objectform/source/tilesourceform.ts
@@ -8,7 +8,7 @@ export class TileSourcePropertiesForm extends SourcePropertiesForm {
   protected processSchema(
     data: IDict<any> | undefined,
     schema: IDict,
-    uiSchema: IDict
+    uiSchema: IDict,
   ) {
     super.processSchema(data, schema, uiSchema);
 
@@ -40,7 +40,7 @@ export class TileSourcePropertiesForm extends SourcePropertiesForm {
     schema.properties.urlParameters = {
       type: 'object',
       required: this._urlParameters,
-      properties: propertiesSchema
+      properties: propertiesSchema,
     };
 
     for (const parameterName of this._urlParameters) {
@@ -49,12 +49,12 @@ export class TileSourcePropertiesForm extends SourcePropertiesForm {
         case 'time':
           propertiesSchema[parameterName] = {
             type: 'string',
-            format: 'date'
+            format: 'date',
           };
           break;
         default:
           propertiesSchema[parameterName] = {
-            type: 'string'
+            type: 'string',
           };
           break;
       }

--- a/packages/base/src/gdal.ts
+++ b/packages/base/src/gdal.ts
@@ -8,9 +8,9 @@ export async function getGdal() {
   return await initGdalJs({
     paths: {
       wasm: wasmurl.href,
-      data: dataurl.href
+      data: dataurl.href,
     },
-    useWorker: false
+    useWorker: false,
   });
 }
 

--- a/packages/base/src/icons.ts
+++ b/packages/base/src/icons.ts
@@ -27,85 +27,85 @@ import visibilitySvgStr from '../style/icons/visibility.svg';
 
 export const logoIcon = new LabIcon({
   name: 'jupytergis::logo',
-  svgstr: logoSvgStr
+  svgstr: logoSvgStr,
 });
 
 export const logoMiniIcon = new LabIcon({
   name: 'jupytergis::logoMini',
-  svgstr: logoMiniSvgStr
+  svgstr: logoMiniSvgStr,
 });
 
 export const logoMiniAlternativeIcon = new LabIcon({
   name: 'jupytergis::logoMiniAlternative',
-  svgstr: logoMiniAlternativeSvgStr
+  svgstr: logoMiniAlternativeSvgStr,
 });
 
 export const rasterIcon = new LabIcon({
   name: 'jupytergis::raster',
-  svgstr: rasterSvgStr
+  svgstr: rasterSvgStr,
 });
 
 export const visibilityIcon = new LabIcon({
   name: 'jupytergis::visibility',
-  svgstr: visibilitySvgStr
+  svgstr: visibilitySvgStr,
 });
 
 export const nonVisibilityIcon = new LabIcon({
   name: 'jupytergis::nonVisibility',
-  svgstr: nonVisibilitySvgStr
+  svgstr: nonVisibilitySvgStr,
 });
 
 export const geoJSONIcon = new LabIcon({
   name: 'jupytergis::geoJSON',
-  svgstr: geoJsonSvgStr
+  svgstr: geoJsonSvgStr,
 });
 
 export const moundIcon = new LabIcon({
   name: 'jupytergis::mound',
-  svgstr: moundSvgStr
+  svgstr: moundSvgStr,
 });
 
 export const logoMiniIconQGZ = new LabIcon({
   name: 'jupytergis::logoQGZ',
-  svgstr: logoMiniQGZ
+  svgstr: logoMiniQGZ,
 });
 
 export const bookOpenIcon = new LabIcon({
   name: 'jupytergis::bookOpen',
-  svgstr: bookOpenSvgStr
+  svgstr: bookOpenSvgStr,
 });
 
 export const vectorSquareIcon = new LabIcon({
   name: 'jupytergis::vectorSquare',
-  svgstr: vectorSquareSvgStr
+  svgstr: vectorSquareSvgStr,
 });
 
 export const infoIcon = new LabIcon({
   name: 'jupytergis::info',
-  svgstr: infoSvgStr
+  svgstr: infoSvgStr,
 });
 
 export const clockIcon = new LabIcon({
   name: 'jupytergis::clock',
-  svgstr: clockSvgStr
+  svgstr: clockSvgStr,
 });
 
 export const terminalToolbarIcon = new LabIcon({
   name: 'jupytergis::terminalToolbar',
-  svgstr: terminalToolbarSvgStr
+  svgstr: terminalToolbarSvgStr,
 });
 
 export const geolocationIcon = new LabIcon({
   name: 'jupytergis::geolocation',
-  svgstr: geolocationSvgStr
+  svgstr: geolocationSvgStr,
 });
 
 export const targetWithoutCenterIcon = new LabIcon({
   name: 'jupytergis::targetWithCenter',
-  svgstr: targetWithCenterSvgStr
+  svgstr: targetWithCenterSvgStr,
 });
 
 export const targetWithCenterIcon = new LabIcon({
   name: 'jupytergis::targetWithoutCenter',
-  svgstr: targetWithoutCenterSvgStr
+  svgstr: targetWithoutCenterSvgStr,
 });

--- a/packages/base/src/mainview/CollaboratorPointers.tsx
+++ b/packages/base/src/mainview/CollaboratorPointers.tsx
@@ -1,6 +1,6 @@
 import {
   faArrowPointer,
-  faWindowMinimize
+  faWindowMinimize,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IDict, JgisCoordinates } from '@jupytergis/schema';
@@ -29,7 +29,7 @@ const CollaboratorPointers = ({ clients }: ICollaboratorPointersProps) => {
             className="jGIS-Popup-Wrapper"
             style={{
               left: `${client.coordinates.x}px`,
-              top: `${client.coordinates.y}px`
+              top: `${client.coordinates.y}px`,
             }}
           >
             <div
@@ -37,7 +37,7 @@ const CollaboratorPointers = ({ clients }: ICollaboratorPointersProps) => {
               className="jGIS-Remote-Pointer"
               style={{
                 color: client.color,
-                cursor: 'pointer'
+                cursor: 'pointer',
               }}
               onClick={() => {
                 setIsOpen(!isOpen);
@@ -51,7 +51,7 @@ const CollaboratorPointers = ({ clients }: ICollaboratorPointersProps) => {
             <div
               style={{
                 visibility: isOpen ? 'visible' : 'hidden',
-                background: client.color
+                background: client.color,
               }}
               className="jGIS-Remote-Pointer-Popup jGIS-Floating-Pointer-Popup"
             >

--- a/packages/base/src/mainview/FollowIndicator.tsx
+++ b/packages/base/src/mainview/FollowIndicator.tsx
@@ -12,7 +12,7 @@ export function FollowIndicator({ remoteUser }: IFollowIndicatorProps) {
         position: 'absolute',
         top: 1,
         right: 3,
-        background: remoteUser.color
+        background: remoteUser.color,
       }}
     >
       {`Following ${remoteUser.display_name}`}

--- a/packages/base/src/mainview/TemporalSlider.tsx
+++ b/packages/base/src/mainview/TemporalSlider.tsx
@@ -6,7 +6,7 @@ import {
   IJGISFilterItem,
   IJGISLayerDocChange,
   IJupyterGISDoc,
-  IJupyterGISModel
+  IJupyterGISModel,
 } from '@jupytergis/schema';
 import { format, isValid, parse } from 'date-fns';
 import {
@@ -16,7 +16,7 @@ import {
   millisecondsInMinute,
   millisecondsInSecond,
   millisecondsInWeek,
-  minutesInMonth
+  minutesInMonth,
 } from 'date-fns/constants';
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -38,7 +38,7 @@ const commonDateFormats = [
   'MM-dd-yyyy', // US format with hyphens (e.g., 10-05-2023)
   'yyyy/MM/dd', // ISO format with slashes (e.g., 2023/10/05)
   'dd.MM.yyyy', // European format with dots (e.g., 05.10.2023)
-  'MM.dd.yyyy' // US format with dots (e.g., 10.05.2023)
+  'MM.dd.yyyy', // US format with dots (e.g., 10.05.2023)
 ];
 
 // Time steps in milliseconds
@@ -50,7 +50,7 @@ const stepMap = {
   day: millisecondsInDay,
   week: millisecondsInWeek,
   month: minutesInMonth * millisecondsInMinute,
-  year: millisecondsInDay * daysInYear
+  year: millisecondsInDay * daysInYear,
 };
 
 const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
@@ -90,11 +90,11 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
     // this is for when the layer itself changes
     const handleLayerChange = (
       _: IJupyterGISDoc,
-      change: IJGISLayerDocChange
+      change: IJGISLayerDocChange,
     ) => {
       // Get the changes for the selected layer
       const selectedLayer = change.layerChange?.find(
-        layer => layer.id === layerIdRef.current
+        layer => layer.id === layerIdRef.current,
       );
 
       // Bail if there's no relevant change
@@ -201,7 +201,7 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
 
     // Get valid step options
     const filteredSteps = Object.fromEntries(
-      Object.entries(stepMap).filter(([_, val]) => val < max - min)
+      Object.entries(stepMap).filter(([_, val]) => val < max - min),
     );
 
     //using filter item as a state object to restore prev values
@@ -214,7 +214,7 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
     setMinMax({ min, max });
     setRange({
       start: currentState?.betweenMin ?? min,
-      end: currentState?.betweenMax ?? min + step
+      end: currentState?.betweenMax ?? min + step,
     });
 
     model.addFeatureAsMs(layerId, selectedFeature);
@@ -225,7 +225,7 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
     const currentState = filterStates[layerId];
 
     setCurrentValue(
-      typeof currentState?.value === 'number' ? currentState.value : minMax.min
+      typeof currentState?.value === 'number' ? currentState.value : minMax.min,
     );
   }, [minMax]);
 
@@ -243,7 +243,7 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
   // Convert milliseconds back to the original date string format
   const millisecondsToDateString = (
     milliseconds: number,
-    dateFormat: string
+    dateFormat: string,
   ): string => {
     const date = new Date(milliseconds); // Create a Date object from milliseconds
     return format(date, dateFormat); // Format back to the original string format
@@ -261,7 +261,7 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
       operator: 'between' as const,
       value: value,
       betweenMin: value,
-      betweenMax: value + step
+      betweenMax: value + step,
     };
 
     const layer = model.getLayer(layerId);
@@ -275,13 +275,13 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
     // This is the only way to add a 'between' filter so
     // find the index of the existing 'between' filter
     const betweenFilterIndex = appliedFilters.findIndex(
-      filter => filter.operator === 'between'
+      filter => filter.operator === 'between',
     );
 
     if (betweenFilterIndex !== -1) {
       // If found, replace the existing filter
       appliedFilters[betweenFilterIndex] = {
-        ...newFilter
+        ...newFilter,
       };
     } else {
       // If not found, add the new filter
@@ -305,7 +305,7 @@ const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
     // This is the only way to add a 'between' filter so
     // find the index of the existing 'between' filter
     const betweenFilterIndex = appliedFilters.findIndex(
-      filter => filter.operator === 'between'
+      filter => filter.operator === 'between',
     );
 
     if (betweenFilterIndex !== -1) {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -27,7 +27,7 @@ import {
   IVectorTileSource,
   IWebGlLayer,
   JgisCoordinates,
-  JupyterGISModel
+  JupyterGISModel,
 } from '@jupytergis/schema';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
@@ -49,14 +49,14 @@ import {
   Layer,
   Vector as VectorLayer,
   VectorTile as VectorTileLayer,
-  WebGLTile as WebGlTileLayer
+  WebGLTile as WebGlTileLayer,
 } from 'ol/layer';
 import TileLayer from 'ol/layer/Tile';
 import {
   fromLonLat,
   get as getRegisteredProjection,
   toLonLat,
-  transformExtent
+  transformExtent,
 } from 'ol/proj';
 import { register } from 'ol/proj/proj4.js';
 import { get as getProjection } from 'ol/proj.js';
@@ -66,7 +66,7 @@ import {
   ImageTile as ImageTileSource,
   Vector as VectorSource,
   VectorTile as VectorTileSource,
-  XYZ as XYZSource
+  XYZ as XYZSource,
 } from 'ol/source';
 import Static from 'ol/source/ImageStatic';
 import TileSource from 'ol/source/Tile';
@@ -120,11 +120,11 @@ export class MainView extends React.Component<IProps, IStates> {
 
     this._model.sharedOptionsChanged.connect(
       this._onSharedOptionsChanged,
-      this
+      this,
     );
     this._model.clientStateChanged.connect(
       this._onClientSharedStateChanged,
-      this
+      this,
     );
     this._model.sharedLayersChanged.connect(this._onLayersChanged, this);
     this._model.sharedLayerTreeChanged.connect(this._onLayerTreeChange, this);
@@ -132,20 +132,20 @@ export class MainView extends React.Component<IProps, IStates> {
     this._model.sharedModel.changed.connect(this._onSharedModelStateChange);
     this._model.sharedMetadataChanged.connect(
       this._onSharedMetadataChanged,
-      this
+      this,
     );
     this._model.zoomToPositionSignal.connect(this._onZoomToPosition, this);
     this._model.updateLayerSignal.connect(this._triggerLayerUpdate, this);
     this._model.addFeatureAsMsSignal.connect(this._convertFeatureToMs, this);
     this._model.geolocationChanged.connect(
       this._handleGeolocationChanged,
-      this
+      this,
     );
 
     this._model.flyToGeometrySignal.connect(this.flyToGeometry, this);
     this._model.highlightFeatureSignal.connect(
       this.highlightFeatureOnMap,
-      this
+      this,
     );
 
     // Watch isIdentifying and clear the highlight when Identify Tool is turned off
@@ -167,7 +167,7 @@ export class MainView extends React.Component<IProps, IStates> {
       scale: 0,
       loadingErrors: [],
       displayTemporalController: false,
-      filterStates: {}
+      filterStates: {},
     };
 
     this._sources = [];
@@ -199,18 +199,18 @@ export class MainView extends React.Component<IProps, IStates> {
     window.removeEventListener('resize', this._handleWindowResize);
     this._mainViewModel.viewSettingChanged.disconnect(
       this._onViewChanged,
-      this
+      this,
     );
 
     this._model.themeChanged.disconnect(this._handleThemeChange, this);
     this._model.sharedOptionsChanged.disconnect(
       this._onSharedOptionsChanged,
-      this
+      this,
     );
 
     this._model.clientStateChanged.disconnect(
       this._onClientSharedStateChanged,
-      this
+      this,
     );
 
     this._mainViewModel.dispose();
@@ -223,14 +223,14 @@ export class MainView extends React.Component<IProps, IStates> {
         layers: [],
         view: new View({
           center,
-          zoom
+          zoom,
         }),
-        controls: [new ScaleLine()]
+        controls: [new ScaleLine()],
       });
 
       // Add map interactions
       const dragAndDropInteraction = new DragAndDrop({
-        formatConstructors: [GeoJSON]
+        formatConstructors: [GeoJSON],
       });
 
       dragAndDropInteraction.on('addfeatures', event => {
@@ -239,7 +239,7 @@ export class MainView extends React.Component<IProps, IStates> {
         const sourceModel: IJGISSource = {
           type: 'GeoJSONSource',
           name: 'Drag and Drop source',
-          parameters: { path: event.file.name }
+          parameters: { path: event.file.name },
         };
 
         const layerId = UUID.uuid4();
@@ -256,8 +256,8 @@ export class MainView extends React.Component<IProps, IStates> {
             color: '#FF0000',
             opacity: 1.0,
             type: 'line',
-            source: sourceId
-          }
+            source: sourceId,
+          },
         };
 
         this.addLayer(layerId, layerModel, this.getLayerIDs().length);
@@ -286,9 +286,9 @@ export class MainView extends React.Component<IProps, IStates> {
           }
           this._model.syncViewport(
             { coordinates: { x: center[0], y: center[1] }, zoom },
-            this._mainViewModel.id
+            this._mainViewModel.id,
           );
-        })
+        }),
       );
 
       this._Map.on('postrender', () => {
@@ -314,14 +314,14 @@ export class MainView extends React.Component<IProps, IStates> {
           longitude: latLng[0],
           bearing,
           projection: projection.getCode(),
-          zoom
+          zoom,
         };
 
         updatedOptions.extent = view.calculateExtent();
 
         this._model.setOptions({
           ...currentOptions,
-          ...updatedOptions
+          ...updatedOptions,
         });
 
         // Calculate scale
@@ -333,7 +333,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
           this.setState(old => ({
             ...old,
-            scale
+            scale,
           }));
         }
       });
@@ -346,7 +346,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
       if (JupyterGISModel.getOrderedLayerIds(this._model).length !== 0) {
         await this._updateLayersImpl(
-          JupyterGISModel.getOrderedLayerIds(this._model)
+          JupyterGISModel.getOrderedLayerIds(this._model),
         );
         const options = this._model.getOptions();
         this.updateOptions(options);
@@ -365,8 +365,8 @@ export class MainView extends React.Component<IProps, IStates> {
         loading: false,
         viewProjection: {
           code: view.getProjection().getCode(),
-          units: view.getProjection().getUnits()
-        }
+          units: view.getProjection().getUnits(),
+        },
       }));
     }
   }
@@ -376,28 +376,28 @@ export class MainView extends React.Component<IProps, IStates> {
       image: new Circle({
         radius: 5,
         fill: new Fill({
-          color: '#C52707'
+          color: '#C52707',
         }),
         stroke: new Stroke({
           color: '#171717',
-          width: 2
-        })
-      })
+          width: 2,
+        }),
+      }),
     });
 
     const lineStyle = new Style({
       stroke: new Stroke({
         color: '#171717',
-        width: 2
-      })
+        width: 2,
+      }),
     });
 
     const polygonStyle = new Style({
       fill: new Fill({ color: '#C5270780' }),
       stroke: new Stroke({
         color: '#171717',
-        width: 2
-      })
+        width: 2,
+      }),
     });
 
     const styleFunction = (feature: FeatureLike) => {
@@ -432,7 +432,7 @@ export class MainView extends React.Component<IProps, IStates> {
       condition: (event: MapBrowserEvent<any>) => {
         return singleClick(event) && this._model.isIdentifying;
       },
-      style: styleFunction
+      style: styleFunction,
     });
 
     selectInteraction.on('select', event => {
@@ -443,7 +443,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
       this._model.syncIdentifiedFeatures(
         identifiedFeatures,
-        this._mainViewModel.id
+        this._mainViewModel.id,
       );
     });
 
@@ -463,19 +463,19 @@ export class MainView extends React.Component<IProps, IStates> {
           label: 'New annotation',
           contents: [],
           parent: this._Map.getViewport().id,
-          open: true
+          open: true,
         });
       },
       label: 'Add annotation',
       isEnabled: () => {
         return !!this._Map;
-      }
+      },
     });
 
     this._contextMenu.addItem({
       command: CommandIDs.addAnnotation,
       selector: '.ol-viewport',
-      rank: 1
+      rank: 1,
     });
   };
 
@@ -502,14 +502,14 @@ export class MainView extends React.Component<IProps, IStates> {
             minZoom: sourceParameters.minZoom,
             maxZoom: sourceParameters.maxZoom,
             tileSize: 256,
-            url: url
+            url: url,
           });
         } else {
           newSource = new PMTilesRasterSource({
             interpolate: sourceParameters.interpolate,
             attributions: sourceParameters.attribution,
             tileSize: 256,
-            url: url
+            url: url,
           });
         }
 
@@ -521,7 +521,7 @@ export class MainView extends React.Component<IProps, IStates> {
         newSource = new ImageTileSource({
           interpolate: sourceParameters.interpolate,
           url: this.computeSourceUrl(source),
-          attributions: sourceParameters.attribution
+          attributions: sourceParameters.attribution,
         });
 
         break;
@@ -538,12 +538,12 @@ export class MainView extends React.Component<IProps, IStates> {
             minZoom: sourceParameters.minZoom,
             maxZoom: sourceParameters.maxZoom,
             url: url,
-            format: new MVT({ featureClass: RenderFeature })
+            format: new MVT({ featureClass: RenderFeature }),
           });
         } else {
           newSource = new PMTilesVectorSource({
             attributions: sourceParameters.attribution,
-            url: url
+            url: url,
           });
         }
 
@@ -555,17 +555,17 @@ export class MainView extends React.Component<IProps, IStates> {
           (await loadFile({
             filepath: source.parameters?.path,
             type: 'GeoJSONSource',
-            model: this._model
+            model: this._model,
           }));
 
         const format = new GeoJSON({
-          featureProjection: this._Map.getView().getProjection()
+          featureProjection: this._Map.getView().getProjection(),
         });
 
         // TODO: Don't hardcode projection
         const featureArray = format.readFeatures(data, {
           dataProjection: 'EPSG:4326',
-          featureProjection: this._Map.getView().getProjection()
+          featureProjection: this._Map.getView().getProjection(),
         });
 
         const featureCollection = new Collection(featureArray);
@@ -575,7 +575,7 @@ export class MainView extends React.Component<IProps, IStates> {
         });
 
         newSource = new VectorSource({
-          features: featureCollection
+          features: featureCollection,
         });
 
         break;
@@ -586,7 +586,7 @@ export class MainView extends React.Component<IProps, IStates> {
         const geojson = await loadFile({
           filepath: parameters.path,
           type: 'ShapefileSource',
-          model: this._model
+          model: this._model,
         });
 
         const geojsonData = Array.isArray(geojson) ? geojson[0] : geojson;
@@ -596,8 +596,8 @@ export class MainView extends React.Component<IProps, IStates> {
         newSource = new VectorSource({
           features: format.readFeatures(geojsonData, {
             dataProjection: 'EPSG:4326',
-            featureProjection: this._Map.getView().getProjection()
-          })
+            featureProjection: this._Map.getView().getProjection(),
+          }),
         });
         break;
       }
@@ -607,16 +607,16 @@ export class MainView extends React.Component<IProps, IStates> {
         // Convert lon/lat array to extent
         // Get lon/lat from source coordinates
         const leftSide = Math.min(
-          ...sourceParameters.coordinates.map(corner => corner[0])
+          ...sourceParameters.coordinates.map(corner => corner[0]),
         );
         const bottomSide = Math.min(
-          ...sourceParameters.coordinates.map(corner => corner[1])
+          ...sourceParameters.coordinates.map(corner => corner[1]),
         );
         const rightSide = Math.max(
-          ...sourceParameters.coordinates.map(corner => corner[0])
+          ...sourceParameters.coordinates.map(corner => corner[0]),
         );
         const topSide = Math.max(
-          ...sourceParameters.coordinates.map(corner => corner[1])
+          ...sourceParameters.coordinates.map(corner => corner[1]),
         );
 
         // Convert lon/lat to OpenLayer coordinates
@@ -634,14 +634,14 @@ export class MainView extends React.Component<IProps, IStates> {
         const imageUrl = await loadFile({
           filepath: sourceParameters.path,
           type: 'ImageSource',
-          model: this._model
+          model: this._model,
         });
 
         newSource = new Static({
           interpolate: sourceParameters.interpolate,
           imageExtent: extent,
           url: imageUrl,
-          crossOrigin: ''
+          crossOrigin: '',
         });
 
         break;
@@ -668,30 +668,30 @@ export class MainView extends React.Component<IProps, IStates> {
                 ...addNoData(sourceInfo),
                 min: sourceInfo.min,
                 max: sourceInfo.max,
-                url: sourceInfo.url
+                url: sourceInfo.url,
               };
             } else {
               const geotiff = await loadFile({
                 filepath: sourceInfo.url ?? '',
                 type: 'GeoTiffSource',
-                model: this._model
+                model: this._model,
               });
               return {
                 ...addNoData(sourceInfo),
                 min: sourceInfo.min,
                 max: sourceInfo.max,
                 geotiff,
-                url: URL.createObjectURL(geotiff.file)
+                url: URL.createObjectURL(geotiff.file),
               };
             }
-          })
+          }),
         );
 
         newSource = new GeoTIFFSource({
           interpolate: sourceParameters.interpolate,
           sources,
           normalize: sourceParameters.normalize,
-          wrapX: sourceParameters.wrapX
+          wrapX: sourceParameters.wrapX,
         });
 
         break;
@@ -787,7 +787,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
       if (!layer) {
         console.warn(
-          `Layer with ID ${layerId} does not exist in the shared model.`
+          `Layer with ID ${layerId} does not exist in the shared model.`,
         );
         continue;
       }
@@ -826,7 +826,7 @@ export class MainView extends React.Component<IProps, IStates> {
    */
   private async _buildMapLayer(
     id: string,
-    layer: IJGISLayer
+    layer: IJGISLayer,
   ): Promise<Layer | undefined> {
     const sourceId = layer.parameters?.source;
     const source = this._model.sharedModel.getLayerSource(sourceId);
@@ -855,7 +855,7 @@ export class MainView extends React.Component<IProps, IStates> {
         newMapLayer = new TileLayer({
           opacity: layerParameters.opacity,
           visible: layer.visible,
-          source: this._sources[layerParameters.source]
+          source: this._sources[layerParameters.source],
         });
 
         break;
@@ -867,7 +867,7 @@ export class MainView extends React.Component<IProps, IStates> {
           opacity: layerParameters.opacity,
           visible: layer.visible,
           source: this._sources[layerParameters.source],
-          style: this.vectorLayerStyleRuleBuilder(layer)
+          style: this.vectorLayerStyleRuleBuilder(layer),
         });
 
         break;
@@ -878,7 +878,7 @@ export class MainView extends React.Component<IProps, IStates> {
         newMapLayer = new VectorTileLayer({
           opacity: layerParameters.opacity,
           source: this._sources[layerParameters.source],
-          style: this.vectorLayerStyleRuleBuilder(layer)
+          style: this.vectorLayerStyleRuleBuilder(layer),
         });
 
         break;
@@ -890,8 +890,8 @@ export class MainView extends React.Component<IProps, IStates> {
           opacity: 0.3,
           source: this._sources[layerParameters.source],
           style: {
-            color: ['color', this.hillshadeMath()]
-          }
+            color: ['color', this.hillshadeMath()],
+          },
         });
 
         break;
@@ -901,7 +901,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
         newMapLayer = new ImageLayer({
           opacity: layerParameters.opacity,
-          source: this._sources[layerParameters.source]
+          source: this._sources[layerParameters.source],
         });
 
         break;
@@ -912,7 +912,7 @@ export class MainView extends React.Component<IProps, IStates> {
         // This is to handle python sending a None for the color
         const layerOptions: any = {
           opacity: layerParameters.opacity,
-          source: this._sources[layerParameters.source]
+          source: this._sources[layerParameters.source],
         };
 
         if (layerParameters.color) {
@@ -930,7 +930,7 @@ export class MainView extends React.Component<IProps, IStates> {
           source: this._sources[layerParameters.source],
           blur: layerParameters.blur ?? 15,
           radius: layerParameters.radius ?? 8,
-          gradient: layerParameters.color
+          gradient: layerParameters.color,
         });
         break;
       }
@@ -965,7 +965,7 @@ export class MainView extends React.Component<IProps, IStates> {
       // Check if the projection exists in proj4list
       if (!proj4list[projectionCode]) {
         console.warn(
-          `Projection code '${projectionCode}' not found in proj4list`
+          `Projection code '${projectionCode}' not found in proj4list`,
         );
         return;
       }
@@ -975,7 +975,7 @@ export class MainView extends React.Component<IProps, IStates> {
         register(proj4);
       } catch (error: any) {
         console.warn(
-          `Failed to register projection '${projectionCode}'. Error: ${error.message}`
+          `Failed to register projection '${projectionCode}'. Error: ${error.message}`,
         );
         return;
       }
@@ -1008,7 +1008,7 @@ export class MainView extends React.Component<IProps, IStates> {
     } catch (error: any) {
       if (
         this.state.loadingErrors.find(
-          item => item.id === id && item.error === error.message
+          item => item.id === id && item.error === error.message,
         )
       ) {
         this._loadingLayers.delete(id);
@@ -1017,13 +1017,13 @@ export class MainView extends React.Component<IProps, IStates> {
 
       await showErrorMessage(
         `Error Adding ${layer.name}`,
-        `Failed to add ${layer.name}: ${error.message || 'invalid file path'}`
+        `Failed to add ${layer.name}: ${error.message || 'invalid file path'}`,
       );
       this.setState(old => ({ ...old, loadingLayer: false }));
       this.state.loadingErrors.push({
         id,
         error: error.message || 'invalid file path',
-        index
+        index,
       });
       this._loadingLayers.delete(id);
     }
@@ -1042,11 +1042,11 @@ export class MainView extends React.Component<IProps, IStates> {
       'circle-radius': 5,
       'circle-fill-color': 'rgba(255,255,255,0.4)',
       'circle-stroke-width': 1.25,
-      'circle-stroke-color': '#3399CC'
+      'circle-stroke-color': '#3399CC',
     };
 
     const defaultRules: Rule = {
-      style: defaultStyle
+      style: defaultStyle,
     };
 
     const layerStyle = { ...defaultRules };
@@ -1069,7 +1069,7 @@ export class MainView extends React.Component<IProps, IStates> {
         // Arguments for "Any" and 'All' need to be wrapped in brackets
         filterExpr = [
           layer.filters.logicalOp,
-          ...layer.filters.appliedFilters.map(buildCondition)
+          ...layer.filters.appliedFilters.map(buildCondition),
         ];
       }
 
@@ -1111,7 +1111,7 @@ export class MainView extends React.Component<IProps, IStates> {
         ['*', 255 * 256, red],
         ['*', 255, green],
         ['*', 255 / 256, blue],
-        -32768
+        -32768,
       ];
     }
     // Generates a shaded relief image given elevation data.  Uses a 3x3
@@ -1131,7 +1131,7 @@ export class MainView extends React.Component<IProps, IStates> {
     const cosIncidence = [
       '+',
       ['*', ['sin', sunEl], ['cos', slope]],
-      ['*', ['cos', sunEl], ['sin', slope], ['cos', ['-', sunAz, aspect]]]
+      ['*', ['cos', sunEl], ['sin', slope], ['cos', ['-', sunAz, aspect]]],
     ];
     const scaled = ['*', 255, cosIncidence];
 
@@ -1148,7 +1148,7 @@ export class MainView extends React.Component<IProps, IStates> {
     id: string,
     layer: IJGISLayer,
     mapLayer: Layer,
-    oldLayer?: IDict
+    oldLayer?: IDict,
   ): Promise<void> {
     const sourceId = layer.parameters?.source;
     const source = this._model.sharedModel.getLayerSource(sourceId);
@@ -1173,7 +1173,7 @@ export class MainView extends React.Component<IProps, IStates> {
         mapLayer.setOpacity(layerParams.opacity || 1);
 
         (mapLayer as VectorLayer).setStyle(
-          this.vectorLayerStyleRuleBuilder(layer)
+          this.vectorLayerStyleRuleBuilder(layer),
         );
 
         break;
@@ -1184,7 +1184,7 @@ export class MainView extends React.Component<IProps, IStates> {
         mapLayer.setOpacity(layerParams.opacity || 1);
 
         (mapLayer as VectorTileLayer).setStyle(
-          this.vectorLayerStyleRuleBuilder(layer)
+          this.vectorLayerStyleRuleBuilder(layer),
         );
 
         break;
@@ -1201,7 +1201,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
         if (layer?.parameters?.color) {
           (mapLayer as WebGlTileLayer).setStyle({
-            color: layer.parameters.color
+            color: layer.parameters.color,
           });
         }
         break;
@@ -1214,7 +1214,7 @@ export class MainView extends React.Component<IProps, IStates> {
         heatmap.setBlur(layerParams.blur ?? 15);
         heatmap.setRadius(layerParams.radius ?? 8);
         heatmap.setGradient(
-          layerParams.color ?? ['#00f', '#0ff', '#0f0', '#ff0', '#f00']
+          layerParams.color ?? ['#00f', '#0ff', '#0f0', '#ff0', '#f00'],
         );
 
         this.handleTemporalController(id, layer);
@@ -1273,8 +1273,8 @@ export class MainView extends React.Component<IProps, IStates> {
         ...old,
         filterStates: {
           ...this.state.filterStates,
-          [selectedLayerId]: activeFilter
-        }
+          [selectedLayerId]: activeFilter,
+        },
       }));
 
       source.addFeatures(filteredFeatures);
@@ -1297,13 +1297,13 @@ export class MainView extends React.Component<IProps, IStates> {
     view.fit(extent, {
       padding: [50, 50, 50, 50],
       duration: 1000,
-      maxZoom: 16
+      maxZoom: 16,
     });
   }
 
   private highlightFeatureOnMap(
     sender: IJupyterGISModel,
-    featureOrGeometry: any
+    featureOrGeometry: any,
   ): void {
     const geometry =
       featureOrGeometry?.geometry ||
@@ -1320,12 +1320,12 @@ export class MainView extends React.Component<IProps, IStates> {
     const parsedGeometry = isOlGeometry
       ? geometry
       : new GeoJSON().readGeometry(geometry, {
-          featureProjection: this._Map.getView().getProjection()
+          featureProjection: this._Map.getView().getProjection(),
         });
 
     const olFeature = new Feature({
       geometry: parsedGeometry,
-      ...(geometry !== featureOrGeometry ? featureOrGeometry : {})
+      ...(geometry !== featureOrGeometry ? featureOrGeometry : {}),
     });
 
     if (!this._highlightLayer) {
@@ -1340,38 +1340,38 @@ export class MainView extends React.Component<IProps, IStates> {
                 image: new Circle({
                   radius: 6,
                   fill: new Fill({ color: 'rgba(255, 255, 0, 0.8)' }),
-                  stroke: new Stroke({ color: '#ff0', width: 2 })
-                })
+                  stroke: new Stroke({ color: '#ff0', width: 2 }),
+                }),
               });
             case 'LineString':
             case 'MultiLineString':
               return new Style({
                 stroke: new Stroke({
                   color: 'rgba(255, 255, 0, 0.8)',
-                  width: 3
-                })
+                  width: 3,
+                }),
               });
             case 'Polygon':
             case 'MultiPolygon':
               return new Style({
                 stroke: new Stroke({
                   color: '#f00',
-                  width: 2
+                  width: 2,
                 }),
                 fill: new Fill({
-                  color: 'rgba(255, 255, 0, 0.8)'
-                })
+                  color: 'rgba(255, 255, 0, 0.8)',
+                }),
               });
             default:
               return new Style({
                 stroke: new Stroke({
                   color: '#000',
-                  width: 2
-                })
+                  width: 2,
+                }),
               });
           }
         },
-        zIndex: 999
+        zIndex: 999,
       });
       this._Map.addLayer(this._highlightLayer);
     }
@@ -1438,7 +1438,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _onClientSharedStateChanged = (
     sender: IJupyterGISModel,
-    clients: Map<number, IJupyterGISClientState>
+    clients: Map<number, IJupyterGISClientState>,
   ): void => {
     const localState = this._model.localState;
     if (!localState) {
@@ -1496,7 +1496,7 @@ export class MainView extends React.Component<IProps, IStates> {
       if (pointer) {
         const pixel = this._Map.getPixelFromCoordinate([
           pointer.coordinates.x,
-          pointer.coordinates.y
+          pointer.coordinates.y,
         ]);
 
         const lonLat = toLonLat([pointer.coordinates.x, pointer.coordinates.y]);
@@ -1507,13 +1507,13 @@ export class MainView extends React.Component<IProps, IStates> {
             displayName: client.user.display_name,
             color: client.user.color,
             coordinates: { x: pixel[0], y: pixel[1] },
-            lonLat: { longitude: lonLat[0], latitude: lonLat[1] }
+            lonLat: { longitude: lonLat[0], latitude: lonLat[1] },
           };
         } else {
           currentClientPointer = {
             ...currentClientPointer,
             coordinates: { x: pixel[0], y: pixel[1] },
-            lonLat: { longitude: lonLat[0], latitude: lonLat[1] }
+            lonLat: { longitude: lonLat[0], latitude: lonLat[1] },
           };
         }
 
@@ -1532,11 +1532,11 @@ export class MainView extends React.Component<IProps, IStates> {
     if (isTemporalControllerActive !== this.state.displayTemporalController) {
       this.setState(old => ({
         ...old,
-        displayTemporalController: isTemporalControllerActive
+        displayTemporalController: isTemporalControllerActive,
       }));
 
       this._mainViewModel.commands.notifyCommandChanged(
-        CommandIDs.temporalController
+        CommandIDs.temporalController,
       );
     }
   };
@@ -1557,7 +1557,7 @@ export class MainView extends React.Component<IProps, IStates> {
       latitude,
       longitude,
       zoom,
-      bearing
+      bearing,
     } = options;
     let view = this._Map.getView();
     const currentProjection = view.getProjection().getCode();
@@ -1579,7 +1579,7 @@ export class MainView extends React.Component<IProps, IStates> {
     } else {
       const centerCoord = fromLonLat(
         [longitude || 0, latitude || 0],
-        view.getProjection()
+        view.getProjection(),
       );
 
       this._moveToPosition({ x: centerCoord[0], y: centerCoord[1] }, zoom || 0);
@@ -1598,7 +1598,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _onViewChanged(
     sender: ObservableMap<JSONValue>,
-    change: IObservableMap.IChangedArgs<JSONValue>
+    change: IObservableMap.IChangedArgs<JSONValue>,
   ): void {
     // TODO SOMETHING
   }
@@ -1676,7 +1676,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _onLayersChanged(
     _: IJupyterGISDoc,
-    change: IJGISLayerDocChange
+    change: IJGISLayerDocChange,
   ): void {
     // Avoid concurrency update on layers on first load, if layersTreeChanged and
     // LayersChanged are triggered simultaneously.
@@ -1714,7 +1714,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _onLayerTreeChange(
     sender?: IJupyterGISDoc,
-    change?: IJGISLayerTreeDocChange
+    change?: IJGISLayerTreeDocChange,
   ): void {
     this._ready = false;
     // We can't properly use the change, because of the nested groups in the the shared
@@ -1724,7 +1724,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _onSourcesChange(
     _: IJupyterGISDoc,
-    change: IJGISSourceDocChange
+    change: IJGISSourceDocChange,
   ): void {
     if (!this._ready) {
       return;
@@ -1744,7 +1744,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _onSharedModelStateChange = (
     _: any,
-    change: IJupyterGISDocChange
+    change: IJupyterGISDocChange,
   ) => {
     const changedState = change.stateChange?.map(value => value.name);
     if (!changedState?.includes('path')) {
@@ -1764,7 +1764,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _onSharedMetadataChanged = (
     _: IJupyterGISModel,
-    changes: MapChange
+    changes: MapChange,
   ) => {
     const newState = { ...this.state.annotations };
     changes.forEach((val, key) => {
@@ -1859,14 +1859,14 @@ export class MainView extends React.Component<IProps, IStates> {
 
     this._Map.getView().fit(transformedExtent, {
       size: this._Map.getSize(),
-      duration: 500
+      duration: 500,
     });
   }
 
   private _moveToPosition(
     center: { x: number; y: number },
     zoom: number,
-    duration = 1000
+    duration = 1000,
   ) {
     const view = this._Map.getView();
 
@@ -1882,7 +1882,7 @@ export class MainView extends React.Component<IProps, IStates> {
   private _flyToPosition(
     center: { x: number; y: number },
     zoom: number,
-    duration = 1000
+    duration = 1000,
   ) {
     const view = this._Map.getView();
     view.animate({ zoom, duration });
@@ -1898,7 +1898,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _syncPointer = throttle((coordinates: Coordinate) => {
     const pointer = {
-      coordinates: { x: coordinates[0], y: coordinates[1] }
+      coordinates: { x: coordinates[0], y: coordinates[1] },
     };
     this._model.syncPointer(pointer);
   });
@@ -1941,7 +1941,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
         this._model.syncIdentifiedFeatures(
           [bandValues],
-          this._mainViewModel.id
+          this._mainViewModel.id,
         );
 
         const coordinate = this._Map.getCoordinateFromPixel(e.pixel);
@@ -1984,7 +1984,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
   private _handleGeolocationChanged(
     sender: any,
-    newPosition: JgisCoordinates
+    newPosition: JgisCoordinates,
   ): void {
     const view = this._Map.getView();
     const zoom = view.getZoom();
@@ -1992,7 +1992,7 @@ export class MainView extends React.Component<IProps, IStates> {
       this._flyToPosition(newPosition, zoom);
     } else {
       throw new Error(
-        'Could not move to geolocation, because current zoom is not defined.'
+        'Could not move to geolocation, because current zoom is not defined.',
       );
     }
   }
@@ -2024,7 +2024,7 @@ export class MainView extends React.Component<IProps, IStates> {
                 id={key}
                 style={{
                   left: screenPosition.x,
-                  top: screenPosition.y
+                  top: screenPosition.y,
                 }}
                 className={'jGIS-Popup-Wrapper'}
               >
@@ -2050,7 +2050,7 @@ export class MainView extends React.Component<IProps, IStates> {
             style={{
               border: this.state.remoteUser
                 ? `solid 3px ${this.state.remoteUser.color}`
-                : 'unset'
+                : 'unset',
             }}
           >
             <Spinner loading={this.state.loading} />
@@ -2061,7 +2061,7 @@ export class MainView extends React.Component<IProps, IStates> {
               ref={this.divRef}
               style={{
                 width: '100%',
-                height: '100%'
+                height: '100%',
               }}
             />
           </div>

--- a/packages/base/src/mainview/mainviewmodel.ts
+++ b/packages/base/src/mainview/mainviewmodel.ts
@@ -2,7 +2,7 @@ import {
   IAnnotation,
   IJGISLayerDocChange,
   IJupyterGISDoc,
-  IJupyterGISModel
+  IJupyterGISModel,
 } from '@jupytergis/schema';
 import { ObservableMap } from '@jupyterlab/observables';
 import { CommandRegistry } from '@lumino/commands';
@@ -43,7 +43,7 @@ export class MainViewModel implements IDisposable {
     }
     this._jGISModel.sharedLayersChanged.disconnect(
       this._onsharedLayersChanged,
-      this
+      this,
     );
     this._isDisposed = true;
   }
@@ -51,7 +51,7 @@ export class MainViewModel implements IDisposable {
   initSignal(): void {
     this._jGISModel.sharedLayersChanged.connect(
       this._onsharedLayersChanged,
-      this
+      this,
     );
   }
 
@@ -61,7 +61,7 @@ export class MainViewModel implements IDisposable {
 
   private async _onsharedLayersChanged(
     _: IJupyterGISDoc,
-    change: IJGISLayerDocChange
+    change: IJGISLayerDocChange,
   ): Promise<void> {
     if (change.layerChange) {
       // TODO STUFF with the new updated shared model

--- a/packages/base/src/menus.ts
+++ b/packages/base/src/menus.ts
@@ -13,17 +13,17 @@ export const vectorSubMenu = (commands: CommandRegistry) => {
 
   subMenu.addItem({
     type: 'command',
-    command: CommandIDs.newVectorTileEntry
+    command: CommandIDs.newVectorTileEntry,
   });
 
   subMenu.addItem({
     type: 'command',
-    command: CommandIDs.newGeoJSONEntry
+    command: CommandIDs.newGeoJSONEntry,
   });
 
   subMenu.addItem({
     type: 'command',
-    command: CommandIDs.newShapefileEntry
+    command: CommandIDs.newShapefileEntry,
   });
 
   return subMenu;
@@ -38,22 +38,22 @@ export const rasterSubMenu = (commands: CommandRegistry) => {
 
   subMenu.addItem({
     type: 'command',
-    command: CommandIDs.newRasterEntry
+    command: CommandIDs.newRasterEntry,
   });
 
   subMenu.addItem({
     type: 'command',
-    command: CommandIDs.newHillshadeEntry
+    command: CommandIDs.newHillshadeEntry,
   });
 
   subMenu.addItem({
     type: 'command',
-    command: CommandIDs.newImageEntry
+    command: CommandIDs.newImageEntry,
   });
 
   subMenu.addItem({
     type: 'command',
-    command: CommandIDs.newGeoTiffEntry
+    command: CommandIDs.newGeoTiffEntry,
   });
 
   return subMenu;

--- a/packages/base/src/panelview/annotationPanel.tsx
+++ b/packages/base/src/panelview/annotationPanel.tsx
@@ -25,11 +25,11 @@ export class AnnotationsPanel extends Component<IAnnotationPanelProps> {
       // await this._annotationModel?.context?.ready;
 
       this._annotationModel?.model?.sharedMetadataChanged.disconnect(
-        updateCallback
+        updateCallback,
       );
       this._annotationModel = props.annotationModel;
       this._annotationModel?.model?.sharedMetadataChanged.connect(
-        updateCallback
+        updateCallback,
       );
       this.forceUpdate();
     });
@@ -76,7 +76,7 @@ export class Annotations extends PanelWithToolbar {
       <AnnotationsPanel
         rightPanelModel={this._rightPanelModel}
         annotationModel={this._annotationModel}
-      />
+      />,
     );
 
     this.addWidget(this._widget);

--- a/packages/base/src/panelview/components/filter-panel/Filter.tsx
+++ b/packages/base/src/panelview/components/filter-panel/Filter.tsx
@@ -3,7 +3,7 @@ import {
   IDict,
   IJGISFilterItem,
   IJupyterGISModel,
-  IJupyterGISTracker
+  IJupyterGISTracker,
 } from '@jupytergis/schema';
 import { Button, ReactWidget } from '@jupyterlab/ui-components';
 import { Panel } from '@lumino/widgets';
@@ -31,8 +31,8 @@ export class FilterPanel extends Panel {
         <FilterComponent
           model={this._model}
           tracker={this._tracker}
-        ></FilterComponent>
-      )
+        ></FilterComponent>,
+      ),
     );
   }
 
@@ -63,7 +63,7 @@ const FilterComponent = (props: IFilterComponentProps) => {
     Record<string, Set<string | number>>
   >({});
   const [model, setModel] = useState<IJupyterGISModel | undefined>(
-    props.model.jGISModel
+    props.model.jGISModel,
   );
 
   props.model?.documentChanged.connect((_, widget) => {
@@ -192,7 +192,7 @@ const FilterComponent = (props: IFilterComponentProps) => {
         const data = await loadFile({
           filepath: source.parameters?.path,
           type: 'GeoJSONSource',
-          model: model
+          model: model,
         });
         data?.features.forEach((feature: GeoJSONFeature1) => {
           feature.properties &&
@@ -212,7 +212,7 @@ const FilterComponent = (props: IFilterComponentProps) => {
 
   const addFeatureValue = (
     featureProperties: Record<string, string | number> | IDict,
-    aggregatedProperties: Record<string, Set<string | number>>
+    aggregatedProperties: Record<string, Set<string | number>>,
   ) => {
     Object.entries(featureProperties).forEach(([key, value]) => {
       if (!(key in aggregatedProperties)) {
@@ -228,8 +228,8 @@ const FilterComponent = (props: IFilterComponentProps) => {
       {
         feature: Object.keys(featuresInLayer)[0],
         operator: '==',
-        value: [...Object.values(featuresInLayer)[0]][0]
-      }
+        value: [...Object.values(featuresInLayer)[0]][0],
+      },
     ]);
   };
 

--- a/packages/base/src/panelview/components/filter-panel/FilterRow.tsx
+++ b/packages/base/src/panelview/components/filter-panel/FilterRow.tsx
@@ -8,7 +8,7 @@ const FilterRow = ({
   features,
   filterRows,
   setFilterRows,
-  deleteRow
+  deleteRow,
 }: {
   index: number;
   features: Record<string, Set<string | number>>;
@@ -19,10 +19,10 @@ const FilterRow = ({
   const operators = ['==', '!=', '>', '<', '>=', '<='];
 
   const [sortedFeatures, setSortedFeatures] = useState<{ [key: string]: any }>(
-    {}
+    {},
   );
   const [selectedFeature, setSelectedFeature] = useState(
-    filterRows[index].feature || Object.keys(features)[0]
+    filterRows[index].feature || Object.keys(features)[0],
   );
 
   // Ensure selected feature matches filter rows and proper values are displayed
@@ -46,7 +46,7 @@ const FilterRow = ({
   // Update the value when a new feature is selected
   useEffect(() => {
     const valueSelect = document.getElementById(
-      `jp-gis-value-select-${index}`
+      `jp-gis-value-select-${index}`,
     ) as HTMLSelectElement;
 
     if (!valueSelect) {
@@ -73,7 +73,7 @@ const FilterRow = ({
   };
 
   const handleOperatorChange = (
-    event: React.ChangeEvent<HTMLSelectElement>
+    event: React.ChangeEvent<HTMLSelectElement>,
   ) => {
     const newFilters = [...filterRows];
     newFilters[index].operator = event.target.value;

--- a/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
+++ b/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
@@ -4,7 +4,7 @@ import {
   IDict,
   IJupyterGISClientState,
   IJupyterGISModel,
-  IJupyterGISTracker
+  IJupyterGISTracker,
 } from '@jupytergis/schema';
 import { User } from '@jupyterlab/services';
 import { LabIcon, ReactWidget, caretDownIcon } from '@jupyterlab/ui-components';
@@ -29,8 +29,8 @@ export class IdentifyPanel extends Panel {
         <IdentifyPanelComponent
           controlPanelModel={this._model}
           tracker={this._tracker}
-        />
-      )
+        />,
+      ),
     );
   }
 
@@ -52,16 +52,16 @@ interface IIdentifyComponentProps {
 
 const IdentifyPanelComponent = ({
   controlPanelModel,
-  tracker
+  tracker,
 }: IIdentifyComponentProps) => {
   const [widgetId, setWidgetId] = useState('');
   const [features, setFeatures] = useState<IDict<any>>();
   const [visibleFeatures, setVisibleFeatures] = useState<IDict<any>>({
-    0: true
+    0: true,
   });
   const [remoteUser, setRemoteUser] = useState<User.IIdentity | null>(null);
   const [jgisModel, setJgisModel] = useState<IJupyterGISModel | undefined>(
-    controlPanelModel?.jGISModel
+    controlPanelModel?.jGISModel,
   );
 
   const featuresRef = useRef(features);
@@ -99,7 +99,7 @@ const IdentifyPanelComponent = ({
   useEffect(() => {
     const handleClientStateChanged = (
       sender: IJupyterGISModel,
-      clients: Map<number, IJupyterGISClientState>
+      clients: Map<number, IJupyterGISClientState>,
     ) => {
       const remoteUserId = jgisModel?.localState?.remoteUser;
 
@@ -150,7 +150,7 @@ const IdentifyPanelComponent = ({
   const toggleFeatureVisibility = (index: number) => {
     setVisibleFeatures(prev => ({
       ...prev,
-      [index]: !prev[index]
+      [index]: !prev[index],
     }));
   };
 
@@ -160,7 +160,7 @@ const IdentifyPanelComponent = ({
       style={{
         border: jgisModel?.localState?.remoteUser
           ? `solid 3px ${remoteUser?.color}`
-          : 'unset'
+          : 'unset',
       }}
     >
       {features &&
@@ -207,7 +207,7 @@ const IdentifyPanelComponent = ({
                 {Object.entries(feature)
                   .filter(
                     ([key, value]) =>
-                      typeof value !== 'object' || value === null
+                      typeof value !== 'object' || value === null,
                   )
                   .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
                   .map(([key, value]) => (

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -2,7 +2,7 @@ import {
   IJGISLayerGroup,
   IJGISLayerTree,
   IJupyterGISClientState,
-  IJupyterGISModel
+  IJupyterGISModel,
 } from '@jupytergis/schema';
 import { DOMUtils } from '@jupyterlab/apputils';
 import { IStateDB } from '@jupyterlab/statedb';
@@ -10,21 +10,21 @@ import {
   Button,
   LabIcon,
   ReactWidget,
-  caretDownIcon
+  caretDownIcon,
 } from '@jupyterlab/ui-components';
 import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { Panel } from '@lumino/widgets';
 import React, {
   MouseEvent as ReactMouseEvent,
   useEffect,
-  useState
+  useState,
 } from 'react';
 
 import { icons } from '@/src/constants';
 import { nonVisibilityIcon, visibilityIcon } from '@/src/icons';
 import {
   ILayerPanelOptions,
-  ILeftPanelClickHandlerParams
+  ILeftPanelClickHandlerParams,
 } from '@/src/panelview/leftpanel';
 import { IControlPanelModel } from '@/src/types';
 
@@ -57,8 +57,8 @@ export class LayersPanel extends Panel {
           model={this._model}
           onSelect={this._onSelect}
           state={this._state}
-        ></LayersBodyComponent>
-      )
+        ></LayersBodyComponent>,
+      ),
     );
     this.node.ondragover = this._onDragOver;
     this.node.ondrop = this._onDrop;
@@ -120,7 +120,7 @@ export class LayersPanel extends Panel {
     model?.moveItemRelatedTo(
       draggedId,
       dragOverId,
-      dragOverPosition === 'above'
+      dragOverPosition === 'above',
     );
   };
 
@@ -129,7 +129,7 @@ export class LayersPanel extends Panel {
   private _onSelect: ({
     type,
     item,
-    nodeId
+    nodeId,
   }: ILeftPanelClickHandlerParams) => void;
 }
 
@@ -147,10 +147,10 @@ interface IBodyProps {
  */
 function LayersBodyComponent(props: IBodyProps): JSX.Element {
   const [model, setModel] = useState<IJupyterGISModel | undefined>(
-    props.model?.jGISModel
+    props.model?.jGISModel,
   );
   const [layerTree, setLayerTree] = useState<IJGISLayerTree>(
-    model?.getLayerTree() || []
+    model?.getLayerTree() || [],
   );
 
   /**
@@ -160,7 +160,7 @@ function LayersBodyComponent(props: IBodyProps): JSX.Element {
     type,
     item,
     nodeId,
-    event
+    event,
   }: ILeftPanelClickHandlerParams) => {
     props.onSelect({ type, item, nodeId, event });
   };
@@ -211,7 +211,7 @@ function LayersBodyComponent(props: IBodyProps): JSX.Element {
               onClick={onItemClick}
               state={props.state}
             />
-          )
+          ),
         )}
     </div>
   );
@@ -243,7 +243,7 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
   const layers = group?.layers ?? [];
   const [selected, setSelected] = useState<boolean>(
     // TODO Support multi-selection as `model?.jGISModel?.localState?.selected.value` does
-    isSelected(group.name, gisModel)
+    isSelected(group.name, gisModel),
   );
 
   useEffect(() => {
@@ -253,7 +253,7 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
 
       setOpen(
         ((groupState as ReadonlyPartialJSONObject)?.expanded as boolean) ??
-          false
+          false,
       );
     };
 
@@ -330,7 +330,7 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
                   onClick={onClick}
                   state={props.state}
                 />
-              )
+              ),
             )}
         </div>
       )}
@@ -368,7 +368,7 @@ function LayerComponent(props: ILayerProps): JSX.Element {
   const [id, setId] = useState('');
   const [selected, setSelected] = useState<boolean>(
     // TODO Support multi-selection as `model?.jGISModel?.localState?.selected.value` does
-    isSelected(layerId, gisModel)
+    isSelected(layerId, gisModel),
   );
   const name = layer.name;
 
@@ -382,7 +382,7 @@ function LayerComponent(props: ILayerProps): JSX.Element {
   useEffect(() => {
     const onClientSharedStateChanged = (
       sender: IJupyterGISModel,
-      clients: Map<number, IJupyterGISClientState>
+      clients: Map<number, IJupyterGISClientState>,
     ) => {
       // TODO Support follow mode and remoteUser state
       setSelected(isSelected(layerId, gisModel));
@@ -461,7 +461,7 @@ namespace Private {
   export const dragInfo: IDragInfo = {
     draggedElement: null,
     dragOverElement: null,
-    dragOverPosition: null
+    dragOverPosition: null,
   };
 
   export const onDragStart = (e: React.DragEvent) => {
@@ -474,7 +474,7 @@ namespace Private {
     const { clientY } = e;
 
     let target = (e.target as HTMLElement).closest(
-      `.${LAYER_GROUP_HEADER_CLASS}, .${LAYER_ITEM_CLASS}`
+      `.${LAYER_GROUP_HEADER_CLASS}, .${LAYER_ITEM_CLASS}`,
     ) as HTMLDivElement;
 
     if (!target) {

--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -2,7 +2,7 @@ import {
   IJupyterGISTracker,
   ISelection,
   JupyterGISDoc,
-  SelectionType
+  SelectionType,
 } from '@jupytergis/schema';
 import { IStateDB } from '@jupyterlab/statedb';
 import { SidePanel } from '@jupyterlab/ui-components';
@@ -52,7 +52,7 @@ export class LeftPanelWidget extends SidePanel {
     const layerTree = new LayersPanel({
       model: this._model,
       state: this._state,
-      onSelect: this._onSelect
+      onSelect: this._onSelect,
     });
     layerTree.title.caption = 'Layer tree';
     layerTree.title.label = 'Layers';
@@ -60,7 +60,7 @@ export class LeftPanelWidget extends SidePanel {
 
     const filterPanel = new FilterPanel({
       model: this._model,
-      tracker: options.tracker
+      tracker: options.tracker,
     });
 
     filterPanel.title.caption = 'Filters';
@@ -121,7 +121,7 @@ export class LeftPanelWidget extends SidePanel {
     type,
     item,
     nodeId,
-    event
+    event,
   }: ILeftPanelClickHandlerParams) => {
     if (!this._model || !nodeId) {
       return;
@@ -158,7 +158,7 @@ export class LeftPanelWidget extends SidePanel {
     if (nodeId) {
       // Check if new selection is the same type as previous selections
       const isSelectedSameType = Object.values(selectedValue).some(
-        selection => selection.type === type
+        selection => selection.type === type,
       );
 
       if (!isSelectedSameType) {
@@ -170,7 +170,7 @@ export class LeftPanelWidget extends SidePanel {
       // If types are the same add the selection
       const updatedSelectedValue = {
         ...selectedValue,
-        [item]: { type, selectedNodeId: nodeId }
+        [item]: { type, selectedNodeId: nodeId },
       };
       this._lastSelectedNodeId = nodeId;
 
@@ -185,7 +185,7 @@ export class LeftPanelWidget extends SidePanel {
     if (item && nodeId) {
       selection[item] = {
         type,
-        selectedNodeId: nodeId
+        selectedNodeId: nodeId,
       };
       this._lastSelectedNodeId = nodeId;
     }

--- a/packages/base/src/panelview/model.ts
+++ b/packages/base/src/panelview/model.ts
@@ -2,7 +2,7 @@ import {
   IJupyterGISDoc,
   IJupyterGISModel,
   IJupyterGISTracker,
-  IJupyterGISWidget
+  IJupyterGISWidget,
 } from '@jupytergis/schema';
 import { ISignal } from '@lumino/signaling';
 

--- a/packages/base/src/panelview/objectproperties.tsx
+++ b/packages/base/src/panelview/objectproperties.tsx
@@ -2,7 +2,7 @@ import {
   IJGISFormSchemaRegistry,
   IJupyterGISClientState,
   IJupyterGISModel,
-  IJupyterGISTracker
+  IJupyterGISTracker,
 } from '@jupytergis/schema';
 import { ReactWidget } from '@jupyterlab/apputils';
 import { PanelWithToolbar } from '@jupyterlab/ui-components';
@@ -22,7 +22,7 @@ export class ObjectProperties extends PanelWithToolbar {
         cpModel={params.controlPanelModel}
         tracker={params.tracker}
         formSchemaRegistry={params.formSchemaRegistry}
-      />
+      />,
     );
     this.addWidget(body);
     this.addClass('jGIS-sidebar-propertiespanel');
@@ -49,14 +49,14 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
     this.state = {
       model: props.tracker.currentWidget?.model,
       clientId: null,
-      id: uuid()
+      id: uuid(),
     };
 
     this.props.cpModel.jGISModel?.sharedLayersChanged.connect(
-      this._sharedJGISModelChanged
+      this._sharedJGISModelChanged,
     );
     this.props.cpModel.jGISModel?.sharedSourcesChanged.connect(
-      this._sharedJGISModelChanged
+      this._sharedJGISModelChanged,
     );
     this.props.cpModel.documentChanged.connect((_, changed) => {
       if (changed) {
@@ -65,21 +65,21 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
 
         changed.model.sharedLayersChanged.connect(this._sharedJGISModelChanged);
         changed.model.sharedSourcesChanged.connect(
-          this._sharedJGISModelChanged
+          this._sharedJGISModelChanged,
         );
         changed.model.clientStateChanged.connect(
-          this._onClientSharedStateChanged
+          this._onClientSharedStateChanged,
         );
         this.setState(old => ({
           ...old,
           model: changed.model,
           filePath: changed.model.filePath,
-          clientId: changed.model.getClientId()
+          clientId: changed.model.getClientId(),
         }));
       } else {
         this.setState({
           model: undefined,
-          selectedObject: undefined
+          selectedObject: undefined,
         });
       }
     });
@@ -91,7 +91,7 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
 
   private _onClientSharedStateChanged = (
     sender: IJupyterGISModel,
-    clients: Map<number, IJupyterGISClientState>
+    clients: Map<number, IJupyterGISClientState>,
   ): void => {
     let newState: IJupyterGISClientState | undefined;
     const clientId = this.state.clientId;
@@ -112,7 +112,7 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
       if (selection === undefined || selectedObjectIds.length !== 1) {
         this.setState(old => ({
           ...old,
-          selectedObject: undefined
+          selectedObject: undefined,
         }));
         return;
       }
@@ -121,7 +121,7 @@ class ObjectPropertiesReact extends React.Component<IProps, IStates> {
       if (selectedObject !== this.state.selectedObject) {
         this.setState(old => ({
           ...old,
-          selectedObject
+          selectedObject,
         }));
       }
     }

--- a/packages/base/src/panelview/rightpanel.tsx
+++ b/packages/base/src/panelview/rightpanel.tsx
@@ -3,7 +3,7 @@ import {
   IJGISFormSchemaRegistry,
   IJupyterGISModel,
   IJupyterGISTracker,
-  JupyterGISDoc
+  JupyterGISDoc,
 } from '@jupytergis/schema';
 import { SidePanel } from '@jupyterlab/ui-components';
 
@@ -28,20 +28,20 @@ export class RightPanelWidget extends SidePanel {
     const properties = new ObjectProperties({
       controlPanelModel: this._model,
       formSchemaRegistry: options.formSchemaRegistry,
-      tracker: options.tracker
+      tracker: options.tracker,
     });
 
     this.addWidget(properties);
 
     const annotations = new Annotations({
       rightPanelModel: this._model,
-      annotationModel: this._annotationModel
+      annotationModel: this._annotationModel,
     });
     this.addWidget(annotations);
 
     const identifyPanel = new IdentifyPanel({
       model: this._model,
-      tracker: options.tracker
+      tracker: options.tracker,
     });
     identifyPanel.title.caption = 'Identify';
     identifyPanel.title.label = 'Identify';

--- a/packages/base/src/processing.ts
+++ b/packages/base/src/processing.ts
@@ -4,7 +4,7 @@ import {
   IJGISSource,
   IJupyterGISModel,
   IJGISFormSchemaRegistry,
-  LayerType
+  LayerType,
 } from '@jupytergis/schema';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { UUID } from '@lumino/coreutils';
@@ -18,7 +18,7 @@ import { JupyterGISTracker } from './types';
  * Get the currently selected layer from the shared model. Returns null if there is no selection or multiple layer is selected.
  */
 export function getSingleSelectedLayer(
-  tracker: JupyterGISTracker
+  tracker: JupyterGISTracker,
 ): IJGISLayer | null {
   const model = tracker.currentWidget?.model as IJupyterGISModel;
   if (!model) {
@@ -49,7 +49,7 @@ export function getSingleSelectedLayer(
  */
 export function selectedLayerIsOfType(
   allowedTypes: LayerType[],
-  tracker: JupyterGISTracker
+  tracker: JupyterGISTracker,
 ): boolean {
   const selectedLayer = getSingleSelectedLayer(tracker);
   return selectedLayer ? allowedTypes.includes(selectedLayer.type) : false;
@@ -61,7 +61,7 @@ export function selectedLayerIsOfType(
 export async function getLayerGeoJSON(
   layer: IJGISLayer,
   sources: IDict,
-  model: IJupyterGISModel
+  model: IJupyterGISModel,
 ): Promise<string | null> {
   if (!layer.parameters || !layer.parameters.source) {
     console.error('Selected layer does not have a valid source.');
@@ -71,7 +71,7 @@ export async function getLayerGeoJSON(
   const source = sources[layer.parameters.source];
   if (!source || !source.parameters) {
     console.error(
-      `Source with ID ${layer.parameters.source} not found or missing path.`
+      `Source with ID ${layer.parameters.source} not found or missing path.`,
     );
     return null;
   }
@@ -97,7 +97,7 @@ export async function processSelectedLayer(
     gdalFunction: GdalFunctions;
     options: (sqlQuery: string) => string[];
   },
-  app: JupyterFrontEnd
+  app: JupyterFrontEnd,
 ) {
   const selected = getSingleSelectedLayer(tracker);
   if (!selected || !tracker.currentWidget) {
@@ -113,10 +113,10 @@ export async function processSelectedLayer(
   }
 
   const schema = {
-    ...(formSchemaRegistry.getSchemas().get(processingType) as IDict)
+    ...(formSchemaRegistry.getSchemas().get(processingType) as IDict),
   };
   const selectedLayerId = Object.keys(
-    model?.sharedModel.awareness.getLocalState()?.selected?.value || {}
+    model?.sharedModel.awareness.getLocalState()?.selected?.value || {},
   )[0];
 
   // Open ProcessingFormDialog
@@ -127,14 +127,14 @@ export async function processSelectedLayer(
       model,
       sourceData: {
         inputLayer: selectedLayerId,
-        outputLayerName: selected.name
+        outputLayerName: selected.name,
       },
       formContext: 'create',
       processingType,
       syncData: (props: IDict) => {
         resolve(props);
         dialog.dispose();
-      }
+      },
     });
     dialog.launch();
   });
@@ -159,10 +159,10 @@ export async function processSelectedLayer(
   const embedOutputLayer = formValues.embedOutputLayer;
 
   const fileBlob = new Blob([geojsonString], {
-    type: 'application/geo+json'
+    type: 'application/geo+json',
   });
   const geoFile = new File([fileBlob], 'data.geojson', {
-    type: 'application/geo+json'
+    type: 'application/geo+json',
   });
 
   const Gdal = await getGdal();
@@ -182,7 +182,7 @@ export async function processSelectedLayer(
     processingType,
     embedOutputLayer,
     tracker,
-    app
+    app,
   );
 }
 
@@ -195,12 +195,12 @@ export async function executeSQLProcessing(
   processingType: 'Buffer' | 'Dissolve',
   embedOutputLayer: boolean,
   tracker: JupyterGISTracker,
-  app: JupyterFrontEnd
+  app: JupyterFrontEnd,
 ) {
   const geoFile = new File(
     [new Blob([geojsonString], { type: 'application/geo+json' })],
     'data.geojson',
-    { type: 'application/geo+json' }
+    { type: 'application/geo+json' },
   );
 
   const Gdal = await getGdal();
@@ -229,7 +229,7 @@ export async function executeSQLProcessing(
     await app.serviceManager.contents.save(savePath, {
       type: 'file',
       format: 'text',
-      content: processedGeoJSONString
+      content: processedGeoJSONString,
     });
 
     const newSourceId = UUID.uuid4();
@@ -237,15 +237,15 @@ export async function executeSQLProcessing(
       type: 'GeoJSONSource',
       name: outputFileName,
       parameters: {
-        path: outputFileName
-      }
+        path: outputFileName,
+      },
     };
 
     const layerModel: IJGISLayer = {
       type: 'VectorLayer',
       parameters: { source: newSourceId },
       visible: true,
-      name: outputFileName
+      name: outputFileName,
     };
 
     model.sharedModel.addSource(newSourceId, sourceModel);
@@ -258,14 +258,14 @@ export async function executeSQLProcessing(
     const sourceModel: IJGISSource = {
       type: 'GeoJSONSource',
       name: `${layerNamePrefix} ${processingType.charAt(0).toUpperCase() + processingType.slice(1)}`,
-      parameters: { data: processedGeoJSON }
+      parameters: { data: processedGeoJSON },
     };
 
     const layerModel: IJGISLayer = {
       type: 'VectorLayer',
       parameters: { source: newSourceId },
       visible: true,
-      name: `${layerNamePrefix} ${processingType.charAt(0).toUpperCase() + processingType.slice(1)}`
+      name: `${layerNamePrefix} ${processingType.charAt(0).toUpperCase() + processingType.slice(1)}`,
     };
 
     model.sharedModel.addSource(newSourceId, sourceModel);

--- a/packages/base/src/statusbar/StatusBar.tsx
+++ b/packages/base/src/statusbar/StatusBar.tsx
@@ -1,7 +1,7 @@
 import {
   faGlobe,
   faLocationDot,
-  faRuler
+  faRuler,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Progress } from '@jupyter/react-components';
@@ -20,7 +20,7 @@ const StatusBar = ({
   jgisModel,
   loading,
   projection,
-  scale
+  scale,
 }: IStatusBarProps) => {
   const [coords, setCoords] = useState<JgisCoordinates>({ x: 0, y: 0 });
 

--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -9,7 +9,7 @@ import {
   ToolbarButton,
   addIcon,
   redoIcon,
-  undoIcon
+  undoIcon,
 } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';
 import { Widget } from '@lumino/widgets';
@@ -43,7 +43,7 @@ export class ToolbarWidget extends ReactiveToolbar {
         id: CommandIDs.undo,
         label: '',
         icon: undoIcon,
-        commands: options.commands
+        commands: options.commands,
       });
 
       this.addItem('undo', undoButton);
@@ -53,7 +53,7 @@ export class ToolbarWidget extends ReactiveToolbar {
         id: CommandIDs.redo,
         label: '',
         icon: redoIcon,
-        commands: options.commands
+        commands: options.commands,
       });
       this.addItem('redo', redoButton);
 
@@ -63,7 +63,7 @@ export class ToolbarWidget extends ReactiveToolbar {
         id: CommandIDs.toggleConsole,
         commands: options.commands,
         label: '',
-        icon: terminalToolbarIcon
+        icon: terminalToolbarIcon,
       });
       this.addItem('Toggle console', toggleConsoleButton);
       toggleConsoleButton.node.dataset.testid = 'toggle-console-button';
@@ -73,7 +73,7 @@ export class ToolbarWidget extends ReactiveToolbar {
       const openLayersBrowserButton = new CommandToolbarButton({
         id: CommandIDs.openLayerBrowser,
         label: '',
-        commands: options.commands
+        commands: options.commands,
       });
       this.addItem('openLayerBrowser', openLayersBrowserButton);
       openLayersBrowserButton.node.dataset.testid = 'open-layers-browser';
@@ -83,11 +83,11 @@ export class ToolbarWidget extends ReactiveToolbar {
 
       NewSubMenu.addItem({
         type: 'submenu',
-        submenu: rasterSubMenu(options.commands)
+        submenu: rasterSubMenu(options.commands),
       });
       NewSubMenu.addItem({
         type: 'submenu',
-        submenu: vectorSubMenu(options.commands)
+        submenu: vectorSubMenu(options.commands),
       });
 
       const NewEntryButton = new ToolbarButton({
@@ -101,7 +101,7 @@ export class ToolbarWidget extends ReactiveToolbar {
           const bbox = NewEntryButton.node.getBoundingClientRect();
 
           NewSubMenu.open(bbox.x, bbox.bottom);
-        }
+        },
       });
       NewEntryButton.node.dataset.testid = 'new-entry-button';
 
@@ -112,7 +112,7 @@ export class ToolbarWidget extends ReactiveToolbar {
       const geolocationButton = new CommandToolbarButton({
         id: CommandIDs.getGeolocation,
         commands: options.commands,
-        label: ''
+        label: '',
       });
       this.addItem('Geolocation', geolocationButton);
       geolocationButton.node.dataset.testid = 'geolocation-button';
@@ -120,7 +120,7 @@ export class ToolbarWidget extends ReactiveToolbar {
       const identifyButton = new CommandToolbarButton({
         id: CommandIDs.identify,
         label: '',
-        commands: options.commands
+        commands: options.commands,
       });
 
       this.addItem('identify', identifyButton);
@@ -129,7 +129,7 @@ export class ToolbarWidget extends ReactiveToolbar {
       const temporalControllerButton = new CommandToolbarButton({
         id: CommandIDs.temporalController,
         label: '',
-        commands: options.commands
+        commands: options.commands,
       });
       this.addItem('temporalController', temporalControllerButton);
       temporalControllerButton.node.dataset.testid =
@@ -140,7 +140,7 @@ export class ToolbarWidget extends ReactiveToolbar {
       // Users
       this.addItem(
         'users',
-        ReactWidget.create(<UsersItem model={options.model} />)
+        ReactWidget.create(<UsersItem model={options.model} />),
       );
     }
   }

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -5,7 +5,7 @@ import {
   IJGISSource,
   IJupyterGISModel,
   IRasterLayerGalleryEntry,
-  SourceType
+  SourceType,
 } from '@jupytergis/schema';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { PathExt, URLExt } from '@jupyterlab/coreutils';
@@ -20,7 +20,7 @@ import { getGdal } from '@/src/gdal';
 
 export const debounce = (
   func: CallableFunction,
-  timeout = 100
+  timeout = 100,
 ): CallableFunction => {
   let timeoutId: number;
   return (...args: any[]) => {
@@ -33,7 +33,7 @@ export const debounce = (
 
 export function throttle<T extends (...args: any[]) => void>(
   callback: T,
-  delay = 100
+  delay = 100,
 ): T {
   let last: number;
   let timer: any;
@@ -54,7 +54,7 @@ export function throttle<T extends (...args: any[]) => void>(
 
 export function getElementFromProperty(
   filePath?: string | null,
-  prop?: string | null
+  prop?: string | null,
 ): HTMLElement | undefined | null {
   if (!filePath || !prop) {
     return;
@@ -92,7 +92,7 @@ export function getCSSVariableColor(name: string): string {
  */
 export async function requestAPI<T>(
   endPoint = '',
-  init: RequestInit = {}
+  init: RequestInit = {},
 ): Promise<T> {
   // Make request to Jupyter API
   const settings = ServerConnection.makeSettings();
@@ -139,7 +139,7 @@ export function deepCopy<T = IDict<any>>(value: T): T {
  * @param layerBrowserRegistry Registry to add layers to
  */
 export function createDefaultLayerRegistry(
-  layerBrowserRegistry: IJGISLayerBrowserRegistry
+  layerBrowserRegistry: IJGISLayerBrowserRegistry,
 ): void {
   const RASTER_THUMBNAILS: { [key: string]: string } = {};
 
@@ -156,7 +156,7 @@ export function createDefaultLayerRegistry(
   const context = require.context(
     '../rasterlayer_gallery',
     false,
-    /\.(png|jpe?g|gif|svg)$/
+    /\.(png|jpe?g|gif|svg)$/,
   );
   importAll(context);
 
@@ -171,7 +171,7 @@ export function createDefaultLayerRegistry(
         const tile = convertToRegistryEntry(
           xyzprovider[mapName]['name'],
           xyzprovider[mapName],
-          entry
+          entry,
         );
 
         layerBrowserRegistry.addRegistryLayer(tile);
@@ -191,7 +191,7 @@ export function createDefaultLayerRegistry(
   function convertToRegistryEntry(
     entry: string,
     xyzprovider: { [x: string]: any },
-    provider?: string | undefined
+    provider?: string | undefined,
   ): IRasterLayerGalleryEntry {
     const urlParameters: any = {};
     if (xyzprovider.time) {
@@ -216,8 +216,8 @@ export function createDefaultLayerRegistry(
         maxZoom: xyzprovider['max_zoom'] || 24,
         attribution: xyzprovider['attribution'] || '',
         provider: provider ?? entry,
-        urlParameters
-      }
+        urlParameters,
+      },
     };
   }
 }
@@ -229,7 +229,7 @@ function getTileCoordinates(latDeg: number, lonDeg: number, zoom: number) {
   const n = 1 << zoom;
   const xTile = Math.floor(((lonDeg + 180.0) / 360.0) * n);
   const yTile = Math.floor(
-    (n * (1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI)) / 2
+    (n * (1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI)) / 2,
   );
 
   // Check if either xTile or yTile is NaN
@@ -243,7 +243,7 @@ function getTileCoordinates(latDeg: number, lonDeg: number, zoom: number) {
 export async function getLayerTileInfo(
   tileUrl: string,
   mapOptions: Pick<IJGISOptions, 'latitude' | 'longitude' | 'extent' | 'zoom'>,
-  urlParameters?: IDict<string>
+  urlParameters?: IDict<string>,
 ): Promise<VectorTile> {
   // If it's tilejson, fetch the json to access the pbf url
   if (tileUrl.includes('.json')) {
@@ -312,7 +312,7 @@ export function parseColor(style: any): IParsedStyle | undefined {
     joinStyle:
       style['circle-stroke-line-join'] ?? style['stroke-line-join'] ?? 'round',
     capStyle:
-      style['circle-stroke-line-cap'] ?? style['stroke-line-cap'] ?? 'round'
+      style['circle-stroke-line-cap'] ?? style['stroke-line-cap'] ?? 'round',
   };
 
   return parsedStyle;
@@ -350,7 +350,7 @@ export const openDatabase = () => {
 export const saveToIndexedDB = async (
   key: string,
   file: any,
-  metadata?: any | undefined
+  metadata?: any | undefined,
 ) => {
   const db = await openDatabase();
   return new Promise<void>((resolve, reject) => {
@@ -390,7 +390,7 @@ export const getFromIndexedDB = async (key: string) => {
 const fetchWithProxies = async <T>(
   url: string,
   model: IJupyterGISModel,
-  parseResponse: (response: Response) => Promise<T>
+  parseResponse: (response: Response) => Promise<T>,
 ): Promise<T | null> => {
   let settings: any = null;
 
@@ -406,7 +406,7 @@ const fetchWithProxies = async <T>(
   const proxyUrls = [
     url, // Direct fetch
     `/jupytergis_core/proxy?url=${encodeURIComponent(url)}`, // Internal proxy
-    `${proxyUrl}/?url=${encodeURIComponent(url)}` // External proxy
+    `${proxyUrl}/?url=${encodeURIComponent(url)}`, // External proxy
   ];
 
   for (const proxyUrl of proxyUrls) {
@@ -414,7 +414,7 @@ const fetchWithProxies = async <T>(
       const response = await fetch(proxyUrl);
       if (!response.ok) {
         console.warn(
-          `Failed to fetch from ${proxyUrl}: ${response.statusText}`
+          `Failed to fetch from ${proxyUrl}: ${response.statusText}`,
         );
         continue;
       }
@@ -436,7 +436,7 @@ const fetchWithProxies = async <T>(
 export const loadGeoTiff = async (
   sourceInfo: { url?: string | undefined },
   model: IJupyterGISModel,
-  file?: Contents.IModel | null
+  file?: Contents.IModel | null,
 ) => {
   if (!sourceInfo?.url) {
     return null;
@@ -453,7 +453,7 @@ export const loadGeoTiff = async (
     return {
       file: cachedData.file,
       metadata: cachedData.metadata,
-      sourceUrl: url
+      sourceUrl: url,
     };
   }
 
@@ -461,7 +461,7 @@ export const loadGeoTiff = async (
 
   if (!file) {
     fileBlob = await fetchWithProxies(url, model, async response =>
-      response.blob()
+      response.blob(),
     );
     if (!fileBlob) {
       showErrorMessage('Network error', `Failed to fetch ${url}`);
@@ -483,7 +483,7 @@ export const loadGeoTiff = async (
   return {
     file: fileBlob,
     metadata,
-    sourceUrl: url
+    sourceUrl: url,
   };
 };
 
@@ -535,7 +535,7 @@ export const loadFile = async (fileInfo: {
           async response => {
             const arrayBuffer = await response.arrayBuffer();
             return shp(arrayBuffer);
-          }
+          },
         );
 
         if (geojson) {
@@ -556,7 +556,7 @@ export const loadFile = async (fileInfo: {
         const geojson = await fetchWithProxies(
           filepath,
           model,
-          async response => response.json()
+          async response => response.json(),
         );
 
         if (geojson) {
@@ -580,12 +580,12 @@ export const loadFile = async (fileInfo: {
 
   const absolutePath = PathExt.resolve(
     PathExt.dirname(model.filePath),
-    filepath
+    filepath,
   );
 
   try {
     const file = await model.contentsManager.get(absolutePath, {
-      content: true
+      content: true,
     });
 
     if (!file.content) {
@@ -668,7 +668,7 @@ const validateImage = async (blob: Blob): Promise<void> => {
  */
 export const base64ToBlob = async (
   base64: string,
-  mimeType: string
+  mimeType: string,
 ): Promise<Blob> => {
   const response = await fetch(`data:${mimeType};base64,${base64}`);
   return await response.blob();
@@ -816,7 +816,7 @@ export const MIME_TYPES: { [ext: string]: string } = {
   '.xul': 'text/xul',
   '.xwd': 'image/x-xwindowdump',
   '.zip': 'application/zip',
-  '.ipynb': 'application/json'
+  '.ipynb': 'application/json',
 };
 
 /**
@@ -833,7 +833,7 @@ export const getMimeType = (filename: string): string => {
   }
 
   console.warn(
-    `Unknown file extension: ${extension}, defaulting to 'application/octet-stream'.`
+    `Unknown file extension: ${extension}, defaulting to 'application/octet-stream'.`,
   );
   return 'application/octet-stream';
 };
@@ -845,17 +845,18 @@ export const getMimeType = (filename: string): string => {
  * @returns An ArrayBuffer.
  */
 export const stringToArrayBuffer = async (
-  content: string
+  content: string,
 ): Promise<ArrayBuffer> => {
   const base64Response = await fetch(
-    `data:application/octet-stream;base64,${content}`
+    `data:application/octet-stream;base64,${content}`,
   );
   return await base64Response.arrayBuffer();
 };
 
 const getFeatureAttributes = <T>(
   featureProperties: Record<string, Set<any>>,
-  predicate: (key: string, value: any) => boolean = (key: string, value) => true
+  predicate: (key: string, value: any) => boolean = (key: string, value) =>
+    true,
 ): Record<string, Set<T>> => {
   const filteredRecord: Record<string, Set<T>> = {};
 
@@ -878,7 +879,7 @@ const getFeatureAttributes = <T>(
  * @returns - Attributes which are numeric.
  */
 export const getNumericFeatureAttributes = (
-  featureProperties: Record<string, Set<any>>
+  featureProperties: Record<string, Set<any>>,
 ): Record<string, Set<number>> => {
   return getFeatureAttributes<number>(featureProperties, (_: string, value) => {
     return !(typeof value === 'string' && isNaN(Number(value)));
@@ -892,7 +893,7 @@ export const getNumericFeatureAttributes = (
  * @returns - Attributes which look like hex color codes.
  */
 export const getColorCodeFeatureAttributes = (
-  featureProperties: Record<string, Set<any>>
+  featureProperties: Record<string, Set<any>>,
 ): Record<string, Set<string>> => {
   return getFeatureAttributes<string>(featureProperties, (_, value) => {
     const regex = new RegExp('^#[0-9a-f]{6}$');
@@ -903,7 +904,7 @@ export const getColorCodeFeatureAttributes = (
 export function downloadFile(
   content: BlobPart,
   fileName: string,
-  mimeType: string
+  mimeType: string,
 ) {
   const blob = new Blob([content], { type: mimeType });
   const url = URL.createObjectURL(blob);
@@ -917,13 +918,13 @@ export function downloadFile(
 
 export async function getGeoJSONDataFromLayerSource(
   source: IJGISSource,
-  model: IJupyterGISModel
+  model: IJupyterGISModel,
 ): Promise<string | null> {
   const vectorSourceTypes: SourceType[] = ['GeoJSONSource', 'ShapefileSource'];
 
   if (!vectorSourceTypes.includes(source.type as SourceType)) {
     console.error(
-      `Invalid source type '${source.type}'. Expected one of: ${vectorSourceTypes.join(', ')}`
+      `Invalid source type '${source.type}'. Expected one of: ${vectorSourceTypes.join(', ')}`,
     );
     return null;
   }
@@ -937,7 +938,7 @@ export async function getGeoJSONDataFromLayerSource(
     const fileContent = await loadFile({
       filepath: source.parameters.path,
       type: source.type,
-      model
+      model,
     });
     return typeof fileContent === 'object'
       ? JSON.stringify(fileContent)

--- a/packages/base/src/types.ts
+++ b/packages/base/src/types.ts
@@ -3,7 +3,7 @@ import {
   IJupyterGISDoc,
   IJupyterGISModel,
   IJupyterGISTracker,
-  IJupyterGISWidget
+  IJupyterGISWidget,
 } from '@jupytergis/schema';
 import { WidgetTracker } from '@jupyterlab/apputils';
 import { ISignal } from '@lumino/signaling';

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -1,7 +1,7 @@
 import {
   IJupyterGISDocumentWidget,
   IJupyterGISModel,
-  IJupyterGISOutputWidget
+  IJupyterGISOutputWidget,
 } from '@jupytergis/schema';
 import { MainAreaWidget } from '@jupyterlab/apputils';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
@@ -28,7 +28,7 @@ export class JupyterGISDocumentWidget
   implements IJupyterGISDocumentWidget
 {
   constructor(
-    options: DocumentWidget.IOptions<JupyterGISPanel, IJupyterGISModel>
+    options: DocumentWidget.IOptions<JupyterGISPanel, IJupyterGISModel>,
   ) {
     super(options);
   }
@@ -112,13 +112,13 @@ export class JupyterGISPanel extends SplitPanel {
     this._mainViewModel = new MainViewModel({
       jGISModel: options.model,
       viewSetting: this._view,
-      commands: options.commandRegistry
+      commands: options.commandRegistry,
     });
   }
 
   _initView() {
     this._jupyterGISMainViewPanel = new JupyterGISMainViewPanel({
-      mainViewModel: this._mainViewModel
+      mainViewModel: this._mainViewModel,
     });
     this.addWidget(this._jupyterGISMainViewPanel);
     SplitPanel.setStretch(this._jupyterGISMainViewPanel, 1);
@@ -186,7 +186,7 @@ export class JupyterGISPanel extends SplitPanel {
         manager,
         mimeTypeService,
         rendermime,
-        commandRegistry
+        commandRegistry,
       } = this._consoleOption;
       if (
         contentFactory &&
@@ -201,7 +201,7 @@ export class JupyterGISPanel extends SplitPanel {
           manager,
           mimeTypeService,
           rendermime,
-          commandRegistry
+          commandRegistry,
         });
         const { consolePanel } = this._consoleView;
 
@@ -211,7 +211,7 @@ export class JupyterGISPanel extends SplitPanel {
         this.setRelativeSizes([2, 1]);
         this._consoleOpened = true;
         await consolePanel.console.inject(
-          `from jupytergis import GISDocument\ndoc = GISDocument("${jgisPath}")`
+          `from jupytergis import GISDocument\ndoc = GISDocument("${jgisPath}")`,
         );
         consolePanel.console.sessionContext.kernelChanged.connect((_, arg) => {
           if (!arg.newValue) {

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -10,7 +10,7 @@ import {
   IJGISLayers,
   IJGISOptions,
   IJGISSource,
-  IJGISSources
+  IJGISSources,
 } from './_interface/project/jgis';
 import { SCHEMA_VERSION } from './_interface/version';
 import {
@@ -19,7 +19,7 @@ import {
   IJGISLayerTreeDocChange,
   IJGISSourceDocChange,
   IJupyterGISDoc,
-  IJupyterGISDocChange
+  IJupyterGISDocChange,
 } from './interfaces';
 
 export class JupyterGISDoc
@@ -67,7 +67,7 @@ export class JupyterGISDoc
     this.transact(() => {
       const layers = value['layers'] ?? {};
       Object.entries(layers).forEach(([key, val]) =>
-        this._layers.set(key, val as string)
+        this._layers.set(key, val as string),
       );
 
       const layerTree =
@@ -78,17 +78,17 @@ export class JupyterGISDoc
 
       const options = value['options'] ?? {};
       Object.entries(options).forEach(([key, val]) =>
-        this._options.set(key, val)
+        this._options.set(key, val),
       );
 
       const sources = value['sources'] ?? {};
       Object.entries(sources).forEach(([key, val]) =>
-        this._sources.set(key, val)
+        this._sources.set(key, val),
       );
 
       const metadata = value['metadata'] ?? {};
       Object.entries(metadata).forEach(([key, val]) =>
-        this._metadata.set(key, val as string)
+        this._metadata.set(key, val as string),
       );
     });
   }
@@ -229,13 +229,13 @@ export class JupyterGISDoc
 
   updateObjectParameters(
     id: string,
-    value: IJGISLayer['parameters'] | IJGISSource['parameters']
+    value: IJGISLayer['parameters'] | IJGISSource['parameters'],
   ) {
     const layer = this.getLayer(id);
     if (layer) {
       layer.parameters = {
         ...layer.parameters,
-        ...value
+        ...value,
       };
 
       this.updateLayer(id, layer);
@@ -245,7 +245,7 @@ export class JupyterGISDoc
     if (source) {
       source.parameters = {
         ...source.parameters,
-        ...value
+        ...value,
       };
 
       this.updateSource(id, source);
@@ -349,7 +349,7 @@ export class JupyterGISDoc
         changes.push({
           id: key as string,
           oldValue: change.oldValue,
-          newValue: JSONExt.deepCopy(event.target.toJSON()[key])
+          newValue: JSONExt.deepCopy(event.target.toJSON()[key]),
         });
       });
     });
@@ -377,7 +377,7 @@ export class JupyterGISDoc
         }
         changes.push({
           id: key as string,
-          newValue: JSONExt.deepCopy(event.target.toJSON()[key])
+          newValue: JSONExt.deepCopy(event.target.toJSON()[key]),
         });
       });
     });
@@ -403,14 +403,14 @@ export class JupyterGISDoc
 
   private _optionsChanged = new Signal<IJupyterGISDoc, MapChange>(this);
   private _layersChanged = new Signal<IJupyterGISDoc, IJGISLayerDocChange>(
-    this
+    this,
   );
   private _layerTreeChanged = new Signal<
     IJupyterGISDoc,
     IJGISLayerTreeDocChange
   >(this);
   private _sourcesChanged = new Signal<IJupyterGISDoc, IJGISSourceDocChange>(
-    this
+    this,
   );
   private _metadataChanged = new Signal<IJupyterGISDoc, MapChange>(this);
 }

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -3,7 +3,7 @@ import {
   DocumentChange,
   MapChange,
   StateChange,
-  YDocument
+  YDocument,
 } from '@jupyter/ydoc';
 import { IWidgetTracker, MainAreaWidget } from '@jupyterlab/apputils';
 import { IChangedArgs } from '@jupyterlab/coreutils';
@@ -24,7 +24,7 @@ import {
   IJGISOptions,
   IJGISSource,
   IJGISSources,
-  SourceType
+  SourceType,
 } from './_interface/project/jgis';
 import { IRasterSource } from './_interface/project/sources/rastersource';
 export { IGeoJSONSource } from './_interface/geojsonsource';
@@ -106,7 +106,7 @@ export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
     id: string,
     value: IJGISLayer,
     groupName?: string,
-    position?: number
+    position?: number,
   ): void;
 
   updateLayer(id: string, value: IJGISLayer): void;
@@ -122,7 +122,7 @@ export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
 
   updateObjectParameters(
     id: string,
-    value: IJGISLayer['parameters'] | IJGISSource['parameters']
+    value: IJGISLayer['parameters'] | IJGISSource['parameters'],
   ): void;
   getObject(id: string): IJGISLayer | IJGISSource | undefined;
 
@@ -196,7 +196,7 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
     id: string,
     layer: IJGISLayer,
     groupName?: string,
-    position?: number
+    position?: number,
   ): void;
   removeLayer(id: string): void;
   getOptions(): IJGISOptions;
@@ -208,7 +208,7 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   moveItemRelatedTo(item: string, relativeItem: string, after: boolean): void;
   addNewLayerGroup(
     selected: { [key: string]: ISelection },
-    group: IJGISLayerGroup
+    group: IJGISLayerGroup,
   ): void;
 
   syncViewport(viewport?: IViewPortState, emitter?: string): void;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -16,7 +16,7 @@ import {
   IJGISLayers,
   IJGISOptions,
   IJGISSource,
-  IJGISSources
+  IJGISSources,
 } from './_interface/project/jgis';
 import { JupyterGISDoc } from './doc';
 import {
@@ -33,7 +33,7 @@ import {
   IViewPortState,
   JgisCoordinates,
   Pointer,
-  IJupyterGISSettings
+  IJupyterGISSettings,
 } from './interfaces';
 import jgisSchema from './schema/project/jgis.json';
 
@@ -52,7 +52,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     this.sharedModel.awareness.on('change', this._onClientStateChanged);
     this._sharedModel.metadataChanged.connect(
       this._metadataChangedHandler,
-      this
+      this,
     );
     this.annotationModel = annotationModel;
     this.settingRegistry = settingRegistry;
@@ -253,7 +253,7 @@ export class JupyterGISModel implements IJupyterGISModel {
         zoom: 0,
         bearing: 0,
         pitch: 0,
-        projection: 'EPSG:3857'
+        projection: 'EPSG:3857',
       };
       this.sharedModel.metadata = jsonData.metadata ?? {};
     });
@@ -285,7 +285,7 @@ export class JupyterGISModel implements IJupyterGISModel {
       layers: this.sharedModel.layers,
       layerTree: this.sharedModel.layerTree,
       options: this.sharedModel.options,
-      metadata: this.sharedModel.metadata
+      metadata: this.sharedModel.metadata,
     };
   }
 
@@ -386,7 +386,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     }
     const item: IJGISLayerGroup = {
       name,
-      layers: []
+      layers: [],
     };
     this._addLayerTreeItem(item, groupName, position);
   }
@@ -405,7 +405,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     id: string,
     layer: IJGISLayer,
     groupName?: string,
-    position?: number
+    position?: number,
   ): void {
     if (!this.getLayer(id)) {
       this.sharedModel.addLayer(id, layer);
@@ -434,28 +434,28 @@ export class JupyterGISModel implements IJupyterGISModel {
   syncViewport(viewport?: IViewPortState, emitter?: string): void {
     this.sharedModel.awareness.setLocalStateField('viewportState', {
       value: viewport,
-      emitter
+      emitter,
     });
   }
 
   syncPointer(pointer?: Pointer, emitter?: string): void {
     this.sharedModel.awareness.setLocalStateField('pointer', {
       value: pointer,
-      emitter
+      emitter,
     });
   }
 
   syncSelected(value: { [key: string]: ISelection }, emitter?: string): void {
     this.sharedModel.awareness.setLocalStateField('selected', {
       value,
-      emitter
+      emitter,
     });
   }
 
   syncIdentifiedFeatures(features: IDict<any>, emitter?: string): void {
     this.sharedModel.awareness.setLocalStateField('identifiedFeatures', {
       value: features,
-      emitter
+      emitter,
     });
   }
 
@@ -481,7 +481,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   private _addLayerTreeItem(
     item: IJGISLayerItem,
     groupName?: string,
-    index?: number
+    index?: number,
   ): void {
     if (groupName) {
       const layerTreeInfo = this._getLayerTreeInfo(groupName);
@@ -490,18 +490,18 @@ export class JupyterGISModel implements IJupyterGISModel {
         layerTreeInfo.workingGroup.layers.splice(
           index ?? layerTreeInfo.workingGroup.layers.length,
           0,
-          item
+          item,
         );
 
         this._sharedModel.updateLayerTreeItem(
           layerTreeInfo.mainGroupIndex,
-          layerTreeInfo.mainGroup
+          layerTreeInfo.mainGroup,
         );
       }
     } else {
       this.sharedModel.addLayerTreeItem(
         index ?? this.getLayerTree().length,
-        item
+        item,
       );
     }
   }
@@ -560,7 +560,7 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   addNewLayerGroup(
     selected: { [key: string]: ISelection },
-    group: IJGISLayerGroup
+    group: IJGISLayerGroup,
   ) {
     const layerTree = this.getLayerTree();
     for (const item in selected) {
@@ -572,7 +572,7 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   private _removeLayerTreeLayer(
     layerTree: IJGISLayerItem[],
-    layerIdToRemove: string
+    layerIdToRemove: string,
   ) {
     this._removeLayerTreeItem(layerTree, layerIdToRemove, true);
     this.sharedModel.layerTree = layerTree;
@@ -580,7 +580,7 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   private _removeLayerTreeGroup(
     layerTree: IJGISLayerItem[],
-    groupName: string
+    groupName: string,
   ) {
     this._removeLayerTreeItem(layerTree, groupName, false);
     this.sharedModel.layerTree = layerTree;
@@ -589,7 +589,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   private _removeLayerTreeItem(
     layerTree: IJGISLayerItem[],
     target: string,
-    isLayer: boolean
+    isLayer: boolean,
   ) {
     // Iterate over each item in the layerTree
     for (let i = 0; i < layerTree.length; i++) {
@@ -618,7 +618,7 @@ export class JupyterGISModel implements IJupyterGISModel {
       layerTreeInfo.workingGroup.name = newName;
       this._sharedModel.updateLayerTreeItem(
         layerTreeInfo.mainGroupIndex,
-        layerTreeInfo.mainGroup
+        layerTreeInfo.mainGroup,
       );
     } else {
       console.log('Something went wrong when renaming layer');
@@ -632,7 +632,7 @@ export class JupyterGISModel implements IJupyterGISModel {
 
     function removeLayerGroupEntry(
       layerTree: IJGISLayerItem[],
-      groupName: string
+      groupName: string,
     ): IJGISLayerItem[] {
       const result: IJGISLayerItem[] = [];
 
@@ -651,7 +651,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     if (layerTreeInfo) {
       this._sharedModel.updateLayerTreeItem(
         layerTreeInfo.mainGroupIndex,
-        updatedLayerTree[layerTreeInfo.mainGroupIndex]
+        updatedLayerTree[layerTreeInfo.mainGroupIndex],
       );
     }
   }
@@ -665,7 +665,7 @@ export class JupyterGISModel implements IJupyterGISModel {
 
     this.sharedModel.awareness.setLocalStateField(
       'isTemporalControllerActive',
-      this._isTemporalControllerActive
+      this._isTemporalControllerActive,
     );
   }
 
@@ -700,7 +700,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     return {
       mainGroup,
       workingGroup,
-      mainGroupIndex
+      mainGroupIndex,
     };
   }
 
@@ -810,7 +810,7 @@ namespace Private {
    */
   export function layerTreeRecursion(
     items: IJGISLayerItem[],
-    current: string[] = []
+    current: string[] = [],
   ): string[] {
     for (const layer of items) {
       if (typeof layer === 'string') {
@@ -833,7 +833,7 @@ namespace Private {
   export function findItemPath(
     items: IJGISLayerItem[],
     itemId: string,
-    indexes: number[] = []
+    indexes: number[] = [],
   ): number[] {
     for (let index = 0; index < items.length; index++) {
       const item = items[index];

--- a/packages/schema/src/token.ts
+++ b/packages/schema/src/token.ts
@@ -5,15 +5,15 @@ import {
   IJGISExternalCommandRegistry,
   IJGISFormSchemaRegistry,
   IJGISLayerBrowserRegistry,
-  IJupyterGISTracker
+  IJupyterGISTracker,
 } from './interfaces';
 
 export const IJupyterGISDocTracker = new Token<IJupyterGISTracker>(
-  'jupyterGISDocTracker'
+  'jupyterGISDocTracker',
 );
 
 export const IJGISFormSchemaRegistryToken = new Token<IJGISFormSchemaRegistry>(
-  'jupytergisFormSchemaRegistry'
+  'jupytergisFormSchemaRegistry',
 );
 
 export const IJGISExternalCommandRegistryToken =
@@ -23,5 +23,5 @@ export const IJGISLayerBrowserRegistryToken =
   new Token<IJGISLayerBrowserRegistry>('jupytergisExternalCommandRegistry');
 
 export const IAnnotationToken = new Token<IAnnotationModel>(
-  'jupytergisAnnotationModel'
+  'jupytergisAnnotationModel',
 );

--- a/python/jupytergis_core/src/externalcommand.ts
+++ b/python/jupytergis_core/src/externalcommand.ts
@@ -1,6 +1,6 @@
 import {
   IJGISExternalCommand,
-  IJGISExternalCommandRegistry
+  IJGISExternalCommandRegistry,
 } from '@jupytergis/schema';
 
 export class JupyterGISExternalCommandRegistry

--- a/python/jupytergis_core/src/factory.ts
+++ b/python/jupytergis_core/src/factory.ts
@@ -2,12 +2,12 @@ import { ICollaborativeDrive } from '@jupyter/collaborative-drive';
 import {
   JupyterGISPanel,
   JupyterGISDocumentWidget,
-  ToolbarWidget
+  ToolbarWidget,
 } from '@jupytergis/base';
 import {
   JupyterGISModel,
   IJupyterGISTracker,
-  IJGISExternalCommandRegistry
+  IJGISExternalCommandRegistry,
 } from '@jupytergis/schema';
 import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
@@ -49,7 +49,7 @@ export class JupyterGISDocumentWidgetFactory extends ABCWidgetFactory<
    * @returns The widget
    */
   protected createNewWidget(
-    context: DocumentRegistry.IContext<JupyterGISModel>
+    context: DocumentRegistry.IContext<JupyterGISModel>,
   ): JupyterGISDocumentWidget {
     if (this._backendCheck) {
       const checked = this._backendCheck();
@@ -69,12 +69,12 @@ export class JupyterGISDocumentWidgetFactory extends ABCWidgetFactory<
       mimeTypeService: this.options.mimeTypeService,
       rendermime: this.options.rendermime,
       consoleTracker: this.options.consoleTracker,
-      commandRegistry: this.options.commands
+      commandRegistry: this.options.commands,
     });
     const toolbar = new ToolbarWidget({
       commands: this._commands,
       model,
-      externalCommands: this._externalCommandRegistry.getCommands()
+      externalCommands: this._externalCommandRegistry.getCommands(),
     });
     return new JupyterGISDocumentWidget({ context, content, toolbar });
   }

--- a/python/jupytergis_core/src/index.ts
+++ b/python/jupytergis_core/src/index.ts
@@ -4,7 +4,7 @@ import {
   formSchemaRegistryPlugin,
   layerBrowserRegistryPlugin,
   trackerPlugin,
-  annotationPlugin
+  annotationPlugin,
 } from './plugin';
 
 export * from './factory';
@@ -14,5 +14,5 @@ export default [
   formSchemaRegistryPlugin,
   externalCommandRegistryPlugin,
   layerBrowserRegistryPlugin,
-  annotationPlugin
+  annotationPlugin,
 ];

--- a/python/jupytergis_core/src/jgisplugin/modelfactory.ts
+++ b/python/jupytergis_core/src/jgisplugin/modelfactory.ts
@@ -1,7 +1,7 @@
 import {
   IAnnotationModel,
   IJupyterGISDoc,
-  JupyterGISModel
+  JupyterGISModel,
 } from '@jupytergis/schema';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Contents } from '@jupyterlab/services';
@@ -81,13 +81,13 @@ export class JupyterGISModelFactory
    * @returns The model
    */
   createNew(
-    options: DocumentRegistry.IModelOptions<IJupyterGISDoc>
+    options: DocumentRegistry.IModelOptions<IJupyterGISDoc>,
   ): JupyterGISModel {
     const model = new JupyterGISModel({
       sharedModel: options.sharedModel,
       languagePreference: options.languagePreference,
       annotationModel: this._annotationModel,
-      settingRegistry: this._settingRegistry
+      settingRegistry: this._settingRegistry,
     });
     model.initSettings();
     return model;

--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -1,6 +1,6 @@
 import {
   ICollaborativeDrive,
-  SharedDocumentFactory
+  SharedDocumentFactory,
 } from '@jupyter/collaborative-drive';
 import { CommandIDs, logoIcon, logoMiniIcon } from '@jupytergis/base';
 import {
@@ -11,16 +11,16 @@ import {
   IJupyterGISDocTracker,
   IJupyterGISWidget,
   JupyterGISDoc,
-  SCHEMA_VERSION
+  SCHEMA_VERSION,
 } from '@jupytergis/schema';
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 import {
   ICommandPalette,
   IThemeManager,
-  WidgetTracker
+  WidgetTracker,
 } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
@@ -54,7 +54,7 @@ const activate = async (
   settingRegistry: ISettingRegistry,
   launcher: ILauncher | null,
   palette: ICommandPalette | null,
-  drive: ICollaborativeDrive | null
+  drive: ICollaborativeDrive | null,
 ): Promise<void> => {
   if (PageConfig.getOption('jgis_expose_maps')) {
     window.jupytergisMaps = {};
@@ -81,7 +81,7 @@ const activate = async (
     contentFactory,
     rendermime,
     mimeTypeService: editorServices.mimeTypeService,
-    consoleTracker
+    consoleTracker,
   });
 
   // Registering the widget factory
@@ -93,14 +93,14 @@ const activate = async (
     modelName: MODEL_NAME,
     name: 'JSON Editor',
     primaryFileType: app.docRegistry.getFileType('json'),
-    fileTypes: [CONTENT_TYPE]
+    fileTypes: [CONTENT_TYPE],
   });
   app.docRegistry.addWidgetFactory(mimeDocumentFactory);
 
   // Creating and registering the model factory for our custom DocumentModel
   const modelFactory = new JupyterGISModelFactory({
     annotationModel,
-    settingRegistry
+    settingRegistry,
   });
   app.docRegistry.addModelFactory(modelFactory);
 
@@ -112,7 +112,7 @@ const activate = async (
     extensions: ['.jgis', '.JGIS'],
     fileFormat: 'text',
     contentType: CONTENT_TYPE,
-    icon: logoMiniIcon
+    icon: logoMiniIcon,
   });
 
   const jGISSharedModelFactory: SharedDocumentFactory = () => {
@@ -121,7 +121,7 @@ const activate = async (
   if (drive) {
     drive.sharedModelFactory.registerDocumentFactory(
       CONTENT_TYPE,
-      jGISSharedModelFactory
+      jGISSharedModelFactory,
     );
   }
 
@@ -131,7 +131,7 @@ const activate = async (
       tracker.save(widget);
     });
     themeManager.themeChanged.connect((_, changes) =>
-      widget.model.themeChanged.emit(changes)
+      widget.model.themeChanged.emit(changes),
     );
     app.shell.activateById('jupytergis::leftControlPanel');
     app.shell.activateById('jupytergis::rightControlPanel');
@@ -163,22 +163,22 @@ const activate = async (
       let model = await app.serviceManager.contents.newUntitled({
         path: cwd,
         type: 'file',
-        ext: '.jGIS'
+        ext: '.jGIS',
       });
 
       model = await app.serviceManager.contents.save(model.path, {
         ...model,
         format: 'text',
         size: undefined,
-        content: `{\n\t"schemaVersion": "${SCHEMA_VERSION}",\n\t"layers": {},\n\t"sources": {},\n\t"options": {"latitude": 0, "longitude": 0, "zoom": 0, "bearing": 0, "pitch": 0, "projection": "EPSG:3857"},\n\t"layerTree": [],\n\t"metadata": {}\n}`
+        content: `{\n\t"schemaVersion": "${SCHEMA_VERSION}",\n\t"layers": {},\n\t"sources": {},\n\t"options": {"latitude": 0, "longitude": 0, "zoom": 0, "bearing": 0, "pitch": 0, "projection": "EPSG:3857"},\n\t"layerTree": [],\n\t"metadata": {}\n}`,
       });
 
       // Open the newly created file with the 'Editor'
       return app.commands.execute('docmanager:open', {
         path: model.path,
-        factory: FACTORY
+        factory: FACTORY,
       });
-    }
+    },
   });
 
   // Add the command to the launcher
@@ -186,7 +186,7 @@ const activate = async (
     launcher.add({
       command: CommandIDs.createNew,
       category: 'Other',
-      rank: 1
+      rank: 1,
     });
   }
 
@@ -195,44 +195,44 @@ const activate = async (
     palette.addItem({
       command: CommandIDs.createNew,
       args: { isPalette: true },
-      category: PALETTE_CATEGORY
+      category: PALETTE_CATEGORY,
     });
 
     palette.addItem({
       command: CommandIDs.openLayerBrowser,
-      category: 'JupyterGIS'
+      category: 'JupyterGIS',
     });
 
     // Layers and Sources
     palette.addItem({
       command: CommandIDs.newRasterEntry,
-      category: 'JupyterGIS'
+      category: 'JupyterGIS',
     });
 
     palette.addItem({
       command: CommandIDs.newVectorTileEntry,
-      category: 'JupyterGIS'
+      category: 'JupyterGIS',
     });
 
     palette.addItem({
       command: CommandIDs.newGeoJSONEntry,
-      category: 'JupyterGIS'
+      category: 'JupyterGIS',
     });
 
     palette.addItem({
       command: CommandIDs.newHillshadeEntry,
-      category: 'JupyterGIS'
+      category: 'JupyterGIS',
     });
 
     // Layer and group actions
     palette.addItem({
       command: CommandIDs.moveLayerToNewGroup,
-      category: 'JupyterGIS'
+      category: 'JupyterGIS',
     });
 
     palette.addItem({
       command: CommandIDs.buffer,
-      category: 'JupyterGIS'
+      category: 'JupyterGIS',
     });
   }
 };
@@ -249,11 +249,11 @@ const jGISPlugin: JupyterFrontEndPlugin<void> = {
     IRenderMimeRegistry,
     IConsoleTracker,
     IAnnotationToken,
-    ISettingRegistry
+    ISettingRegistry,
   ],
   optional: [ILauncher, ICommandPalette, ICollaborativeDrive],
   autoStart: true,
-  activate
+  activate,
 };
 
 export default jGISPlugin;

--- a/python/jupytergis_core/src/layerBrowserRegistry.ts
+++ b/python/jupytergis_core/src/layerBrowserRegistry.ts
@@ -1,6 +1,6 @@
 import {
   IJGISLayerBrowserRegistry,
-  IRasterLayerGalleryEntry
+  IRasterLayerGalleryEntry,
 } from '@jupytergis/schema';
 
 /**

--- a/python/jupytergis_core/src/plugin.ts
+++ b/python/jupytergis_core/src/plugin.ts
@@ -10,11 +10,11 @@ import {
   IJGISLayerBrowserRegistryToken,
   IJupyterGISDocTracker,
   IJupyterGISTracker,
-  IJupyterGISWidget
+  IJupyterGISWidget,
 } from '@jupytergis/schema';
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 import { WidgetTracker } from '@jupyterlab/apputils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
@@ -36,14 +36,14 @@ export const trackerPlugin: JupyterFrontEndPlugin<IJupyterGISTracker> = {
   activate: (
     app: JupyterFrontEnd,
     translator: ITranslator,
-    mainMenu?: IMainMenu
+    mainMenu?: IMainMenu,
   ): IJupyterGISTracker => {
     const tracker = new WidgetTracker<IJupyterGISWidget>({
-      namespace: NAME_SPACE
+      namespace: NAME_SPACE,
     });
     console.log('jupytergis:core:tracker is activated!');
     return tracker;
-  }
+  },
 };
 
 export const formSchemaRegistryPlugin: JupyterFrontEndPlugin<IJGISFormSchemaRegistry> =
@@ -54,11 +54,11 @@ export const formSchemaRegistryPlugin: JupyterFrontEndPlugin<IJGISFormSchemaRegi
     provides: IJGISFormSchemaRegistryToken,
     activate: (
       app: JupyterFrontEnd,
-      docmanager: IDocumentManager
+      docmanager: IDocumentManager,
     ): IJGISFormSchemaRegistry => {
       const registry = new JupyterGISFormSchemaRegistry(docmanager);
       return registry;
-    }
+    },
   };
 
 export const externalCommandRegistryPlugin: JupyterFrontEndPlugin<IJGISExternalCommandRegistry> =
@@ -70,7 +70,7 @@ export const externalCommandRegistryPlugin: JupyterFrontEndPlugin<IJGISExternalC
     activate: (app: JupyterFrontEnd): IJGISExternalCommandRegistry => {
       const registry = new JupyterGISExternalCommandRegistry();
       return registry;
-    }
+    },
   };
 
 export const layerBrowserRegistryPlugin: JupyterFrontEndPlugin<IJGISLayerBrowserRegistry> =
@@ -84,7 +84,7 @@ export const layerBrowserRegistryPlugin: JupyterFrontEndPlugin<IJGISLayerBrowser
 
       const registry = new JupyterGISLayerBrowserRegistry();
       return registry;
-    }
+    },
   };
 
 export const annotationPlugin: JupyterFrontEndPlugin<IAnnotationModel> = {
@@ -94,12 +94,12 @@ export const annotationPlugin: JupyterFrontEndPlugin<IAnnotationModel> = {
   provides: IAnnotationToken,
   activate: (app: JupyterFrontEnd, tracker: IJupyterGISTracker) => {
     const annotationModel = new AnnotationModel({
-      model: tracker.currentWidget?.model
+      model: tracker.currentWidget?.model,
     });
 
     tracker.currentChanged.connect((_, changed) => {
       annotationModel.model = changed?.model || undefined;
     });
     return annotationModel;
-  }
+  },
 };

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -8,7 +8,7 @@ import {
   createDefaultLayerRegistry,
   rasterSubMenu,
   vectorSubMenu,
-  logoMiniIcon
+  logoMiniIcon,
 } from '@jupytergis/base';
 import {
   IAnnotationModel,
@@ -20,12 +20,12 @@ import {
   IJGISLayerItem,
   IJupyterGISDocTracker,
   IJupyterGISTracker,
-  IJupyterGISWidget
+  IJupyterGISWidget,
 } from '@jupytergis/schema';
 import {
   ILayoutRestorer,
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 import { WidgetTracker } from '@jupyterlab/apputils';
 import { ICompletionProviderManager } from '@jupyterlab/completer';
@@ -45,7 +45,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     IJupyterGISDocTracker,
     IJGISFormSchemaRegistryToken,
     IJGISLayerBrowserRegistryToken,
-    IStateDB
+    IStateDB,
   ],
   optional: [IMainMenu, ITranslator, ICompletionProviderManager],
   activate: (
@@ -56,7 +56,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     state: IStateDB,
     mainMenu?: IMainMenu,
     translator?: ITranslator,
-    completionProviderManager?: ICompletionProviderManager
+    completionProviderManager?: ICompletionProviderManager,
   ): void => {
     console.log('jupytergis:lab:main-menu is activated!');
     translator = translator ?? nullTranslator;
@@ -78,51 +78,51 @@ const plugin: JupyterFrontEndPlugin<void> = {
       formSchemaRegistry,
       layerBrowserRegistry,
       state,
-      completionProviderManager
+      completionProviderManager,
     );
 
     app.contextMenu.addItem({
       selector: '.jp-gis-source.jp-gis-sourceUnused',
       rank: 1,
-      command: CommandIDs.removeSource
+      command: CommandIDs.removeSource,
     });
 
     app.contextMenu.addItem({
       selector: '.jp-gis-source',
       rank: 1,
-      command: CommandIDs.renameSource
+      command: CommandIDs.renameSource,
     });
 
     // LAYERS and LAYER GROUPS context menu
     app.contextMenu.addItem({
       command: CommandIDs.symbology,
       selector: '.jp-gis-layerItem',
-      rank: 1
+      rank: 1,
     });
 
     // Separator
     app.contextMenu.addItem({
       type: 'separator',
       selector: '.jp-gis-layerPanel',
-      rank: 1
+      rank: 1,
     });
 
     app.contextMenu.addItem({
       command: CommandIDs.removeLayer,
       selector: '.jp-gis-layerItem',
-      rank: 2
+      rank: 2,
     });
 
     app.contextMenu.addItem({
       command: CommandIDs.renameLayer,
       selector: '.jp-gis-layerItem',
-      rank: 2
+      rank: 2,
     });
 
     app.contextMenu.addItem({
       command: CommandIDs.zoomToLayer,
       selector: '.jp-gis-layerItem',
-      rank: 2
+      rank: 2,
     });
 
     // Create the Download submenu
@@ -131,7 +131,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     downloadSubmenu.id = 'jp-gis-contextmenu-download';
 
     downloadSubmenu.addItem({
-      command: CommandIDs.downloadGeoJSON
+      command: CommandIDs.downloadGeoJSON,
     });
 
     // Add the Download submenu to the context menu
@@ -139,7 +139,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       type: 'submenu',
       selector: '.jp-gis-layerItem',
       rank: 2,
-      submenu: downloadSubmenu
+      submenu: downloadSubmenu,
     });
 
     // Create the Processing submenu
@@ -150,18 +150,18 @@ const plugin: JupyterFrontEndPlugin<void> = {
     processingSubmenu.id = 'jp-gis-contextmenu-processing';
 
     processingSubmenu.addItem({
-      command: CommandIDs.buffer
+      command: CommandIDs.buffer,
     });
 
     processingSubmenu.addItem({
-      command: CommandIDs.dissolve
+      command: CommandIDs.dissolve,
     });
 
     app.contextMenu.addItem({
       type: 'submenu',
       selector: '.jp-gis-layerItem',
       rank: 2,
-      submenu: processingSubmenu
+      submenu: processingSubmenu,
     });
 
     const moveLayerSubmenu = new Menu({ commands: app.commands });
@@ -174,30 +174,30 @@ const plugin: JupyterFrontEndPlugin<void> = {
       type: 'submenu',
       selector: '.jp-gis-layerItem',
       rank: 2,
-      submenu: moveLayerSubmenu
+      submenu: moveLayerSubmenu,
     });
 
     app.contextMenu.opened.connect(() =>
-      buildGroupsMenu(app.contextMenu, tracker)
+      buildGroupsMenu(app.contextMenu, tracker),
     );
 
     app.contextMenu.addItem({
       command: CommandIDs.removeGroup,
       selector: '.jp-gis-layerGroupHeader',
-      rank: 2
+      rank: 2,
     });
 
     app.contextMenu.addItem({
       command: CommandIDs.renameGroup,
       selector: '.jp-gis-layerGroupHeader',
-      rank: 2
+      rank: 2,
     });
 
     // Separator
     app.contextMenu.addItem({
       type: 'separator',
       selector: '.jp-gis-layerPanel',
-      rank: 2
+      rank: 2,
     });
 
     const newLayerSubMenu = new Menu({ commands: app.commands });
@@ -206,24 +206,24 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     newLayerSubMenu.addItem({
       type: 'submenu',
-      submenu: rasterSubMenu(app.commands)
+      submenu: rasterSubMenu(app.commands),
     });
     newLayerSubMenu.addItem({
       type: 'submenu',
-      submenu: vectorSubMenu(app.commands)
+      submenu: vectorSubMenu(app.commands),
     });
 
     app.contextMenu.addItem({
       type: 'submenu',
       selector: '.jp-gis-layerPanel',
       rank: 3,
-      submenu: newLayerSubMenu
+      submenu: newLayerSubMenu,
     });
 
     if (mainMenu) {
       populateMenus(mainMenu, isEnabled);
     }
-  }
+  },
 };
 
 const controlPanel: JupyterFrontEndPlugin<void> = {
@@ -234,7 +234,7 @@ const controlPanel: JupyterFrontEndPlugin<void> = {
     IJupyterGISDocTracker,
     IJGISFormSchemaRegistryToken,
     IStateDB,
-    IAnnotationToken
+    IAnnotationToken,
   ],
   activate: (
     app: JupyterFrontEnd,
@@ -242,7 +242,7 @@ const controlPanel: JupyterFrontEndPlugin<void> = {
     tracker: IJupyterGISTracker,
     formSchemaRegistry: IJGISFormSchemaRegistry,
     state: IStateDB,
-    annotationModel: IAnnotationModel
+    annotationModel: IAnnotationModel,
   ) => {
     const controlModel = new ControlPanelModel({ tracker });
 
@@ -250,7 +250,7 @@ const controlPanel: JupyterFrontEndPlugin<void> = {
       model: controlModel,
       tracker,
       state,
-      commands: app.commands
+      commands: app.commands,
     });
     leftControlPanel.id = 'jupytergis::leftControlPanel';
     leftControlPanel.title.caption = 'JupyterGIS Control Panel';
@@ -260,7 +260,7 @@ const controlPanel: JupyterFrontEndPlugin<void> = {
       model: controlModel,
       tracker,
       formSchemaRegistry,
-      annotationModel
+      annotationModel,
     });
     rightControlPanel.id = 'jupytergis::rightControlPanel';
     rightControlPanel.title.caption = 'JupyterGIS Control Panel';
@@ -272,7 +272,7 @@ const controlPanel: JupyterFrontEndPlugin<void> = {
     }
     app.shell.add(leftControlPanel, 'left', { rank: 2000 });
     app.shell.add(rightControlPanel, 'right', { rank: 2000 });
-  }
+  },
 };
 
 /**
@@ -282,11 +282,11 @@ function populateMenus(mainMenu: IMainMenu, isEnabled: () => boolean): void {
   // Add undo/redo hooks to the edit menu.
   mainMenu.editMenu.undoers.redo.add({
     id: CommandIDs.redo,
-    isEnabled
+    isEnabled,
   });
   mainMenu.editMenu.undoers.undo.add({
     id: CommandIDs.undo,
-    isEnabled
+    isEnabled,
   });
 }
 
@@ -295,7 +295,7 @@ function populateMenus(mainMenu: IMainMenu, isEnabled: () => boolean): void {
  */
 function buildGroupsMenu(
   contextMenu: ContextMenu,
-  tracker: WidgetTracker<IJupyterGISWidget>
+  tracker: WidgetTracker<IJupyterGISWidget>,
 ) {
   if (!tracker.currentWidget?.model) {
     return;
@@ -307,7 +307,7 @@ function buildGroupsMenu(
     contextMenu.menu.items.find(
       item =>
         item.type === 'submenu' &&
-        item.submenu?.id === 'jp-gis-contextmenu-movelayer'
+        item.submenu?.id === 'jp-gis-contextmenu-movelayer',
     )?.submenu ?? null;
 
   // Bail early if the submenu isn't found
@@ -346,18 +346,18 @@ function buildGroupsMenu(
 
   submenu.addItem({
     command: CommandIDs.moveLayersToGroup,
-    args: { label: '' }
+    args: { label: '' },
   });
 
   groupNames.forEach(name => {
     submenu.addItem({
       command: CommandIDs.moveLayersToGroup,
-      args: { label: name }
+      args: { label: name },
     });
   });
 
   submenu.addItem({
-    command: CommandIDs.moveLayerToNewGroup
+    command: CommandIDs.moveLayerToNewGroup,
   });
 }
 

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -3,18 +3,18 @@ import {
   JupyterGISOutputWidget,
   JupyterGISPanel,
   JupyterGISTracker,
-  ToolbarWidget
+  ToolbarWidget,
 } from '@jupytergis/base';
 import {
   IJGISExternalCommandRegistry,
   IJGISExternalCommandRegistryToken,
   IJupyterGISDoc,
   IJupyterGISDocTracker,
-  JupyterGISModel
+  JupyterGISModel,
 } from '@jupytergis/schema';
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { ConsolePanel } from '@jupyterlab/console';
@@ -29,7 +29,7 @@ import {
   IJupyterYWidget,
   IJupyterYWidgetManager,
   JupyterYDoc,
-  JupyterYModel
+  JupyterYModel,
 } from 'yjs-widgets';
 
 export interface ICommMetadata {
@@ -87,13 +87,13 @@ export class YJupyterGISLuminoWidget extends Panel {
       toolbar = new ToolbarWidget({
         commands,
         model,
-        externalCommands: externalCommands?.getCommands() || []
+        externalCommands: externalCommands?.getCommands() || [],
       });
     }
     this._jgisWidget = new JupyterGISOutputWidget({
       model,
       content,
-      toolbar
+      toolbar,
     });
     this.addWidget(this._jgisWidget);
     tracker?.add(this._jgisWidget);
@@ -116,14 +116,14 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
     IJGISExternalCommandRegistryToken,
     IJupyterGISDocTracker,
     IJupyterYWidgetManager,
-    ICollaborativeDrive
+    ICollaborativeDrive,
   ],
   activate: (
     app: JupyterFrontEnd,
     externalCommandRegistry?: IJGISExternalCommandRegistry,
     jgisTracker?: JupyterGISTracker,
     yWidgetManager?: IJupyterYWidgetManager,
-    drive?: ICollaborativeDrive
+    drive?: ICollaborativeDrive,
   ): void => {
     if (!yWidgetManager) {
       console.error('Missing IJupyterYWidgetManager token!');
@@ -140,10 +140,10 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
         if (!drive) {
           showErrorMessage(
             'Error using the JupyterGIS Python API',
-            'You cannot use the JupyterGIS Python API without a collaborative drive. You need to install a package providing collaboration features (e.g. jupyter-collaboration).'
+            'You cannot use the JupyterGIS Python API without a collaborative drive. You need to install a package providing collaboration features (e.g. jupyter-collaboration).',
           );
           throw new Error(
-            'Failed to create the YDoc without a collaborative drive'
+            'Failed to create the YDoc without a collaborative drive',
           );
         }
 
@@ -167,14 +167,14 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
           } catch (e) {
             await app.serviceManager.contents.save(localPath, {
               content: btoa('{}'),
-              format: 'base64'
+              format: 'base64',
             });
           }
         } else {
           // If the user did not provide a path, do not create
           localPath = PathExt.join(
             PathExt.dirname(currentWidgetPath),
-            'unsaved_project'
+            'unsaved_project',
           );
         }
 
@@ -182,10 +182,10 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
           path: localPath,
           format: fileFormat,
           contentType,
-          collaborative: true
+          collaborative: true,
         })!;
         this.jupyterGISModel = new JupyterGISModel({
-          sharedModel: sharedModel as IJupyterGISDoc
+          sharedModel: sharedModel as IJupyterGISDoc,
         });
 
         this.jupyterGISModel.contentsManager = app.serviceManager.contents;
@@ -204,7 +204,7 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
           commands: app.commands,
           model: yModel.jupyterGISModel,
           externalCommands: externalCommandRegistry,
-          tracker: jgisTracker
+          tracker: jgisTracker,
         });
         this._jgisWidget = widget.jgisWidget;
 
@@ -226,7 +226,7 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
     yWidgetManager.registerWidget(
       '@jupytergis:widget',
       YJupyterGISModelFactory,
-      YJupyterGISWidget
+      YJupyterGISWidget,
     );
-  }
+  },
 };

--- a/python/jupytergis_qgis/src/modelfactory.ts
+++ b/python/jupytergis_qgis/src/modelfactory.ts
@@ -1,7 +1,7 @@
 import {
   IJupyterGISDoc,
   JupyterGISModel,
-  IAnnotationModel
+  IAnnotationModel,
 } from '@jupytergis/schema';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Contents } from '@jupyterlab/services';
@@ -82,13 +82,13 @@ export class JupyterGISModelFactoryBase
    * @returns The model
    */
   createNew(
-    options: DocumentRegistry.IModelOptions<IJupyterGISDoc>
+    options: DocumentRegistry.IModelOptions<IJupyterGISDoc>,
   ): JupyterGISModel {
     const model = new JupyterGISModel({
       sharedModel: options.sharedModel,
       languagePreference: options.languagePreference,
       annotationModel: this._annotationModel,
-      settingRegistry: this._settingRegistry
+      settingRegistry: this._settingRegistry,
     });
     return model;
   }

--- a/python/jupytergis_qgis/src/plugins.ts
+++ b/python/jupytergis_qgis/src/plugins.ts
@@ -1,12 +1,12 @@
 import {
   ICollaborativeDrive,
-  SharedDocumentFactory
+  SharedDocumentFactory,
 } from '@jupyter/collaborative-drive';
 import {
   JupyterGISDocumentWidget,
   logoMiniIcon,
   logoMiniIconQGZ,
-  requestAPI
+  requestAPI,
 } from '@jupytergis/base';
 import { JupyterGISDocumentWidgetFactory } from '@jupytergis/jupytergis-core';
 import {
@@ -16,11 +16,11 @@ import {
   IJupyterGISDocTracker,
   IJupyterGISWidget,
   IAnnotationModel,
-  IAnnotationToken
+  IAnnotationToken,
 } from '@jupytergis/schema';
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 import {
   Dialog,
@@ -29,7 +29,7 @@ import {
   InputDialog,
   WidgetTracker,
   showDialog,
-  showErrorMessage
+  showErrorMessage,
 } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
@@ -80,21 +80,21 @@ const activate = async (
   consoleTracker: IConsoleTracker,
   annotationModel: IAnnotationModel,
   settingRegistry: ISettingRegistry,
-  commandPalette: ICommandPalette | null
+  commandPalette: ICommandPalette | null,
 ): Promise<void> => {
   const fcCheck = await requestAPI<{ installed: boolean }>(
     'jupytergis_qgis/backend-check',
     {
       method: 'POST',
-      body: JSON.stringify({})
-    }
+      body: JSON.stringify({}),
+    },
   );
   const { installed } = fcCheck;
   const backendCheck = () => {
     if (!installed) {
       showErrorMessage(
         'QGIS is not installed',
-        'QGIS is required to open QGIS files'
+        'QGIS is required to open QGIS files',
       );
     }
     return installed;
@@ -112,7 +112,7 @@ const activate = async (
     contentFactory,
     rendermime,
     mimeTypeService: editorServices.mimeTypeService,
-    consoleTracker
+    consoleTracker,
   });
   const QGZWidgetFactory = new JupyterGISDocumentWidgetFactory({
     name: 'JupyterGIS QGZ Factory',
@@ -127,7 +127,7 @@ const activate = async (
     contentFactory,
     rendermime,
     mimeTypeService: editorServices.mimeTypeService,
-    consoleTracker
+    consoleTracker,
   });
 
   // Registering the widget factory
@@ -136,10 +136,10 @@ const activate = async (
 
   // Creating and registering the model factory for our custom DocumentModel
   app.docRegistry.addModelFactory(
-    new QGSModelFactory({ annotationModel, settingRegistry })
+    new QGSModelFactory({ annotationModel, settingRegistry }),
   );
   app.docRegistry.addModelFactory(
-    new QGZModelFactory({ annotationModel, settingRegistry })
+    new QGZModelFactory({ annotationModel, settingRegistry }),
   );
   // register the filetype
   app.docRegistry.addFileType({
@@ -149,7 +149,7 @@ const activate = async (
     extensions: ['.qgs', '.QGS'],
     fileFormat: 'base64',
     contentType: 'QGS',
-    icon: logoMiniIcon
+    icon: logoMiniIcon,
   });
   app.docRegistry.addFileType({
     name: 'QGZ',
@@ -158,7 +158,7 @@ const activate = async (
     extensions: ['.qgz', '.QGZ'],
     fileFormat: 'base64',
     contentType: 'QGZ',
-    icon: logoMiniIconQGZ
+    icon: logoMiniIconQGZ,
   });
 
   const QGISSharedModelFactory: SharedDocumentFactory = () => {
@@ -166,16 +166,16 @@ const activate = async (
   };
   drive.sharedModelFactory.registerDocumentFactory(
     'QGS',
-    QGISSharedModelFactory
+    QGISSharedModelFactory,
   );
   drive.sharedModelFactory.registerDocumentFactory(
     'QGZ',
-    QGISSharedModelFactory
+    QGISSharedModelFactory,
   );
 
   const widgetCreatedCallback = (
     sender: any,
-    widget: JupyterGISDocumentWidget
+    widget: JupyterGISDocumentWidget,
   ) => {
     widget.title.icon = logoMiniIconQGZ;
     // Notify the instance tracker if restore data needs to update.
@@ -183,7 +183,7 @@ const activate = async (
       tracker.save(widget);
     });
     themeManager.themeChanged.connect((_, changes) =>
-      widget.model.themeChanged.emit(changes)
+      widget.model.themeChanged.emit(changes),
     );
 
     tracker.add(widget);
@@ -222,7 +222,7 @@ const activate = async (
             await InputDialog.getText({
               label: 'File name',
               placeholder: PathExt.basename(sourcePath, sourceExtension),
-              title: 'Export the project to QGZ file'
+              title: 'Export the project to QGZ file',
             })
           ).value;
         }
@@ -248,7 +248,7 @@ const activate = async (
           layers: model.layers,
           sources: model.sources,
           layerTree: model.layerTree.slice().reverse(),
-          options: model.options
+          options: model.options,
         };
 
         // Check if the file exists
@@ -259,7 +259,7 @@ const activate = async (
         if (fileExist) {
           const overwrite = await showDialog({
             title: 'Export the project to QGZ file',
-            body: `The file ${filepath} already exists.\nDo you want to overwrite it ?`
+            body: `The file ${filepath} already exists.\nDo you want to overwrite it ?`,
           });
           if (!overwrite.button.accept) {
             return;
@@ -271,16 +271,16 @@ const activate = async (
             method: 'POST',
             body: JSON.stringify({
               path: absolutePath,
-              virtual_file: virtualFile
-            })
-          }
+              virtual_file: virtualFile,
+            }),
+          },
         );
         if (!response.exported) {
           showErrorMessage(
             'Export the project to QGZ file',
             response.logs.errors.length
               ? response.logs.errors.join('\n')
-              : 'Unknown error'
+              : 'Unknown error',
           );
         } else if (response.logs.warnings.length) {
           const bodyElement = document.createElement('pre');
@@ -289,16 +289,16 @@ const activate = async (
           await showDialog<HTMLPreElement>({
             title: 'Export the project to QGZ file',
             body,
-            buttons: [Dialog.okButton()]
+            buttons: [Dialog.okButton()],
           });
         }
-      }
+      },
     });
 
     if (commandPalette) {
       commandPalette.addItem({
         command: CommandIDs.exportQgis,
-        category: 'JupyterGIS'
+        category: 'JupyterGIS',
       });
     }
   }
@@ -318,9 +318,9 @@ export const qgisplugin: JupyterFrontEndPlugin<void> = {
     IRenderMimeRegistry,
     IConsoleTracker,
     IAnnotationToken,
-    ISettingRegistry
+    ISettingRegistry,
   ],
   optional: [ICommandPalette],
   autoStart: true,
-  activate
+  activate,
 };

--- a/ui-tests/tests/annotations.spec.ts
+++ b/ui-tests/tests/annotations.spec.ts
@@ -8,7 +8,7 @@ test.describe('#annotations', () => {
     await content.deleteDirectory('/testDir');
     await content.uploadDirectory(
       path.resolve(__dirname, './gis-files'),
-      '/testDir'
+      '/testDir',
     );
   });
   test.beforeEach(async ({ page }) => {
@@ -27,8 +27,8 @@ test.describe('#annotations', () => {
       button: 'right',
       position: {
         x: 253,
-        y: 194
-      }
+        y: 194,
+      },
     });
     await page.getByText('Add annotation').click();
     await page
@@ -47,12 +47,12 @@ test.describe('#annotations', () => {
 
     // Check map
     await expect(
-      page.getByLabel('annotation-test.jGIS').getByRole('paragraph')
+      page.getByLabel('annotation-test.jGIS').getByRole('paragraph'),
     ).toContainText('this is a test');
 
     // Check side panel
     await expect(
-      page.getByLabel('Annotations', { exact: true }).getByRole('paragraph')
+      page.getByLabel('Annotations', { exact: true }).getByRole('paragraph'),
     ).toContainText('this is a test');
 
     // Delete
@@ -68,7 +68,7 @@ test.describe('#annotations', () => {
         .getByLabel('annotation-test.jGIS')
         .locator('div')
         .filter({ hasText: /^AHthis is a test$/ })
-        .nth(2)
+        .nth(2),
     ).not.toBeVisible();
   });
 });

--- a/ui-tests/tests/contextmenu.spec.ts
+++ b/ui-tests/tests/contextmenu.spec.ts
@@ -7,7 +7,7 @@ test.describe('context menu', () => {
     await content.deleteDirectory('/testDir');
     await content.uploadDirectory(
       path.resolve(__dirname, './gis-files'),
-      '/testDir'
+      '/testDir',
     );
   });
   test.beforeEach(async ({ page }) => {
@@ -77,11 +77,11 @@ test.describe('context menu', () => {
   });
 
   test('clicking remove layer should remove the layer from the tree', async ({
-    page
+    page,
   }) => {
     // Create new layer first
     await page.getByLabel('Layers', { exact: true }).click({
-      button: 'right'
+      button: 'right',
     });
     await page.getByText('Add Layer').hover();
     await page.getByText('Add Raster Layer', { exact: true }).hover();
@@ -90,7 +90,7 @@ test.describe('context menu', () => {
     await page
       .locator('input#root_url')
       .type(
-        'https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}.pbf'
+        'https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}.pbf',
       );
 
     await page.getByRole('dialog').getByRole('button', { name: 'Ok' }).click();
@@ -99,7 +99,7 @@ test.describe('context menu', () => {
     expect(page.getByText(layerTitle)).toBeVisible();
 
     await page.getByText(layerTitle).click({
-      button: 'right'
+      button: 'right',
     });
 
     await page.getByRole('menu').getByText('Remove Layer').click();
@@ -108,7 +108,7 @@ test.describe('context menu', () => {
   });
 
   test('clicking remove group should remove the group from the tree', async ({
-    page
+    page,
   }) => {
     const firstItem = page
       .getByLabel('Layers', { exact: true })

--- a/ui-tests/tests/export.spec.ts
+++ b/ui-tests/tests/export.spec.ts
@@ -7,7 +7,7 @@ test.describe('#export', () => {
     await content.deleteDirectory('/testDir');
     await content.uploadDirectory(
       path.resolve(__dirname, './gis-files'),
-      '/testDir'
+      '/testDir',
     );
   });
 
@@ -35,7 +35,7 @@ test.describe('#export', () => {
     await dialog.locator('.jp-mod-reject').click();
     await page.filebrowser.refresh();
     expect(
-      await page.filebrowser.contents.fileExists('testDir/france-hiking.qgz')
+      await page.filebrowser.contents.fileExists('testDir/france-hiking.qgz'),
     ).toBeFalsy();
   });
 
@@ -48,7 +48,7 @@ test.describe('#export', () => {
     await dialog.locator('.jp-mod-accept').click();
     await page.filebrowser.refresh();
     expect(
-      await page.filebrowser.contents.fileExists('testDir/france-hiking.qgz')
+      await page.filebrowser.contents.fileExists('testDir/france-hiking.qgz'),
     ).toBeTruthy();
   });
 
@@ -63,7 +63,7 @@ test.describe('#export', () => {
     await dialog.locator('.jp-mod-accept').click();
     await page.filebrowser.refresh();
     expect(
-      await page.filebrowser.contents.fileExists(`testDir/${filename}.qgz`)
+      await page.filebrowser.contents.fileExists(`testDir/${filename}.qgz`),
     ).toBeTruthy();
   });
 });

--- a/ui-tests/tests/filters.spec.ts
+++ b/ui-tests/tests/filters.spec.ts
@@ -8,7 +8,7 @@ test.describe('#filters', () => {
     await content.deleteDirectory('/testDir');
     await content.uploadDirectory(
       path.resolve(__dirname, './gis-files'),
-      '/testDir'
+      '/testDir',
     );
   });
   test.beforeEach(async ({ page }) => {
@@ -42,7 +42,7 @@ test.describe('#filters', () => {
 
     expect(await main.screenshot()).toMatchSnapshot({
       name: 'two-filter.png',
-      maxDiffPixelRatio: 0.01
+      maxDiffPixelRatio: 0.01,
     });
 
     // Remove filter
@@ -50,7 +50,7 @@ test.describe('#filters', () => {
 
     expect(await main.screenshot()).toMatchSnapshot({
       name: 'one-filter.png',
-      maxDiffPixelRatio: 0.01
+      maxDiffPixelRatio: 0.01,
     });
 
     // Clear filters
@@ -58,7 +58,7 @@ test.describe('#filters', () => {
 
     expect(await main.screenshot()).toMatchSnapshot({
       name: 'no-filter.png',
-      maxDiffPixelRatio: 0.01
+      maxDiffPixelRatio: 0.01,
     });
   });
 });

--- a/ui-tests/tests/geojson-layers.spec.ts
+++ b/ui-tests/tests/geojson-layers.spec.ts
@@ -2,7 +2,7 @@ import {
   IJupyterLabPageFixture,
   expect,
   galata,
-  test
+  test,
 } from '@jupyterlab/galata';
 import { Locator } from '@playwright/test';
 import path from 'path';
@@ -12,7 +12,7 @@ const FILENAME = 'empty-france.jGIS';
 const openGIS = async (
   page: IJupyterLabPageFixture,
   tmpPath: string,
-  filename: string
+  filename: string,
 ): Promise<Locator> => {
   const panel = await page.activity.getPanelLocator(filename);
   if (panel !== null && (await panel.count())) {
@@ -21,7 +21,7 @@ const openGIS = async (
 
   await page.filebrowser.open(`/${tmpPath}/${filename}`);
   await page.waitForCondition(
-    async () => await page.activity.isTabActive(filename)
+    async () => await page.activity.isTabActive(filename),
   );
   return (await page.activity.getPanelLocator(filename)) as Locator;
 };
@@ -31,11 +31,11 @@ test.describe('#geoJSONLayer', () => {
     const content = galata.newContentsHelper(request);
     await content.uploadFile(
       path.resolve(__dirname, `./gis-files/${FILENAME}`),
-      `/${tmpPath}/${FILENAME}`
+      `/${tmpPath}/${FILENAME}`,
     );
     await content.uploadFile(
       path.resolve(__dirname, `./gis-files/france_regions.json`),
-      `/${tmpPath}/france_regions.json`
+      `/${tmpPath}/france_regions.json`,
     );
   });
 

--- a/ui-tests/tests/layer-browser.spec.ts
+++ b/ui-tests/tests/layer-browser.spec.ts
@@ -2,7 +2,7 @@ import {
   IJupyterLabPageFixture,
   expect,
   galata,
-  test
+  test,
 } from '@jupyterlab/galata';
 import { Locator } from '@playwright/test';
 import path from 'path';
@@ -16,8 +16,8 @@ const TEST_REGISTRY = {
       html_attribution:
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       attribution: '(C) OpenStreetMap contributors',
-      name: 'OpenStreetMap.Mapnik'
-    }
+      name: 'OpenStreetMap.Mapnik',
+    },
   },
   Strava: {
     All: {
@@ -28,7 +28,7 @@ const TEST_REGISTRY = {
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
       html_attribution:
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
-      name: 'Strava.All'
+      name: 'Strava.All',
     },
     Ride: {
       thumbnailPath: 'rasterlayer_gallery/Strava-Ride.png',
@@ -38,7 +38,7 @@ const TEST_REGISTRY = {
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
       html_attribution:
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
-      name: 'Strava.Ride'
+      name: 'Strava.Ride',
     },
     Run: {
       thumbnailPath: 'rasterlayer_gallery/Strava-Run.png',
@@ -48,7 +48,7 @@ const TEST_REGISTRY = {
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
       html_attribution:
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
-      name: 'Strava.Run'
+      name: 'Strava.Run',
     },
     Water: {
       thumbnailPath: 'rasterlayer_gallery/Strava-Water.png',
@@ -58,7 +58,7 @@ const TEST_REGISTRY = {
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
       html_attribution:
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
-      name: 'Strava.Water'
+      name: 'Strava.Water',
     },
     Winter: {
       thumbnailPath: 'rasterlayer_gallery/Strava-Winter.png',
@@ -68,13 +68,13 @@ const TEST_REGISTRY = {
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
       html_attribution:
         'Map tiles by <a href="https://labs.strava.com/heatmap">Strava 2021</a>',
-      name: 'Strava.Winter'
-    }
-  }
+      name: 'Strava.Winter',
+    },
+  },
 };
 
 async function openLayerBrowser(
-  page: IJupyterLabPageFixture
+  page: IJupyterLabPageFixture,
 ): Promise<Locator> {
   const layerBrowser = page.locator('#jupytergis\\:\\:layerBrowser');
 
@@ -89,7 +89,7 @@ async function getGridTiles(page: IJupyterLabPageFixture): Promise<Locator> {
   const layerBrowser = await openLayerBrowser(page);
 
   const gridTiles = layerBrowser.locator(
-    '.jGIS-layer-browser-container .jGIS-layer-browser-grid .jGIS-layer-browser-tile'
+    '.jGIS-layer-browser-container .jGIS-layer-browser-grid .jGIS-layer-browser-tile',
   );
 
   return gridTiles;
@@ -101,7 +101,7 @@ test.describe('#layerBrowser', () => {
     await content.deleteDirectory('/testDir');
     await content.uploadDirectory(
       path.resolve(__dirname, './gis-files'),
-      '/testDir'
+      '/testDir',
     );
   });
 
@@ -127,7 +127,7 @@ test.describe('#layerBrowser', () => {
     const layerBrowser = await openLayerBrowser(page);
 
     const gridTiles = layerBrowser.locator(
-      '.jGIS-layer-browser-container .jGIS-layer-browser-grid .jGIS-layer-browser-tile'
+      '.jGIS-layer-browser-container .jGIS-layer-browser-grid .jGIS-layer-browser-tile',
     );
     const numberOfTiles = await gridTiles.count();
 
@@ -148,7 +148,7 @@ test.describe('#layerBrowser', () => {
   });
 
   test('clicking category filter twice should clear filter', async ({
-    page
+    page,
   }) => {
     const gridTiles = await getGridTiles(page);
     const numberOfTiles = await gridTiles.count();

--- a/ui-tests/tests/left-panel.spec.ts
+++ b/ui-tests/tests/left-panel.spec.ts
@@ -2,7 +2,7 @@ import {
   IJupyterLabPageFixture,
   expect,
   galata,
-  test
+  test,
 } from '@jupyterlab/galata';
 import { Locator } from '@playwright/test';
 import path from 'path';
@@ -29,7 +29,7 @@ async function openLayerTree(page: IJupyterLabPageFixture): Promise<Locator> {
 }
 
 async function getOpenLayerIds(
-  page: IJupyterLabPageFixture
+  page: IJupyterLabPageFixture,
 ): Promise<string[]> {
   return await page.evaluate(() => {
     const olMap = Object.values(window.jupytergisMaps)[0];
@@ -41,7 +41,7 @@ async function getOpenLayerIds(
 }
 
 async function getOpenLayerVisibility(
-  page: IJupyterLabPageFixture
+  page: IJupyterLabPageFixture,
 ): Promise<boolean[]> {
   return await page.evaluate(() => {
     const olMap = Object.values(window.jupytergisMaps)[0];
@@ -80,7 +80,7 @@ test.describe('#layerPanel', () => {
       await content.deleteDirectory('/testDir');
       await content.uploadDirectory(
         path.resolve(__dirname, './gis-files'),
-        '/testDir'
+        '/testDir',
       );
     });
     test.beforeEach(async ({ page }) => {
@@ -105,18 +105,18 @@ test.describe('#layerPanel', () => {
     test('raster layer should have icons', async ({ page }) => {
       const layerTree = await openLayerTree(page);
       const layerIcons = layerTree.locator(
-        '.jp-gis-layer .jp-gis-layerIcon svg'
+        '.jp-gis-layer .jp-gis-layerIcon svg',
       );
       const visToggleIcon = layerIcons.nth(0);
       const rasterIcon = layerIcons.nth(1);
 
       await expect(visToggleIcon).toHaveAttribute(
         'data-icon',
-        'jupytergis::visibility'
+        'jupytergis::visibility',
       );
       await expect(rasterIcon).toHaveAttribute(
         'data-icon',
-        'jupytergis::raster'
+        'jupytergis::raster',
       );
     });
 
@@ -177,7 +177,7 @@ test.describe('#layerPanel', () => {
 
       // Wait for the map to be loaded;
       await page.waitForCondition(
-        async () => (await getOpenLayerIds(page)).length === 3
+        async () => (await getOpenLayerIds(page)).length === 3,
       );
 
       // Wait for the map to be displayed.
@@ -230,7 +230,7 @@ test.describe('#layerPanel', () => {
 
       await page.mouse.move(
         firstItemBox!.x + 10,
-        firstItemBox!.y + firstItemBox!.height - 10
+        firstItemBox!.y + firstItemBox!.height - 10,
       );
       // We need to force hover
       await layerItems
@@ -242,7 +242,7 @@ test.describe('#layerPanel', () => {
     });
 
     test('should move the top raster layer using drag and drop', async ({
-      page
+      page,
     }) => {
       const layerTree = await openLayerTree(page);
       const layers = layerTree.locator('.jp-gis-layer');
@@ -250,7 +250,7 @@ test.describe('#layerPanel', () => {
 
       // Wait for the map to be loaded;
       await page.waitForCondition(
-        async () => (await getOpenLayerIds(page)).length === 3
+        async () => (await getOpenLayerIds(page)).length === 3,
       );
 
       const layerIds = await getOpenLayerIds(page);
@@ -265,7 +265,7 @@ test.describe('#layerPanel', () => {
       await page.mouse.down();
       await page.mouse.move(
         lowLayerBox!.x + 10,
-        lowLayerBox!.y + lowLayerBox!.height + 10
+        lowLayerBox!.y + lowLayerBox!.height + 10,
       );
       await page.mouse.up();
 

--- a/ui-tests/tests/lite.spec.ts
+++ b/ui-tests/tests/lite.spec.ts
@@ -11,7 +11,7 @@ test.describe('UI Test', () => {
     test.beforeEach(async ({ page }) => {
       const unrelatedErrors = [
         // This error is related to plotly dependency, installed with qgis.
-        "@jupyter-widgets/base doesn't exist in shared scope default"
+        "@jupyter-widgets/base doesn't exist in shared scope default",
       ];
       page.setViewportSize({ width: 1920, height: 1080 });
       page.on('console', message => {
@@ -33,13 +33,13 @@ test.describe('UI Test', () => {
 
     for (const file of fileList) {
       test(`Should be able to render ${file} without error`, async ({
-        browser
+        browser,
       }) => {
         const context = await browser.newContext();
         const page = await context.newPage();
 
         await page.goto(`lab/index.html?path=${file}`, {
-          waitUntil: 'domcontentloaded'
+          waitUntil: 'domcontentloaded',
         });
 
         await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
@@ -49,7 +49,7 @@ test.describe('UI Test', () => {
         }
 
         const main = await page.waitForSelector('.jp-MainAreaWidget', {
-          state: 'visible'
+          state: 'visible',
         });
 
         await page.waitForTimeout(10000);
@@ -58,7 +58,7 @@ test.describe('UI Test', () => {
         if (main) {
           expect(await main.screenshot()).toMatchSnapshot({
             name: `Render-${file}.png`,
-            maxDiffPixelRatio: 0.01
+            maxDiffPixelRatio: 0.01,
           });
         }
       });
@@ -69,11 +69,11 @@ test.describe('UI Test', () => {
     const context = await browser.newContext();
     const page = await context.newPage();
     await page.goto('lab/index.html?path=jgis.ipynb', {
-      waitUntil: 'domcontentloaded'
+      waitUntil: 'domcontentloaded',
     });
 
     const Notebook = await page.waitForSelector('.jp-Notebook', {
-      state: 'visible'
+      state: 'visible',
     });
     await Notebook.click();
 
@@ -87,15 +87,15 @@ test.describe('UI Test', () => {
     const jgisWidget = await page.waitForSelector(
       '.jupytergis-notebook-widget',
       {
-        state: 'visible'
-      }
+        state: 'visible',
+      },
     );
 
     await page.waitForTimeout(10000);
 
     expect(await jgisWidget.screenshot()).toMatchSnapshot({
       name: 'Render-notebook.png',
-      maxDiffPixelRatio: 0.01
+      maxDiffPixelRatio: 0.01,
     });
   });
 });

--- a/ui-tests/tests/notebook.spec.ts
+++ b/ui-tests/tests/notebook.spec.ts
@@ -7,7 +7,7 @@ const FILENAME = 'eq.json';
 const testCellOutputs = async (
   page: IJupyterLabPageFixture,
   tmpPath: string,
-  theme: 'JupyterLab Light' | 'JupyterLab Dark'
+  theme: 'JupyterLab Light' | 'JupyterLab Dark',
 ) => {
   const paths = klaw(path.resolve(__dirname, './notebooks'), { nodir: true });
   const notebooks = paths.map(item => path.basename(item.path));
@@ -30,7 +30,7 @@ const testCellOutputs = async (
     const getCaptureImageName = (
       contextPrefix: string,
       notebook: string,
-      id: number
+      id: number,
     ): string => {
       return `${contextPrefix}-${notebook}-cell-${id}.png`;
     };
@@ -44,12 +44,12 @@ const testCellOutputs = async (
           results.push(await cell.screenshot());
           numCellImages++;
         }
-      }
+      },
     });
 
     for (let c = 0; c < numCellImages; ++c) {
       expect(results[c]).toMatchSnapshot(
-        getCaptureImageName(contextPrefix, notebook, c)
+        getCaptureImageName(contextPrefix, notebook, c),
       );
     }
 
@@ -65,25 +65,25 @@ test.describe('Notebook API Visual Regression', () => {
 
     await page.contents.uploadDirectory(
       path.resolve(__dirname, './notebooks'),
-      tmpPath
+      tmpPath,
     );
     await page.contents.uploadFile(
       path.resolve(__dirname, `./gis-files/${FILENAME}`),
-      `/${tmpPath}/${FILENAME}`
+      `/${tmpPath}/${FILENAME}`,
     );
     await page.filebrowser.openDirectory(tmpPath);
   });
 
   test('Light theme: Cell outputs should be correct', async ({
     page,
-    tmpPath
+    tmpPath,
   }) => {
     await testCellOutputs(page, tmpPath, 'JupyterLab Light');
   });
 
   test('Dark theme: Cell outputs should be correct', async ({
     page,
-    tmpPath
+    tmpPath,
   }) => {
     await testCellOutputs(page, tmpPath, 'JupyterLab Dark');
   });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -12,14 +12,14 @@ test.describe('UI Test', () => {
       await content.deleteDirectory('/testDir');
       await content.uploadDirectory(
         path.resolve(__dirname, './gis-files'),
-        '/testDir'
+        '/testDir',
       );
     });
     let errors = 0;
     test.beforeEach(async ({ page }) => {
       const unrelatedErrors = [
         // This error is related to plotly dependency, installed with qgis.
-        "@jupyter-widgets/base doesn't exist in shared scope default"
+        "@jupyter-widgets/base doesn't exist in shared scope default",
       ];
       page.setViewportSize({ width: 1920, height: 1080 });
       page.on('console', message => {
@@ -41,7 +41,7 @@ test.describe('UI Test', () => {
 
     for (const file of fileList) {
       test(`Should be able to render ${file} without error`, async ({
-        page
+        page,
       }) => {
         await page.goto();
         const fullPath = `testDir/${file}`;


### PR DESCRIPTION
This mirrors the Python formatting style. In my opinion, it's a better option because it simplifies updating the list, and improves diffs. [From the docs](https://eslint.style/rules/js/comma-dangle):

>Trailing commas simplify adding and removing items to objects and arrays, since only the lines you are modifying must be touched. Another argument in favor of trailing commas is that it improves the clarity of diffs when an item is added or removed from an object or array:
>
> Less clear:
>
> ```diff
>  var foo = {
> -    bar: "baz",
> -    qux: "quux"
> +    bar: "baz"
>  };
> ```
>
>More clear:
>
> ```diff
>  var foo = {
>      bar: "baz",
> -    qux: "quux",
>  };
> ```



## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--731.org.readthedocs.build/en/731/
💡 JupyterLite preview: https://jupytergis--731.org.readthedocs.build/en/731/lite

<!-- readthedocs-preview jupytergis end -->