### PR TITLE
Support transient layers

### DIFF
--- a/python/jupytergis_core/jupytergis_core/jgis_ydoc.py
+++ b/python/jupytergis_core/jupytergis_core/jgis_ydoc.py
@@ -27,21 +27,27 @@ class YJGIS(YBaseDoc):
         :rtype: Any
         """
         # don't save transient layers and sources to disk
-        transient_layers = [key for key, val in self._ylayers.to_py().items() if val["transient"]]
-        transient_sources = [key for key, val in self._ysources.to_py().items() if val["transient"]]
+        transient_layers = [
+            key for key, val in self._ylayers.to_py().items() if val["transient"]
+        ]
+        transient_sources = [
+            key for key, val in self._ysources.to_py().items() if val["transient"]
+        ]
         layers = {
             key: val
             for key, val in self._ylayers.to_py().items()
-            if not key in transient_layers
+            if key not in transient_layers
         }
         sources = {
             key: val
             for key, val in self._ysources.to_py().items()
-            if not key in transient_sources
+            if key not in transient_sources
         }
         options = self._yoptions.to_py()
         meta = self._ymetadata.to_py()
-        layers_tree = [idx for idx in self._ylayerTree.to_py() if idx not in transient_layers]
+        layers_tree = [
+            idx for idx in self._ylayerTree.to_py() if idx not in transient_layers
+        ]
         return json.dumps(
             dict(
                 schemaVersion=SCHEMA_VERSION,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -900,7 +900,11 @@ class ObjectFactoryManager(metaclass=SingletonMeta):
                 args[field] = params.get(field, None)
             obj_params = Model(**args)
             return JGISSource(
-                parent=parent, name=name, transient=transient, type=object_type, parameters=obj_params
+                parent=parent,
+                name=name,
+                transient=transient,
+                type=object_type,
+                parameters=obj_params,
             )
 
         return None


### PR DESCRIPTION
## Description

There are situations where one wants to add a layer to the shared model without saving it to disk (in the `.jGIS` file). These "transient" layers are not meant to exist forever, like a raster layer that would load tiles from a stable origin (e.g. OSM). For instance, they might be computed by a live kernel, and they disappear as soon as the kernel is shut down. A good example of such ephemeral layers can be generated by [jupytergis-tiler](https://github.com/geojupyter/jupytergis-tiler).
This PR adds a "transient" attribute to a layer model, which is `False` by default. When set to `True`, the layer won't be saved to the `.jGIS` file.

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--735.org.readthedocs.build/en/735/
💡 JupyterLite preview: https://jupytergis--735.org.readthedocs.build/en/735/lite

<!-- readthedocs-preview jupytergis end -->