### PR TITLE
Fix LayoutRestorer entries

### DIFF
--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -266,8 +266,8 @@ const controlPanel: JupyterFrontEndPlugin<void> = {
     rightControlPanel.title.icon = logoMiniIcon;
 
     if (restorer) {
-      restorer.add(leftControlPanel, NAME_SPACE);
-      restorer.add(rightControlPanel, NAME_SPACE);
+      restorer.add(leftControlPanel, `${NAME_SPACE}-left`);
+      restorer.add(rightControlPanel, `${NAME_SPACE}-right`);
     }
     app.shell.add(leftControlPanel, 'left', { rank: 2000 });
     app.shell.add(rightControlPanel, 'right', { rank: 2000 });


### PR DESCRIPTION
Unlike the "namespace" name may indicate, the namespace entry of the `LayoutRestorer` is unique

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--743.org.readthedocs.build/en/743/
💡 JupyterLite preview: https://jupytergis--743.org.readthedocs.build/en/743/lite

<!-- readthedocs-preview jupytergis end -->