### PR TITLE
Minor typo fix "you can you" -> "you can use"

### DIFF
--- a/docs/user_guide/tutorials/01-intro/index.md
+++ b/docs/user_guide/tutorials/01-intro/index.md
@@ -48,7 +48,7 @@ The elements shown in the figure above are:
 4. Right Sidebar showing the property inspector (active in notebooks), the debugger, and GIS object properties, annotation and filters.
 5. The GIS object properties, annotations and filters of a selected GIS layer.
 6. The Jupyter toolbar menu which you will use with Jupyter Notebooks.
-7. The Log console (which you can you for debugging).
+7. The Log console (which you can use for debugging).
 
 ## Adding your first layers
 


### PR DESCRIPTION
## Description

Fix a typo in the tutorial.

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--779.org.readthedocs.build/en/779/
💡 JupyterLite preview: https://jupytergis--779.org.readthedocs.build/en/779/lite

<!-- readthedocs-preview jupytergis end -->