### PR TITLE
Add more explicit typing on RJSF objects

### DIFF
--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -4,6 +4,7 @@ import { Dialog } from '@jupyterlab/apputils';
 import { FormComponent } from '@jupyterlab/ui-components';
 import { Signal } from '@lumino/signaling';
 import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import validatorAjv8 from '@rjsf/validator-ajv8';
 import * as React from 'react';
 
@@ -11,7 +12,7 @@ import { deepCopy } from '@/src/tools';
 import { IDict } from '@/src/types';
 
 export interface IBaseFormStates {
-  schema?: IDict;
+  schema?: RJSFSchema;
   extraErrors?: any;
 }
 
@@ -118,8 +119,8 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
 
   protected processSchema(
     data: IDict<any> | undefined,
-    schema: IDict,
-    uiSchema: IDict,
+    schema: RJSFSchema,
+    uiSchema: UiSchema,
   ): void {
     if (!schema['properties']) {
       return;
@@ -251,13 +252,13 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
   protected removeFormEntry(
     entry: string,
     data: IDict<any> | undefined,
-    schema: IDict,
-    uiSchema: IDict,
+    schema: RJSFSchema,
+    uiSchema: UiSchema,
   ) {
     if (data) {
       delete data[entry];
     }
-    delete schema.properties[entry];
+    delete schema.properties![entry];
     delete uiSchema[entry];
     if (schema.required && schema.required.includes(entry)) {
       schema.required.splice(schema.required.indexOf(entry), 1);

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -258,7 +258,9 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
     if (data) {
       delete data[entry];
     }
-    delete schema.properties![entry];
+    if (schema.properties) {
+      delete schema.properties[entry];
+    }
     delete uiSchema[entry];
     if (schema.required && schema.required.includes(entry)) {
       schema.required.splice(schema.required.indexOf(entry), 1);

--- a/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
+++ b/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
@@ -86,7 +86,7 @@ export class DissolveForm extends BaseForm {
           properties: {
             ...prevState.schema?.properties,
             dissolveField: {
-              ...prevState.schema?.properties?.dissolveField as RJSFSchema,
+              ...(prevState.schema?.properties?.dissolveField as RJSFSchema),
               enum: [...this.features],
             },
           },

--- a/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
+++ b/packages/base/src/formbuilder/objectform/process/dissolveProcessForm.tsx
@@ -1,5 +1,6 @@
 import { IDict, IJupyterGISModel, IGeoJSONSource } from '@jupytergis/schema';
 import { IChangeEvent } from '@rjsf/core';
+import { RJSFSchema } from '@rjsf/utils';
 
 import {
   BaseForm,
@@ -85,7 +86,7 @@ export class DissolveForm extends BaseForm {
           properties: {
             ...prevState.schema?.properties,
             dissolveField: {
-              ...prevState.schema?.properties?.dissolveField,
+              ...prevState.schema?.properties?.dissolveField as RJSFSchema,
               enum: [...this.features],
             },
           },


### PR DESCRIPTION
## Description

`IDict` is a very permissive type, and [RJSF](https://github.com/rjsf-team/react-jsonschema-form) provides some types we can use for more safety :)

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
