### PR TITLE
Add react component typings

### DIFF
--- a/packages/base/src/dialogs/ProcessingFormDialog.tsx
+++ b/packages/base/src/dialogs/ProcessingFormDialog.tsx
@@ -34,7 +34,7 @@ export interface IProcessingFormWrapperProps
   formErrorSignalPromise?: PromiseDelegate<Signal<Dialog<any>, boolean>>;
 }
 
-const ProcessingFormWrapper = (props: IProcessingFormWrapperProps) => {
+const ProcessingFormWrapper: React.FC<IProcessingFormWrapperProps> = (props) => {
   const [ready, setReady] = React.useState<boolean>(false);
 
   const okSignal = React.useRef<Signal<Dialog<any>, number>>();

--- a/packages/base/src/dialogs/ProcessingFormDialog.tsx
+++ b/packages/base/src/dialogs/ProcessingFormDialog.tsx
@@ -34,7 +34,7 @@ export interface IProcessingFormWrapperProps
   formErrorSignalPromise?: PromiseDelegate<Signal<Dialog<any>, boolean>>;
 }
 
-const ProcessingFormWrapper: React.FC<IProcessingFormWrapperProps> = (props) => {
+const ProcessingFormWrapper: React.FC<IProcessingFormWrapperProps> = props => {
   const [ready, setReady] = React.useState<boolean>(false);
 
   const okSignal = React.useRef<Signal<Dialog<any>, number>>();

--- a/packages/base/src/dialogs/layerCreationFormDialog.tsx
+++ b/packages/base/src/dialogs/layerCreationFormDialog.tsx
@@ -29,7 +29,7 @@ export interface ICreationFormDialogOptions extends ICreationFormProps {
   title: string;
 }
 
-export const CreationFormWrapper = (props: ICreationFormWrapperProps) => {
+export const CreationFormWrapper: React.FC<ICreationFormWrapperProps> = (props) => {
   const [ready, setReady] = React.useState<boolean>(false);
 
   const okSignal = React.useRef<Signal<Dialog<any>, number>>();

--- a/packages/base/src/dialogs/layerCreationFormDialog.tsx
+++ b/packages/base/src/dialogs/layerCreationFormDialog.tsx
@@ -29,7 +29,9 @@ export interface ICreationFormDialogOptions extends ICreationFormProps {
   title: string;
 }
 
-export const CreationFormWrapper: React.FC<ICreationFormWrapperProps> = (props) => {
+export const CreationFormWrapper: React.FC<
+  ICreationFormWrapperProps
+> = props => {
   const [ready, setReady] = React.useState<boolean>(false);
 
   const okSignal = React.useRef<Signal<Dialog<any>, number>>();

--- a/packages/base/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent.tsx
@@ -14,10 +14,10 @@ interface ICanvasSelectComponentProps {
   setSelected: (item: any) => void;
 }
 
-const CanvasSelectComponent = ({
+const CanvasSelectComponent: React.FC<ICanvasSelectComponentProps> = ({
   selectedRamp,
   setSelected,
-}: ICanvasSelectComponentProps) => {
+}) => {
   const colorRampNames = [
     'jet',
     // 'hsv', 11 steps min

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
@@ -25,13 +25,13 @@ export type ColorRampOptions = {
   selectedMode: string;
 };
 
-const ColorRamp = ({
+const ColorRamp: React.FC<IColorRampProps> = ({
   layerParams,
   modeOptions,
   classifyFunc,
   showModeRow,
   showRampSelector,
-}: IColorRampProps) => {
+}) => {
   const [selectedRamp, setSelectedRamp] = useState('');
   const [selectedMode, setSelectedMode] = useState('');
   const [numberOfShades, setNumberOfShades] = useState('');

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampEntry.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampEntry.tsx
@@ -8,7 +8,11 @@ interface IColorRampEntryProps {
   onClick: (item: any) => void;
 }
 
-const ColorRampEntry: React.FC<IColorRampEntryProps> = ({ index, colorMap, onClick }) => {
+const ColorRampEntry: React.FC<IColorRampEntryProps> = ({
+  index,
+  colorMap,
+  onClick,
+}) => {
   const canvasHeight = 30;
 
   useEffect(() => {

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampEntry.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampEntry.tsx
@@ -8,7 +8,7 @@ interface IColorRampEntryProps {
   onClick: (item: any) => void;
 }
 
-const ColorRampEntry = ({ index, colorMap, onClick }: IColorRampEntryProps) => {
+const ColorRampEntry: React.FC<IColorRampEntryProps> = ({ index, colorMap, onClick }) => {
   const canvasHeight = 30;
 
   useEffect(() => {

--- a/packages/base/src/dialogs/symbology/components/color_ramp/ModeSelectRow.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ModeSelectRow.tsx
@@ -6,13 +6,13 @@ interface IModeSelectRowProps {
   setSelectedMode: (value: string) => void;
   modeOptions: string[];
 }
-const ModeSelectRow = ({
+const ModeSelectRow: React.FC<IModeSelectRowProps> = ({
   numberOfShades,
   setNumberOfShades,
   selectedMode,
   setSelectedMode,
   modeOptions,
-}: IModeSelectRowProps) => {
+}) => {
   return (
     <div className="jp-gis-symbology-row">
       <div className="jp-gis-color-ramp-div">

--- a/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
@@ -10,11 +10,11 @@ interface IStopContainerProps {
   setStopRows: (stops: IStopRow[]) => void;
 }
 
-const StopContainer = ({
+const StopContainer: React.FC<IStopContainerProps> = ({
   selectedMethod,
   stopRows,
   setStopRows,
-}: IStopContainerProps) => {
+}) => {
   const addStopRow = () => {
     setStopRows([
       {

--- a/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
@@ -5,15 +5,7 @@ import React, { useEffect, useRef } from 'react';
 
 import { IStopRow } from '@/src/dialogs/symbology/symbologyDialog';
 
-const StopRow = ({
-  index,
-  value,
-  outputValue,
-  stopRows,
-  setStopRows,
-  deleteRow,
-  useNumber,
-}: {
+const StopRow: React.FC<{
   index: number;
   value: number;
   outputValue: number | number[];
@@ -21,6 +13,14 @@ const StopRow = ({
   setStopRows: (stopRows: IStopRow[]) => void;
   deleteRow: () => void;
   useNumber?: boolean;
+}> = ({
+  index,
+  value,
+  outputValue,
+  stopRows,
+  setStopRows,
+  deleteRow,
+  useNumber,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 

--- a/packages/base/src/dialogs/symbology/symbologyDialog.tsx
+++ b/packages/base/src/dialogs/symbology/symbologyDialog.tsx
@@ -39,12 +39,12 @@ export interface IStopRow {
   output: number | number[];
 }
 
-const SymbologyDialog = ({
+const SymbologyDialog: React.FC<ISymbologyDialogProps> = ({
   model,
   state,
   okSignalPromise,
   cancel,
-}: ISymbologyDialogProps) => {
+}) => {
   const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
   const [componentToRender, setComponentToRender] = useState<any>(null);
 

--- a/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/TiffRendering.tsx
@@ -4,13 +4,13 @@ import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 import MultibandColor from './types/MultibandColor';
 import SingleBandPseudoColor from './types/SingleBandPseudoColor';
 
-const TiffRendering = ({
+const TiffRendering: React.FC<ISymbologyDialogProps> = ({
   model,
   state,
   okSignalPromise,
   cancel,
   layerId,
-}: ISymbologyDialogProps) => {
+}) => {
   const renderTypes = ['Singleband Pseudocolor', 'Multiband Color'];
   const [selectedRenderType, setSelectedRenderType] = useState<string>();
   const [componentToRender, setComponentToRender] = useState<any>(null);

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
@@ -16,12 +16,12 @@ interface ISelectedBands {
 
 type rgbEnum = keyof ISelectedBands;
 
-const MultibandColor = ({
+const MultibandColor: React.FC<ISymbologyDialogProps> = ({
   model,
   okSignalPromise,
   cancel,
   layerId,
-}: ISymbologyDialogProps) => {
+}) => {
   if (!layerId) {
     return;
   }

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
@@ -23,12 +23,12 @@ import { GlobalStateDbManager } from '@/src/store';
 
 export type InterpolationType = 'discrete' | 'linear' | 'exact';
 
-const SingleBandPseudoColor = ({
+const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
   model,
   okSignalPromise,
   cancel,
   layerId,
-}: ISymbologyDialogProps) => {
+}) => {
   if (!layerId) {
     return;
   }

--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -101,13 +101,13 @@ const useLayerRenderType = (
     setSelectedRenderType(renderType);
   }, []);
 
-const VectorRendering = ({
+const VectorRendering: React.FC<ISymbologyDialogProps> = ({
   model,
   state,
   okSignalPromise,
   cancel,
   layerId,
-}: ISymbologyDialogProps) => {
+}) => {
   const [selectedRenderType, setSelectedRenderType] = useState<
     VectorRenderType | undefined
   >();

--- a/packages/base/src/dialogs/symbology/vector_layer/components/ValueSelect.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/components/ValueSelect.tsx
@@ -6,11 +6,11 @@ interface IValueSelectProps {
   setSelectedValue: (value: string) => void;
 }
 
-const ValueSelect = ({
+const ValueSelect: React.FC<IValueSelectProps> = ({
   featureProperties,
   selectedValue,
   setSelectedValue,
-}: IValueSelectProps) => {
+}) => {
   return (
     <div className="jp-gis-symbology-row">
       <label htmlFor={'vector-value-select'}>Value:</label>

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
@@ -5,14 +5,14 @@ import React, { useEffect, useRef, useState } from 'react';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
 import { ISymbologyDialogWithAttributesProps } from '../../symbologyDialog';
 
-const Canonical = ({
+const Canonical: React.FC<ISymbologyDialogWithAttributesProps> = ({
   model,
   state,
   okSignalPromise,
   cancel,
   layerId,
   selectableAttributesAndValues,
-}: ISymbologyDialogWithAttributesProps) => {
+}) => {
   const selectedValueRef = useRef<string>();
   const [selectedValue, setSelectedValue] = useState('');
 

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
@@ -13,7 +13,7 @@ import { Utils, VectorUtils } from '@/src/dialogs/symbology/symbologyUtils';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
 import { SymbologyTab } from '@/src/types';
 
-const Categorized = ({
+const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
   model,
   state,
   okSignalPromise,
@@ -21,7 +21,7 @@ const Categorized = ({
   layerId,
   symbologyTab,
   selectableAttributesAndValues,
-}: ISymbologyTabbedDialogWithAttributesProps) => {
+}) => {
   const selectedAttributeRef = useRef<string>();
   const stopRowsRef = useRef<IStopRow[]>();
   const colorRampOptionsRef = useRef<ReadonlyJSONObject | undefined>();

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
@@ -4,13 +4,13 @@ import React, { useEffect, useRef, useState } from 'react';
 import CanvasSelectComponent from '@/src/dialogs/symbology/components/color_ramp/CanvasSelectComponent';
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 
-const Heatmap = ({
+const Heatmap: React.FC<ISymbologyDialogProps> = ({
   model,
   state,
   okSignalPromise,
   cancel,
   layerId,
-}: ISymbologyDialogProps) => {
+}) => {
   if (!layerId) {
     return;
   }

--- a/packages/base/src/dialogs/symbology/vector_layer/types/SimpleSymbol.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/SimpleSymbol.tsx
@@ -4,14 +4,14 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ISymbologyTabbedDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 import { IParsedStyle, parseColor } from '@/src/tools';
 
-const SimpleSymbol = ({
+const SimpleSymbol: React.FC<ISymbologyTabbedDialogProps> = ({
   model,
   state,
   okSignalPromise,
   cancel,
   layerId,
   symbologyTab,
-}: ISymbologyTabbedDialogProps) => {
+}) => {
   const styleRef = useRef<IParsedStyle>();
 
   const [style, setStyle] = useState<IParsedStyle>({

--- a/packages/base/src/mainview/CollaboratorPointers.tsx
+++ b/packages/base/src/mainview/CollaboratorPointers.tsx
@@ -18,7 +18,7 @@ export type ClientPointer = {
   lonLat: { latitude: number; longitude: number };
 };
 
-const CollaboratorPointers = ({ clients }: ICollaboratorPointersProps) => {
+const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({ clients }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/packages/base/src/mainview/CollaboratorPointers.tsx
+++ b/packages/base/src/mainview/CollaboratorPointers.tsx
@@ -18,7 +18,9 @@ export type ClientPointer = {
   lonLat: { latitude: number; longitude: number };
 };
 
-const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({ clients }) => {
+const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({
+  clients,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/packages/base/src/mainview/TemporalSlider.tsx
+++ b/packages/base/src/mainview/TemporalSlider.tsx
@@ -53,7 +53,7 @@ const stepMap = {
   year: millisecondsInDay * daysInYear,
 };
 
-const TemporalSlider = ({ model, filterStates }: ITemporalSliderProps) => {
+const TemporalSlider: React.FC<ITemporalSliderProps> = ({ model, filterStates }) => {
   const [layerId, setLayerId] = useState('');
   const [selectedFeature, setSelectedFeature] = useState('');
   const [range, setRange] = useState({ start: 0, end: 1 }); // min/max of current range being displayed

--- a/packages/base/src/mainview/TemporalSlider.tsx
+++ b/packages/base/src/mainview/TemporalSlider.tsx
@@ -53,7 +53,10 @@ const stepMap = {
   year: millisecondsInDay * daysInYear,
 };
 
-const TemporalSlider: React.FC<ITemporalSliderProps> = ({ model, filterStates }) => {
+const TemporalSlider: React.FC<ITemporalSliderProps> = ({
+  model,
+  filterStates,
+}) => {
   const [layerId, setLayerId] = useState('');
   const [selectedFeature, setSelectedFeature] = useState('');
   const [range, setRange] = useState({ start: 0, end: 1 }); // min/max of current range being displayed

--- a/packages/base/src/panelview/components/filter-panel/Filter.tsx
+++ b/packages/base/src/panelview/components/filter-panel/Filter.tsx
@@ -52,7 +52,7 @@ interface IFilterComponentProps {
   tracker: IJupyterGISTracker;
 }
 
-const FilterComponent: React.FC<IFilterComponentProps> = (props) => {
+const FilterComponent: React.FC<IFilterComponentProps> = props => {
   const featuresInLayerRef = useRef({});
   const [widgetId, setWidgetId] = useState('');
   const [logicalOp, setLogicalOp] = useState('all');

--- a/packages/base/src/panelview/components/filter-panel/Filter.tsx
+++ b/packages/base/src/panelview/components/filter-panel/Filter.tsx
@@ -52,7 +52,7 @@ interface IFilterComponentProps {
   tracker: IJupyterGISTracker;
 }
 
-const FilterComponent = (props: IFilterComponentProps) => {
+const FilterComponent: React.FC<IFilterComponentProps> = (props) => {
   const featuresInLayerRef = useRef({});
   const [widgetId, setWidgetId] = useState('');
   const [logicalOp, setLogicalOp] = useState('all');

--- a/packages/base/src/panelview/components/filter-panel/FilterRow.tsx
+++ b/packages/base/src/panelview/components/filter-panel/FilterRow.tsx
@@ -3,18 +3,18 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@jupyterlab/ui-components';
 import React, { useEffect, useState } from 'react';
 
-const FilterRow = ({
-  index,
-  features,
-  filterRows,
-  setFilterRows,
-  deleteRow,
-}: {
+const FilterRow: React.FC<{
   index: number;
   features: Record<string, Set<string | number>>;
   filterRows: any;
   setFilterRows: any;
   deleteRow: () => void;
+}> = ({
+  index,
+  features,
+  filterRows,
+  setFilterRows,
+  deleteRow,
 }) => {
   const operators = ['==', '!=', '>', '<', '>=', '<='];
 

--- a/packages/base/src/panelview/components/filter-panel/FilterRow.tsx
+++ b/packages/base/src/panelview/components/filter-panel/FilterRow.tsx
@@ -9,13 +9,7 @@ const FilterRow: React.FC<{
   filterRows: any;
   setFilterRows: any;
   deleteRow: () => void;
-}> = ({
-  index,
-  features,
-  filterRows,
-  setFilterRows,
-  deleteRow,
-}) => {
+}> = ({ index, features, filterRows, setFilterRows, deleteRow }) => {
   const operators = ['==', '!=', '>', '<', '>=', '<='];
 
   const [sortedFeatures, setSortedFeatures] = useState<{ [key: string]: any }>(

--- a/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
+++ b/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
@@ -50,10 +50,10 @@ interface IIdentifyComponentProps {
   tracker: IJupyterGISTracker;
 }
 
-const IdentifyPanelComponent = ({
+const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
   controlPanelModel,
   tracker,
-}: IIdentifyComponentProps) => {
+}) => {
   const [widgetId, setWidgetId] = useState('');
   const [features, setFeatures] = useState<IDict<any>>();
   const [visibleFeatures, setVisibleFeatures] = useState<IDict<any>>({

--- a/packages/base/src/shared/components/Pagination.tsx
+++ b/packages/base/src/shared/components/Pagination.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { Button, ButtonProps } from './Button';
 
-const Pagination = ({ ...props }: React.ComponentProps<'nav'>) => (
+const Pagination: React.FC<React.ComponentProps<'nav'>> = ({ ...props }) => (
   <nav
     role="navigation"
     aria-label="pagination"

--- a/packages/base/src/statusbar/StatusBar.tsx
+++ b/packages/base/src/statusbar/StatusBar.tsx
@@ -16,12 +16,12 @@ interface IStatusBarProps {
   projection?: { code: string; units: string };
   scale: number;
 }
-const StatusBar = ({
+const StatusBar: React.FC<IStatusBarProps> = ({
   jgisModel,
   loading,
   projection,
   scale,
-}: IStatusBarProps) => {
+}) => {
   const [coords, setCoords] = useState<JgisCoordinates>({ x: 0, y: 0 });
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Many of our functional components had typed props, but did not type the entire component itself. This PR types those components as `React.FC`!

Thanks to GPT-4.1 agent for completing this task in <1 minute ;) 

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
