### PR TITLE
Fix lint errors :bell:

### DIFF
--- a/docs/contributor_guide/code_quality.md
+++ b/docs/contributor_guide/code_quality.md
@@ -10,7 +10,6 @@ We have several tools configured for checking code quality:
   Install checks with `pre-commit install`.
   Run them manually with `pre-commit run --all-files`.
   **Will exit non-zero when finding errors or changing files.**
-
   - Ruff formats and lints (sometimes autofixes) Python code.
 
   - Generic pre-commit checks help avoid common mistakes like committing large
@@ -21,7 +20,6 @@ We have several tools configured for checking code quality:
   Run manually with `jlpm run lint`.
   **Will exit 0 when applying fixes.**
   **Check the logs and/or `git status` after every run.**
-
   - Prettier formats the file types listed above.
 
   - Eslint lints (sometimes autofixes) JS/TS code.

--- a/docs/contributor_guide/troubleshooting.md
+++ b/docs/contributor_guide/troubleshooting.md
@@ -2,13 +2,11 @@
 
 - Setup of development environment hangs indefinitely when running the
   `dev-install.py` step, specifically on the Yarn linking step.
-
   - This may be caused by having a `.gitignore` file in your home directory.
     This is a [known issue with Nx](https://github.com/nrwl/nx/issues/27494).
     The [only known workaround](https://github.com/nrwl/nx/issues/27494#issuecomment-2481207598) is to remove the `.gitignore` file from your home directory or to work in a location outside of the home directory tree.
 
 - Every UI test fails after 60 seconds due to timeout.
-
   - This could be caused by having a JupyterLab instance already running at port
     `:8888`. Please ensure that there is nothing running at <http://localhost:8888/lab>
     before running tests.

--- a/docs/user_guide/features/collab.md
+++ b/docs/user_guide/features/collab.md
@@ -9,7 +9,6 @@ One of the standout features of JupyterGIS is its shared editing functionality, 
 If you are using a local installation, your JupyterLab instance is not available to the Internet by default, thus collaborators cannot join your session directly. Here are two techniques to facilitating collaboration in such instances.
 
 1. Hosting a local server using VSCode (Microsoft) or PyCharm (Jetbrains) enables real-time collaboration without exposing your server to the Internet.
-
    - To use VSCode's Live Share, you can follow the steps [here](https://learn.microsoft.com/en-us/visualstudio/liveshare/use/share-server-visual-studio-code#share-a-server).
    - To use PyCharm's Code With Me, first you can enable [Code With Me](https://www.jetbrains.com/help/pycharm/code-with-me.html), then set up [port forwarding](https://www.jetbrains.com/help/pycharm/code-with-me.html#port_forwarding).
 

--- a/docs/user_guide/tutorials/02-collaboration/index.md
+++ b/docs/user_guide/tutorials/02-collaboration/index.md
@@ -31,7 +31,6 @@ First, let's create a GIS file and invite collaborators to the session.
 ### Create Your GIS File
 
 1. Open JupyterLab
-
    - If you are using a local installation, start JupyterLab.
 
      ```


### PR DESCRIPTION
## Description

Some linting errors made it on to main recently, not sure how -- they weren't introduced in recent commits. One of the files was last changed 5 months ago. Must have been an update to prettier's formatting rules. :shrug: 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--796.org.readthedocs.build/en/796/
💡 JupyterLite preview: https://jupytergis--796.org.readthedocs.build/en/796/lite

<!-- readthedocs-preview jupytergis end -->