### PR TITLE
Add JSON validity pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
       - id: check-added-large-files
         args: ['--maxkb=5000']
       - id: check-case-conflict
+      - id: check-json
       - id: check-toml
       - id: check-yaml
       - id: debug-statements


### PR DESCRIPTION
## Description

Why not?

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--799.org.readthedocs.build/en/799/
💡 JupyterLite preview: https://jupytergis--799.org.readthedocs.build/en/799/lite

<!-- readthedocs-preview jupytergis end -->