### PR TITLE
Remove platform/product selections when no longer relevant

### DIFF
--- a/packages/base/src/stacBrowser/components/StacFilterSection.tsx
+++ b/packages/base/src/stacBrowser/components/StacFilterSection.tsx
@@ -139,10 +139,17 @@ const StacFilterSection = ({
     }
   }, [section, data, selectedCollections, selectedData, handleCheckedChange]);
 
+  const isTriggerDisabled =
+    (section === 'Platform' || section === 'Data / Product') &&
+    selectedCollections.length === 0;
+
   return (
     <div className="jgis-stac-filter-section-container">
       <DropdownMenu modal={false}>
-        <DropdownMenuTrigger className="jgis-stac-filter-trigger">
+        <DropdownMenuTrigger
+          className="jgis-stac-filter-trigger"
+          disabled={isTriggerDisabled}
+        >
           {section}
           <ChevronRight className="DropdownMenuIcon" />
         </DropdownMenuTrigger>

--- a/packages/base/src/stacBrowser/components/StacPanelFilters.tsx
+++ b/packages/base/src/stacBrowser/components/StacPanelFilters.tsx
@@ -13,8 +13,8 @@ import {
 import StacFilterSection from '@/src/stacBrowser/components/StacFilterSection';
 import {
   datasets as datasetsList,
-  platforms,
-  products,
+  platforms as platformsList,
+  products as productsList,
 } from '@/src/stacBrowser/constants';
 import {
   StacFilterState,
@@ -57,6 +57,28 @@ const StacPanelFilters = ({
       });
       if (datasetsForCollection.length === 0) {
         collections.delete(collection);
+
+        const platforms = new Set(filterState.platforms);
+        const products = new Set(filterState.products);
+
+        // Remove platforms belonging to this collection
+        if (platformsList[collection as keyof typeof platformsList]) {
+          platformsList[collection as keyof typeof platformsList].forEach(
+            platform => {
+              platforms.delete(platform);
+            },
+          );
+        }
+
+        // Remove products belonging to this collection
+        productsList
+          .filter(product => product.collections.includes(collection))
+          .forEach(product => {
+            products.delete(product.productCode);
+          });
+
+        filterSetters.platforms(platforms);
+        filterSetters.products(products);
       }
     } else {
       datasets.add(dataset);
@@ -127,14 +149,14 @@ const StacPanelFilters = ({
       />
       <StacFilterSection
         section="Platform"
-        data={platforms}
+        data={platformsList}
         selectedCollections={Array.from(filterState.collections)}
         selectedData={Array.from(filterState.platforms)}
         handleCheckedChange={platform => handleToggle('platforms', platform)}
       />
       <StacFilterSection
         section="Data / Product"
-        data={products}
+        data={productsList}
         selectedCollections={Array.from(filterState.collections)}
         selectedData={Array.from(filterState.products)}
         handleCheckedChange={product => handleToggle('products', product)}

--- a/packages/base/style/stacBrowser.css
+++ b/packages/base/style/stacBrowser.css
@@ -56,6 +56,10 @@
   gap: 0.15rem;
 }
 
+.jgis-stac-filter-trigger:disabled {
+  cursor: not-allowed;
+}
+
 .jgis-stac-filter-section-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description
Fix #804 

Clears Platform and Product / Data sections and disables the buttons when no relevant collections are selected.

![clearProducts](https://github.com/user-attachments/assets/2fdf14b9-6bd1-48f1-80ea-187a1443bb83)

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--805.org.readthedocs.build/en/805/
💡 JupyterLite preview: https://jupytergis--805.org.readthedocs.build/en/805/lite

<!-- readthedocs-preview jupytergis end -->