### PR TITLE
Add remove button to stac badge

### DIFF
--- a/packages/base/src/shared/components/Badge.tsx
+++ b/packages/base/src/shared/components/Badge.tsx
@@ -1,14 +1,20 @@
 import * as React from 'react';
 
+import { cn } from './utils';
+
 interface IBadgeProps extends React.HTMLAttributes<HTMLButtonElement> {
   variant?: 'destructive' | 'outline' | 'secondary';
   size?: 'sm' | 'lg' | 'icon';
 }
 
-function Badge({ variant, ...props }: IBadgeProps) {
+function Badge({ variant, className, ...props }: IBadgeProps) {
   return (
     // @ts-expect-error lol
-    <div data-variant={variant} className={'jgis-badge'} {...props} />
+    <div
+      data-variant={variant}
+      className={cn('jgis-badge', className)}
+      {...props}
+    />
   );
 }
 

--- a/packages/base/src/shared/components/Button.tsx
+++ b/packages/base/src/shared/components/Button.tsx
@@ -1,10 +1,12 @@
 import { Slot } from '@radix-ui/react-slot';
 import * as React from 'react';
 
+import { cn } from './utils';
+
 interface IButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
   variant?: 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link' | 'icon';
-  size?: 'sm' | 'lg' | 'icon';
+  size?: 'sm' | 'lg' | 'icon' | 'icon-sm';
 }
 
 const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
@@ -14,7 +16,7 @@ const Button = React.forwardRef<HTMLButtonElement, IButtonProps>(
       <Comp
         data-size={size}
         data-variant={variant}
-        className={`jgis-button ${className ? className : ''}`}
+        className={cn('jgis-button', className)}
         ref={ref}
         {...props}
       />

--- a/packages/base/src/stacBrowser/components/StacFilterSection.tsx
+++ b/packages/base/src/stacBrowser/components/StacFilterSection.tsx
@@ -167,7 +167,6 @@ const StacFilterSection = ({
               size="icon-sm"
               className="jgis-stac-badge-icon"
               onClick={() => {
-                console.log('data', data);
                 handleCheckedChange(data, '');
               }}
             >

--- a/packages/base/src/stacBrowser/components/StacFilterSection.tsx
+++ b/packages/base/src/stacBrowser/components/StacFilterSection.tsx
@@ -1,7 +1,10 @@
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ChevronRight } from 'lucide-react';
 import React, { useMemo } from 'react';
 
 import Badge from '@/src/shared/components/Badge';
+import { Button } from '@/src/shared/components/Button';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -157,7 +160,20 @@ const StacFilterSection = ({
       </DropdownMenu>
       <div className="jgis-stac-filter-section-badges">
         {selectedData.map(data => (
-          <Badge key={data}>{data}</Badge>
+          <Badge key={data} className="jgis-stac-badge">
+            <span>{data}</span>
+            <Button
+              variant="icon"
+              size="icon-sm"
+              className="jgis-stac-badge-icon"
+              onClick={() => {
+                console.log('data', data);
+                handleCheckedChange(data, '');
+              }}
+            >
+              <FontAwesomeIcon icon={faXmark} />
+            </Button>
+          </Badge>
         ))}
       </div>
     </div>

--- a/packages/base/style/shared/button.css
+++ b/packages/base/style/shared/button.css
@@ -162,3 +162,8 @@
   height: 2.5rem;
   width: 2.5rem;
 }
+
+.jgis-button[data-size='icon-sm'] {
+  height: 1rem;
+  width: 1rem;
+}

--- a/packages/base/style/stacBrowser.css
+++ b/packages/base/style/stacBrowser.css
@@ -76,3 +76,16 @@
   width: 1rem;
   height: 1rem;
 }
+
+.jgis-stac-badge {
+  gap: 0.25rem;
+  padding-right: 0.3rem !important;
+}
+
+.jgis-stac-badge-icon:hover {
+  background-color: color-mix(
+    in srgb,
+    var(--jp-error-color0),
+    transparent 20%
+  ) !important;
+}


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix #803 
Adds an `x` icon to badges to remove item.

![badgeclose](https://github.com/user-attachments/assets/071992e7-3ae2-4c0a-8033-e6600716a68f)

Hover: 
![badgeclosehover](https://github.com/user-attachments/assets/2f4960ab-624c-4d7d-b739-c05f0211c8de)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
