### PR TITLE
Restore follow mode

### DIFF
--- a/python/jupytergis_lab/style/base.css
+++ b/python/jupytergis_lab/style/base.css
@@ -830,3 +830,13 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
   border-bottom: 2px solid var(--jp-brand-color1);
   font-weight: 500;
 }
+
+.jp-toolbar-users-item > .lm-MenuBar-itemIcon {
+  cursor: pointer !important;
+  border: 2px solid transparent;
+  border-radius: 50%;
+}
+
+.jp-toolbar-users-item > .lm-MenuBar-itemIcon.selected {
+  border-color: var(--jp-brand-color1);
+}


### PR DESCRIPTION
## Description

Arjun and I paired on this a bit this morning!

Resolves #811 

The idea is that we'd pass in a custom icon renderer function to the UsersItem component which would handle click-to-follow behavior. Our custom function is based on the old code prior to [PR #723](https://github.com/geojupyter/jupytergis/pull/723).

I really don't know what I'm doing here :upside_down_face: `ToolbarWidget` isn't a react component, so I don't know how to manage state! Perhaps we don't need to keep track of state at all, we just need to update the model and let the model keep track of it. But then, how do we display the red outline around the selected user?


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--812.org.readthedocs.build/en/812/
💡 JupyterLite preview: https://jupytergis--812.org.readthedocs.build/en/812/lite

<!-- readthedocs-preview jupytergis end -->