### PR TITLE
Fix processing functions

### DIFF
--- a/packages/base/src/processing/index.ts
+++ b/packages/base/src/processing/index.ts
@@ -213,6 +213,8 @@ export async function executeSQLProcessing(
   const processedGeoJSONString = new TextDecoder().decode(processedBytes);
   Gdal.close(dataset);
 
+  const layerName = `${layerNamePrefix} ${processingType.charAt(0).toUpperCase() + processingType.slice(1)}`;
+
   if (!embedOutputLayer) {
     // Save the output as a file
     const jgisFilePath = tracker.currentWidget?.model.filePath;
@@ -242,7 +244,7 @@ export async function executeSQLProcessing(
       type: 'VectorLayer',
       parameters: { source: newSourceId },
       visible: true,
-      name: outputFileName,
+      name: layerName,
     };
 
     model.sharedModel.addSource(newSourceId, sourceModel);
@@ -254,7 +256,7 @@ export async function executeSQLProcessing(
 
     const sourceModel: IJGISSource = {
       type: 'GeoJSONSource',
-      name: `${layerNamePrefix} ${processingType.charAt(0).toUpperCase() + processingType.slice(1)}`,
+      name: `${layerName} Source`,
       parameters: { data: processedGeoJSON },
     };
 
@@ -262,7 +264,7 @@ export async function executeSQLProcessing(
       type: 'VectorLayer',
       parameters: { source: newSourceId },
       visible: true,
-      name: `${layerNamePrefix} ${processingType.charAt(0).toUpperCase() + processingType.slice(1)}`,
+      name: layerName,
     };
 
     model.sharedModel.addSource(newSourceId, sourceModel);

--- a/packages/schema/scripts/process.py
+++ b/packages/schema/scripts/process.py
@@ -61,29 +61,22 @@ if __name__ == "__main__":
         file for file in os.listdir(processingSchemaDir) if file.endswith(".json")
     ]
 
-    params = []
     for filename in filenamesSchema:
-        filename = f"{processingSchemaDir}/{filename}"
-        with open(filename, "r") as f:
+        schemaFilename = f"{processingSchemaDir}/{filename}"
+
+        processingParams = {}
+        with open(schemaFilename, "r") as f:
             e = json.loads(f.read())
 
-            toAdd = {}
-            toAdd["description"] = e["description"]
+            processingParams["description"] = e["description"]
 
-            params.append(toAdd)
-
-    filenamesProcessConfig = [
-        file for file in os.listdir(processingConfigDir) if file.endswith(".json")
-    ]
-
-    cnt = 0
-    for filename in filenamesProcessConfig:
-        filename = f"{processingConfigDir}/{filename}"
-        with open(filename, "r") as f:
+        configName = f"{processingConfigDir}/{filename}"
+        with open(configName, "r") as f:
             e = json.loads(f.read())
             for x in e:
-                params[cnt][x] = e[x]
-        cnt += 1
+                processingParams[x] = e[x]
+
+        params.append(processingParams)
 
     os.makedirs(directory, exist_ok=True)
     generateJsonMerge()


### PR DESCRIPTION
## Description

Fixing a couple of issues here:
- the output layer name wouldn't always make sense
- the processing config + schema merge script was relying on the order that `os.listdir` outputs for schema files, which locally for me was messing out everything. We probably have been lucky with the released version. But I don't want to push luck further and fixing the issue here.