### PR TITLE
Change default colormap from 'cool' to 'viridis'

### DIFF
--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRamp.tsx
@@ -51,7 +51,7 @@ const ColorRamp: React.FC<IColorRampProps> = ({
     }
     setNumberOfShades(nClasses ? nClasses : '9');
     setSelectedMode(singleBandMode ? singleBandMode : 'equal interval');
-    setSelectedRamp(colorRamp ? colorRamp : 'cool');
+    setSelectedRamp(colorRamp ? colorRamp : 'viridis');
   };
 
   return (

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
@@ -23,7 +23,7 @@ const Heatmap: React.FC<ISymbologyDialogProps> = ({
     radius: 8,
     blur: 15,
   });
-  const selectedRampRef = useRef('cool');
+  const selectedRampRef = useRef('viridis');
   const heatmapOptionsRef = useRef({
     radius: 8,
     blur: 15,
@@ -55,7 +55,7 @@ const Heatmap: React.FC<ISymbologyDialogProps> = ({
       colorRamp = layer.parameters.symbologyState.colorRamp;
     }
 
-    setSelectedRamp(colorRamp ? colorRamp : 'cool');
+    setSelectedRamp(colorRamp ? colorRamp : 'viridis');
   };
 
   const handleOk = () => {

--- a/packages/schema/src/schema/project/layers/heatmapLayer.json
+++ b/packages/schema/src/schema/project/layers/heatmapLayer.json
@@ -44,7 +44,7 @@
         },
         "colorRamp": {
           "type": "string",
-          "default": "cool"
+          "default": "viridis"
         }
       }
     }

--- a/packages/schema/src/schema/project/layers/vectorLayer.json
+++ b/packages/schema/src/schema/project/layers/vectorLayer.json
@@ -39,7 +39,7 @@
         },
         "colorRamp": {
           "type": "string",
-          "default": "cool"
+          "default": "viridis"
         },
         "nClasses": {
           "type": "string",

--- a/packages/schema/src/schema/project/layers/webGlLayer.json
+++ b/packages/schema/src/schema/project/layers/webGlLayer.json
@@ -77,7 +77,7 @@
         },
         "colorRamp": {
           "type": "string",
-          "default": "cool"
+          "default": "viridis"
         },
         "nClasses": {
           "type": "string",

--- a/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
@@ -212,7 +212,7 @@ def qgis_layer_to_jgis(
                 case_conditions.append([r, g, b, a / 255])
 
             layer_parameters["symbologyState"] = {
-                "colorRamp": "cool",
+                "colorRamp": "viridis",
                 "mode": "",
                 "nClasses": "",
                 "renderType": "Categorized",

--- a/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
@@ -302,7 +302,7 @@ def test_qgis_saver():
                     "opacity": 1.0,
                     "source": source_ids[6],
                     "symbologyState": {
-                        "colorRamp": "cool",
+                        "colorRamp": "viridis",
                         "mode": "",
                         "nClasses": "",
                         "renderType": "Categorized",


### PR DESCRIPTION
## Description

Viridis is the Matplotlib default. It's a beautiful colormap that is colorblind-friendly and perceptually uniform.


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
