### PR TITLE
Forbid console.log and console.info

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
       }
     ],
     "prefer-arrow-callback": "error",
+    "no-console": ["error", {"allow": ["error", "warn", "debug"]}],
     "no-duplicate-imports": "error",
   },
 };

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -740,7 +740,6 @@ export function addCommands(
       if (!currentWidget || !completionProviderManager) {
         return;
       }
-      console.log('zooming');
       const model = tracker.currentWidget.model;
       const selectedItems = model.localState?.selected.value;
 
@@ -961,7 +960,7 @@ namespace Private {
     const selected = model?.localState?.selected?.value;
 
     if (!selected) {
-      console.info('Nothing selected');
+      console.error('Failed to remove selected item -- nothing selected');
       return;
     }
 

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
@@ -203,8 +203,6 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     const newStyle = { ...layer.parameters.color };
 
     if (method === 'color') {
-      console.log('delecol');
-
       delete newStyle['fill-color'];
       delete newStyle['stroke-color'];
       delete newStyle['circle-fill-color'];

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2110,7 +2110,7 @@ export class MainView extends React.Component<IProps, IStates> {
     const olLayer = this.getLayer(layerId);
 
     if (!jgisLayer || !olLayer) {
-      console.log('Layer not found');
+      console.error('Failed to update layer -- layer not found');
       return;
     }
 

--- a/packages/base/src/stacBrowser/hooks/useStacSearch.ts
+++ b/packages/base/src/stacBrowser/hooks/useStacSearch.ts
@@ -209,7 +209,7 @@ function useStacSearch({ model }: IUseStacSearchProps): IUseStacSearchReturn {
       )) as IStacSearchResult;
 
       if (!data) {
-        console.log('No Results found');
+        console.debug('STAC search failed -- no results found');
         setResults([]);
         setTotalPages(1);
         setTotalResults(0);
@@ -221,7 +221,7 @@ function useStacSearch({ model }: IUseStacSearchProps): IUseStacSearchReturn {
       setTotalPages(Math.ceil(pages));
       setTotalResults(data.context.matched);
     } catch (error) {
-      console.error('Error fetching data:', error);
+      console.error('STAC search failed -- error fetching data:', error);
       setResults([]);
       setTotalPages(1);
       setTotalResults(0);

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -111,7 +111,10 @@ export async function requestAPI<T>(
     try {
       data = JSON.parse(data);
     } catch (error) {
-      console.log('Not a JSON response body.', response);
+      console.error(
+        'Jupyter API request failed -- not a JSON response body:',
+        response,
+      );
     }
   }
 

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -69,7 +69,6 @@ export class JupyterGISModel implements IJupyterGISModel {
 
       setting.changed.connect(() => {
         this._settings = setting.composite as any;
-        console.log('JupyterGIS Settings updated:', this._settings);
       });
     }
   }
@@ -628,7 +627,7 @@ export class JupyterGISModel implements IJupyterGISModel {
         layerTreeInfo.mainGroup,
       );
     } else {
-      console.log('Something went wrong when renaming layer');
+      console.error('Layer group rename failed -- could not get layer tree.');
     }
   }
 

--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -65,7 +65,6 @@ const activate = async (
 
   try {
     settings = await settingRegistry.load(SETTINGS_ID);
-    console.log(`Loaded settings for ${SETTINGS_ID}`, settings);
   } catch (error) {
     console.warn(`Failed to load settings for ${SETTINGS_ID}`, error);
   }

--- a/python/jupytergis_core/src/plugin.ts
+++ b/python/jupytergis_core/src/plugin.ts
@@ -41,7 +41,6 @@ export const trackerPlugin: JupyterFrontEndPlugin<IJupyterGISTracker> = {
     const tracker = new WidgetTracker<IJupyterGISWidget>({
       namespace: NAME_SPACE,
     });
-    console.log('jupytergis:core:tracker is activated!');
     return tracker;
   },
 };
@@ -80,8 +79,6 @@ export const layerBrowserRegistryPlugin: JupyterFrontEndPlugin<IJGISLayerBrowser
     requires: [],
     provides: IJGISLayerBrowserRegistryToken,
     activate: (app: JupyterFrontEnd) => {
-      console.log('jupytergis:core:layer-browser-registry is activated');
-
       const registry = new JupyterGISLayerBrowserRegistry();
       return registry;
     },

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -59,7 +59,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
     translator?: ITranslator,
     completionProviderManager?: ICompletionProviderManager,
   ): void => {
-    console.log('jupytergis:lab:main-menu is activated!');
     translator = translator ?? nullTranslator;
     const isEnabled = (): boolean => {
       return (

--- a/python/jupytergis_qgis/src/plugins.ts
+++ b/python/jupytergis_qgis/src/plugins.ts
@@ -302,8 +302,6 @@ const activate = async (
       });
     }
   }
-
-  console.log('@jupytergis/jupytergis-qgis:qgisplugin is activated!');
 };
 
 export const qgisplugin: JupyterFrontEndPlugin<void> = {


### PR DESCRIPTION
## Description

Console calls, IMO, should be for debugging only. They're useful
for users facing bugs to share information about any unexpected events.
Instead of using `console.log` as a catch-all, I'd like to think more
carefully about the purpose of each message, and either omit or
log it as an error, warning, or debug message.

What do you all think?

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
