### PR TITLE
Add a flag to hide STAC browser

### DIFF
--- a/docs/jupyter-lite.json
+++ b/docs/jupyter-lite.json
@@ -1,4 +1,6 @@
 {
   "jupyter-lite-schema-version": 0,
-  "jupyter-config-data": {}
+  "jupyter-config-data": {
+    "HIDE_STAC_PANEL": "true"
+  }
 }

--- a/docs/jupyter-lite.json
+++ b/docs/jupyter-lite.json
@@ -1,6 +1,4 @@
 {
   "jupyter-lite-schema-version": 0,
-  "jupyter-config-data": {
-    "HIDE_STAC_PANEL": "true"
-  }
+  "jupyter-config-data": {}
 }

--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -49,19 +49,19 @@ export const LeftPanel: React.FC<ILeftPanelProps> = (
         <TabsList>
           {tabInfo.map(e => {
             return (
-            <TabsTrigger
-              className="jGIS-layer-browser-category"
-              value={e.name}
-              onClick={() => {
-                if (curTab !== e.name) {
-                  setCurTab(e.name);
-                } else {
-                  setCurTab('');
-                }
-              }}
-            >
-              {e.title}
-            </TabsTrigger>
+              <TabsTrigger
+                className="jGIS-layer-browser-category"
+                value={e.name}
+                onClick={() => {
+                  if (curTab !== e.name) {
+                    setCurTab(e.name);
+                  } else {
+                    setCurTab('');
+                  }
+                }}
+              >
+                {e.title}
+              </TabsTrigger>
             );
           })}
         </TabsList>
@@ -78,7 +78,7 @@ export const LeftPanel: React.FC<ILeftPanelProps> = (
 
         {!hideStacPanel && (
           <TabsContent value="stac">
-          <StacPanel model={props.model}></StacPanel>
+            <StacPanel model={props.model}></StacPanel>
           </TabsContent>
         )}
 

--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -1,4 +1,5 @@
 import { IJupyterGISModel, SelectionType } from '@jupytergis/schema';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { IStateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 import { MouseEvent as ReactMouseEvent } from 'react';
@@ -30,11 +31,14 @@ interface ILeftPanelProps {
 export const LeftPanel: React.FC<ILeftPanelProps> = (
   props: ILeftPanelProps,
 ) => {
+  const hideStacPanel = PageConfig.getOption('HIDE_STAC_PANEL') === 'true';
+
   const tabInfo = [
     { name: 'layers', title: 'Layers' },
-    { name: 'stac', title: 'Stac Browser' },
+    ...(hideStacPanel ? [] : [{ name: 'stac', title: 'Stac Browser' }]),
     { name: 'filters', title: 'Filters' },
   ];
+
   const [curTab, setCurTab] = React.useState<string | undefined>(
     tabInfo[0].name,
   );
@@ -45,19 +49,19 @@ export const LeftPanel: React.FC<ILeftPanelProps> = (
         <TabsList>
           {tabInfo.map(e => {
             return (
-              <TabsTrigger
-                className="jGIS-layer-browser-category"
-                value={e.name}
-                onClick={() => {
-                  if (curTab !== e.name) {
-                    setCurTab(e.name);
-                  } else {
-                    setCurTab('');
-                  }
-                }}
-              >
-                {e.title}
-              </TabsTrigger>
+            <TabsTrigger
+              className="jGIS-layer-browser-category"
+              value={e.name}
+              onClick={() => {
+                if (curTab !== e.name) {
+                  setCurTab(e.name);
+                } else {
+                  setCurTab('');
+                }
+              }}
+            >
+              {e.title}
+            </TabsTrigger>
             );
           })}
         </TabsList>
@@ -71,9 +75,13 @@ export const LeftPanel: React.FC<ILeftPanelProps> = (
             state={props.state}
           ></LayersBodyComponent>
         </TabsContent>
-        <TabsContent value="stac">
+
+        {!hideStacPanel && (
+          <TabsContent value="stac">
           <StacPanel model={props.model}></StacPanel>
-        </TabsContent>
+          </TabsContent>
+        )}
+
         <TabsContent value="filters" className="jgis-panel-tab-content">
           <FilterComponent model={props.model}></FilterComponent>,
         </TabsContent>


### PR DESCRIPTION
## Description

Seems to work well when i test it with the lite deployment:

<img width="2940" height="1506" alt="12660" src="https://github.com/user-attachments/assets/7182cca6-05b6-4399-b738-164edbab2fa8" />


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--855.org.readthedocs.build/en/855/
💡 JupyterLite preview: https://jupytergis--855.org.readthedocs.build/en/855/lite

<!-- readthedocs-preview jupytergis end -->