### PR TITLE
Fix add_geoparquet_layer docstring bug

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -559,6 +559,7 @@ class GISDocument(CommWidget):
     ):
         """
         Add a GeoParquet Layer to the document
+
         :param path: The path to the GeoParquet file to embed into the jGIS file.
         :param name: The name that will be used for the object in the document.
         :param type: The type of the vector layer to create.


### PR DESCRIPTION
## Description

Resolves #866

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--867.org.readthedocs.build/en/867/
💡 JupyterLite preview: https://jupytergis--867.org.readthedocs.build/en/867/lite

<!-- readthedocs-preview jupytergis end -->