### PR TITLE
Fix typo in docs: delete extra backtick

### DIFF
--- a/docs/user_guide/features/extension.md
+++ b/docs/user_guide/features/extension.md
@@ -5,7 +5,7 @@
 JupyterGIS comes with a JupyterLab extension that embeds QGIS features directly into the JupyterLab UI.
 This extension allows you to:
 
-- Open `.qgz` and `` .jGIS` `` files in JupyterLab
+- Open `.qgz` and `.jGIS` files in JupyterLab
 - Create new `.jGIS` files
 - Edit those files by adding new vector or raster layers, modifying geometries, and performing spatial operations.
 


### PR DESCRIPTION
## Description

Delete extra backtick in docs

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--868.org.readthedocs.build/en/868/
💡 JupyterLite preview: https://jupytergis--868.org.readthedocs.build/en/868/lite

<!-- readthedocs-preview jupytergis end -->