### PR TITLE
Automatically switch to identify panel when identifying

### DIFF
--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -160,15 +160,14 @@ export function addCommands(
         'WebGlLayer',
         'VectorTileLayer',
       ].includes(selectedLayer.type);
-      const isIdentifying = current.model.isIdentifying;
 
-      if (isIdentifying && !canIdentify) {
-        current.model.isIdentifying = false;
+      if (current.model.currentMode === 'identifying' && !canIdentify) {
+        current.model.currentMode = 'panning';
         current.node.classList.remove('jGIS-identify-tool');
         return false;
       }
 
-      return isIdentifying;
+      return current.model.currentMode === 'identifying';
     },
     isEnabled: () => {
       if (tracker.currentWidget?.model.jgisSettings.identifyDisabled) {
@@ -198,7 +197,7 @@ export function addCommands(
       if (luminoEvent) {
         const keysPressed = luminoEvent.keys as string[] | undefined;
         if (keysPressed?.includes('Escape')) {
-          current.model.isIdentifying = false;
+          current.model.currentMode = 'panning';
           current.node.classList.remove('jGIS-identify-tool');
           commands.notifyCommandChanged(CommandIDs.identify);
           return;
@@ -207,10 +206,6 @@ export function addCommands(
 
       current.node.classList.toggle('jGIS-identify-tool');
       current.model.toggleIdentify();
-
-      if (current.model.isIdentifying) {
-        current.model.activeRightPanelTab = 'identifyPanel';
-      }
 
       commands.notifyCommandChanged(CommandIDs.identify);
     },

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -211,8 +211,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
     // Watch isIdentifying and clear the highlight when Identify Tool is turned off
     this._model.sharedModel.awareness.on('change', () => {
-      const isIdentifying = this._model.isIdentifying;
-      if (!isIdentifying && this._highlightLayer) {
+      if (this._model.currentMode !== 'identifying' && this._highlightLayer) {
         this._highlightLayer.getSource()?.clear();
       }
     });
@@ -519,7 +518,7 @@ export class MainView extends React.Component<IProps, IStates> {
         return layer === this.getLayer(selectedLayerId);
       },
       condition: (event: MapBrowserEvent<any>) => {
-        return singleClick(event) && this._model.isIdentifying;
+        return singleClick(event) && this._model.currentMode === 'identifying';
       },
       style: styleFunction,
     });
@@ -2086,7 +2085,7 @@ export class MainView extends React.Component<IProps, IStates> {
   });
 
   private _identifyFeature(e: MapBrowserEvent<any>) {
-    if (!this._model.isIdentifying) {
+    if (this._model.currentMode !== 'identifying') {
       return;
     }
 

--- a/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
+++ b/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
@@ -58,7 +58,10 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
         return;
       }
 
-      if (model.isIdentifying && featuresRef.current !== identifiedFeatures) {
+      if (
+        model.currentMode === 'identifying' &&
+        featuresRef.current !== identifiedFeatures
+      ) {
         setFeatures(identifiedFeatures);
       }
     };

--- a/packages/base/src/panelview/rightpanel.tsx
+++ b/packages/base/src/panelview/rightpanel.tsx
@@ -1,6 +1,7 @@
 import {
   IAnnotationModel,
   IJGISFormSchemaRegistry,
+  IJupyterGISClientState,
   IJupyterGISModel,
 } from '@jupytergis/schema';
 import * as React from 'react';
@@ -23,26 +24,6 @@ interface IRightPanelProps {
 
 export const RightPanel: React.FC<IRightPanelProps> = props => {
   const [settings, setSettings] = React.useState(props.model.jgisSettings);
-
-  React.useEffect(() => {
-    const onSettingsChanged = () => {
-      setSettings({ ...props.model.jgisSettings });
-    };
-
-    props.model.settingsChanged.connect(onSettingsChanged);
-    return () => {
-      props.model.settingsChanged.disconnect(onSettingsChanged);
-    };
-  }, [props.model]);
-
-  const allRightTabsDisabled =
-    settings.objectPropertiesDisabled &&
-    settings.annotationsDisabled &&
-    settings.identifyDisabled;
-
-  const rightPanelVisible =
-    !settings.rightPanelDisabled && !allRightTabsDisabled;
-
   const tabInfo = [
     !settings.objectPropertiesDisabled
       ? { name: 'objectProperties', title: 'Object Properties' }
@@ -59,14 +40,47 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
     tabInfo.length > 0 ? tabInfo[0].name : undefined,
   );
 
+  React.useEffect(() => {
+    const onSettingsChanged = () => {
+      setSettings({ ...props.model.jgisSettings });
+    };
+    let currentlyIdentifiedFeatures: any = undefined;
+    const onAwerenessChanged = (
+      _: IJupyterGISModel,
+      clients: Map<number, IJupyterGISClientState>,
+    ) => {
+      const clientId = props.model.getClientId();
+      const localState = clientId ? clients.get(clientId) : null;
+
+      if (
+        localState &&
+        localState.identifiedFeatures?.value &&
+        localState.identifiedFeatures.value !== currentlyIdentifiedFeatures
+      ) {
+        currentlyIdentifiedFeatures = localState.identifiedFeatures.value;
+        setCurTab('identifyPanel');
+      }
+    };
+
+    props.model.settingsChanged.connect(onSettingsChanged);
+    props.model.clientStateChanged.connect(onAwerenessChanged);
+
+    return () => {
+      props.model.settingsChanged.disconnect(onSettingsChanged);
+      props.model.clientStateChanged.disconnect(onAwerenessChanged);
+    };
+  }, [props.model]);
+
+  const allRightTabsDisabled =
+    settings.objectPropertiesDisabled &&
+    settings.annotationsDisabled &&
+    settings.identifyDisabled;
+
+  const rightPanelVisible =
+    !settings.rightPanelDisabled && !allRightTabsDisabled;
+
   const [selectedObjectProperties, setSelectedObjectProperties] =
     React.useState(undefined);
-
-  React.useEffect(() => {
-    if (props.model.activeRightPanelTab) {
-      setCurTab(props.model.activeRightPanelTab);
-    }
-  }, [props.model.activeRightPanelTab]);
 
   return (
     <div

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -161,7 +161,9 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   geolocation: JgisCoordinates;
   localState: IJupyterGISClientState | null;
   annotationModel?: IAnnotationModel;
-  activeRightPanelTab?: string;
+
+  // TODO Add more modes: "annotating"
+  currentMode: 'panning' | 'identifying';
 
   themeChanged: Signal<
     IJupyterGISModel,
@@ -245,7 +247,6 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   centerOnPosition(id: string): void;
 
   toggleIdentify(): void;
-  isIdentifying: boolean;
 
   isTemporalControllerActive: boolean;
   toggleTemporalController(): void;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -161,22 +161,6 @@ export class JupyterGISModel implements IJupyterGISModel {
     return this._settings;
   }
 
-  get activeRightPanelTab(): string | undefined {
-    return this._activeRightPanelTab;
-  }
-
-  set activeRightPanelTab(tab: string | undefined) {
-    if (this._activeRightPanelTab !== tab) {
-      const oldValue = this._activeRightPanelTab;
-      this._activeRightPanelTab = tab;
-      this._stateChanged.emit({
-        name: 'activeRightPanelTab',
-        oldValue,
-        newValue: tab,
-      });
-    }
-  }
-
   getFeaturesForCurrentTile({ sourceId }: { sourceId: string }): FeatureLike[] {
     return Array.from(this._tileFeatureCache.get(sourceId) ?? []);
   }
@@ -305,14 +289,6 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   get zoomToPositionSignal(): ISignal<this, string> {
     return this._zoomToPositionSignal;
-  }
-
-  set isIdentifying(isIdentifying: boolean) {
-    this._isIdentifying = isIdentifying;
-  }
-
-  get isIdentifying(): boolean {
-    return this._isIdentifying;
   }
 
   set isTemporalControllerActive(isActive: boolean) {
@@ -783,7 +759,19 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   toggleIdentify() {
-    this._isIdentifying = !this._isIdentifying;
+    if (this._currentMode === 'identifying') {
+      this._currentMode = 'panning';
+    } else {
+      this._currentMode = 'identifying';
+    }
+  }
+
+  get currentMode(): 'panning' | 'identifying' {
+    return this._currentMode;
+  }
+
+  set currentMode(value: 'panning' | 'identifying') {
+    this._currentMode = value;
   }
 
   toggleTemporalController() {
@@ -881,14 +869,14 @@ export class JupyterGISModel implements IJupyterGISModel {
   private _settingsChanged: Signal<JupyterGISModel, string>;
   private _jgisSettings: IJupyterGISSettings;
 
+  private _currentMode: 'panning' | 'identifying';
+
   private _sharedModel: IJupyterGISDoc;
   private _filePath: string;
   private _contentsManager?: Contents.IManager;
   private _dirty = false;
   private _readOnly = false;
   private _isDisposed = false;
-
-  private _activeRightPanelTab: string | undefined;
 
   private _userChanged = new Signal<this, IUserData[]>(this);
   private _usersMap?: Map<number, any>;
@@ -910,7 +898,6 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   private _updateLayerSignal = new Signal<this, string>(this);
 
-  private _isIdentifying = false;
   private _isTemporalControllerActive = false;
 
   static worker: Worker;

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -20,12 +20,12 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { showErrorMessage } from '@jupyterlab/apputils';
 import { ConsolePanel } from '@jupyterlab/console';
 import { PathExt } from '@jupyterlab/coreutils';
 import { NotebookPanel } from '@jupyterlab/notebook';
 import { Contents } from '@jupyterlab/services';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';
 import { Toolbar } from '@jupyterlab/ui-components';
 import { CommandRegistry } from '@lumino/commands';


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--900.org.readthedocs.build/en/900/
💡 JupyterLite preview: https://jupytergis--900.org.readthedocs.build/en/900/lite

<!-- readthedocs-preview jupytergis end -->