### PR TITLE
Lazy load gdal

### DIFF
--- a/packages/base/src/gdal.ts
+++ b/packages/base/src/gdal.ts
@@ -13,6 +13,3 @@ export async function getGdal() {
     useWorker: false,
   });
 }
-
-// Early load gdal
-getGdal();


### PR DESCRIPTION
## Description

We used to need gdal for visualization and symbology, so I decided to early-load it. Now that it's only used for processing, it probably make more sense to pay the cost of loading gdal only when we need it for processing. This is 11MB of data that won't be loaded when opening JupyterGIS!!

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--901.org.readthedocs.build/en/901/
💡 JupyterLite preview: https://jupytergis--901.org.readthedocs.build/en/901/lite

<!-- readthedocs-preview jupytergis end -->