### PR TITLE
Identify panel: try to infer the feature name instead of showing the default "Feature X" name

### DIFF
--- a/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
+++ b/packages/base/src/panelview/components/identify-panel/IdentifyPanel.tsx
@@ -87,6 +87,18 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
     }));
   };
 
+  const getFeatureNameOrId = (feature: any, featureIndex: number) => {
+    for (const key of Object.keys(feature)) {
+      const lowerCase = key.toLowerCase();
+
+      if ((lowerCase.includes('name') || lowerCase === 'id') && feature[key]) {
+        return feature[key];
+      }
+    }
+
+    return `Feature ${featureIndex + 1}`;
+  };
+
   return (
     <div
       className="jgis-identify-wrapper"
@@ -106,7 +118,7 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
                   className={`jp-gis-layerGroupCollapser${visibleFeatures[featureIndex] ? ' jp-mod-expanded' : ''}`}
                   tag={'span'}
                 />
-                <span>Feature {featureIndex + 1}</span>
+                <span>{getFeatureNameOrId(feature, featureIndex)}</span>
               </span>
 
               {(() => {


### PR DESCRIPTION
## Description

<img width="945" height="575" alt="Screenshot From 2025-08-27 14-39-06" src="https://github.com/user-attachments/assets/d2994858-3460-4bbb-86c3-017587e11555" />


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--906.org.readthedocs.build/en/906/
💡 JupyterLite preview: https://jupytergis--906.org.readthedocs.build/en/906/lite

<!-- readthedocs-preview jupytergis end -->