### PR TITLE
Fix double click bug while identifying vectorTileLayers

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2125,6 +2125,7 @@ export class MainView extends React.Component<IProps, IStates> {
             const { geometry, ...clean } = rawProps;
             props = clean;
             if (fid !== null) {
+              // TODO Clean the cache under some condition?
               this._featurePropertyCache.set(fid, props);
             }
           } else if (fid !== null && this._featurePropertyCache.has(fid)) {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--908.org.readthedocs.build/en/908/
💡 JupyterLite preview: https://jupytergis--908.org.readthedocs.build/en/908/lite

<!-- readthedocs-preview jupytergis end -->