### PR TITLE
Add contributor docs troubleshooting entry for `.yarn-state.yml` CI failure

### DIFF
--- a/docs/contributor_guide/troubleshooting.md
+++ b/docs/contributor_guide/troubleshooting.md
@@ -1,12 +1,23 @@
 # Troubleshooting
 
-- Setup of development environment hangs indefinitely when running the
-  `dev-install.py` step, specifically on the Yarn linking step.
-  - This may be caused by having a `.gitignore` file in your home directory.
-    This is a [known issue with Nx](https://github.com/nrwl/nx/issues/27494).
-    The [only known workaround](https://github.com/nrwl/nx/issues/27494#issuecomment-2481207598) is to remove the `.gitignore` file from your home directory or to work in a location outside of the home directory tree.
+## Setup of development environment hangs indefinitely when running the `dev-install.py` step, specifically on the Yarn linking step.
 
-- Every UI test fails after 60 seconds due to timeout.
-  - This could be caused by having a JupyterLab instance already running at port
-    `:8888`. Please ensure that there is nothing running at <http://localhost:8888/lab>
-    before running tests.
+This may be caused by having a `.gitignore` file in your home directory.
+This is a [known issue with Nx](https://github.com/nrwl/nx/issues/27494).
+The [only known workaround](https://github.com/nrwl/nx/issues/27494#issuecomment-2481207598)
+is to remove the `.gitignore` file from your home directory or to work in a location
+outside of the home directory tree.
+
+## Every UI test fails after 60 seconds due to timeout.
+
+This could be caused by having a JupyterLab instance already running at port `:8888`.
+Please ensure that there is nothing running at <http://localhost:8888/lab> before
+running tests.
+
+## Build fails in CI with error about `.yarn-state.yml`
+
+```
+Error: ENOENT: no such file or directory, unlink '/home/runner/work/jupytergis/jupytergis/node_modules/.yarn-state.yml'
+```
+
+Re-running the job can get you past this error.


### PR DESCRIPTION
## Description

This has been happening lately, and I don't know why! I just know that re-running CI seems to get around it. :shrug: Might as well share that information for now ;) 


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--915.org.readthedocs.build/en/915/
💡 JupyterLite preview: https://jupytergis--915.org.readthedocs.build/en/915/lite

<!-- readthedocs-preview jupytergis end -->