### PR TITLE
Exclude unsupported files from JupyterLite build in documentation site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,3 +48,8 @@ todo_include_todos = False
 htmlhelp_basename = "jupytergisdoc"
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+
+jupyterlite_ignore_contents = [
+    "../examples/*.qgz",
+    "../examples/99-Explore_data_in_a_map.ipynb",
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,6 @@ htmlhelp_basename = "jupytergisdoc"
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 jupyterlite_ignore_contents = [
-    "*.qgz",
-    "99-Explore_data_in_a_map.ipynb",
+    r"examples/.*\.qgz$",
+    r"examples/99-Explore_data_in_a_map\.ipynb$",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,6 @@ htmlhelp_basename = "jupytergisdoc"
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 jupyterlite_ignore_contents = [
-    "../examples/*.qgz",
-    "../examples/99-Explore_data_in_a_map.ipynb",
+    "*.qgz",
+    "99-Explore_data_in_a_map.ipynb",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,6 @@ htmlhelp_basename = "jupytergisdoc"
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 jupyterlite_ignore_contents = [
-    r"examples/.*\.qgz$",
-    r"examples/99-Explore_data_in_a_map\.ipynb$",
+    r".*\.qgz$",
+    r"99-Explore_data_in_a_map\.ipynb$",
 ]


### PR DESCRIPTION
## Description

Shall close #917 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--919.org.readthedocs.build/en/919/
💡 JupyterLite preview: https://jupytergis--919.org.readthedocs.build/en/919/lite

<!-- readthedocs-preview jupytergis end -->