### PR TITLE
Create new top-level "oveview" section in docs

### DIFF
--- a/docs/build-on-change.sh
+++ b/docs/build-on-change.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# NOTE: Requires `inotify-tools`. e.g. `apt install inotify-tools`.
+# TODO: MacOS support?
+set -euo pipefail
+
+THIS_DIR="$( cd "$(dirname "$0")"; pwd -P )"
+cd "${THIS_DIR}"
+HTML_PATH="./_build/html/index.html"
+
+${THIS_DIR}/clean.sh
+
+set +e
+${THIS_DIR}/build.sh
+xdg-open "${HTML_PATH}"
+set -e
+
+while inotifywait -e delete -e create -e close_write -r ${THIS_DIR}; do
+    ${THIS_DIR}/clean.sh
+
+    set +e
+    ${THIS_DIR}/build.sh
+    set -e
+done

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 THIS_DIR="$( cd "$(dirname "$0")"; pwd -P )"
 
 # Build can fail if certain artifacts exist here:
-rm -rf "${THIS_DIR}/_build"
+${THIS_DIR}/clean.sh
 
 python -m sphinx \
     --nitpicky --show-traceback \

--- a/docs/clean.sh
+++ b/docs/clean.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THIS_DIR="$( cd "$(dirname "$0")"; pwd -P )"
+rm -rf "${THIS_DIR}/_build"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,29 +1,52 @@
 # JupyterGIS
 
+JupyterGIS is a **collaborative** Geographical Information System (GIS) environment in
+JupyterLab.
+
+```{raw} html
+<center>
+```
+
 ```{jupyterlite}
 :new_tab: True
 :new_tab_button_text: Try it with JupyterLite!
 ```
 
-JupyterGIS is a JupyterLab extension for collaborative GIS (Geographical Information System). It is designed to
-allow multiple people to work on the same geospatial project simultaneously, facilitating discussion and collaboration
-around map layers, spatial analyses, and other GIS data being developed.
+```{raw} html
+</center>
+<br />
+```
 
-JupyterGIS provides basic support for [QGIS](https://www.qgis.org) project files, allowing users to import and export
-projects seamlessly between QGIS and JupyterLab.
-This compatibility preserves layer styles, data sources, and project settings, enabling smooth transitions between GIS work
-in QGIS and collaborative, cloud-based work in JupyterLab.
+JupyterGIS is the flagship project of the user-centric and open
+[GeoJupyter community](https://geojupyter.org), which aims to enable more people to
+confidently engage with geospatial data.
+We'd love to hear from you at a
+[community meeting](https://geojupyter.org/calendar.html)!
 
-Beyond QGIS project support, JupyterGIS offers a range of features tailored specifically for collaborative geospatial analysis.
-Users can edit, visualize, and analyze spatial data together in real-time, share map layers, and annotate directly within the
-JupyterLab environment, fostering efficient teamwork on GIS projects.
 
-Python users can further extend JupyterGIS workflows by integrating with Python geospatial libraries, such as GeoPandas, Xarray
-and Rasterio, to perform custom analyses and automate processes. Together, these features make JupyterGIS a powerful tool for
-both collaborative mapping and in-depth geospatial analysis.
+## ✨ Highlights ✨
+
+🤝 Work simultaneously with your colleagues on the same GIS project (like Google Docs)
+
+🔄 Basic support for importing/exporting [QGIS](https://www.qgis.org) project files
+
+🐍 Python API and integration with Jupyter Notebook workflows
+
+For more details, check out the [project overview](overview/index.md)!
 
 ```{image} ../jupytergis.png
 :alt: JupyterGIS application
+```
+
+## Overview
+
+High-level information about the project.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 2
+
+overview/index
 ```
 
 ## User guide

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -1,0 +1,25 @@
+# Overview
+
+## 🤝 Real-time collaboration
+
+JupyterGIS is designed to allow multiple people to work on the same geospatial project
+simultaneously, facilitating discussion and collaboration around map layers, spatial
+analyses, and other GIS data being developed.
+
+Users can edit, visualize, and analyze spatial data together in real-time, share map
+layers, and annotate directly within the JupyterLab environment, fostering efficient
+teamwork on GIS projects.
+
+## 🔄 QGIS project file support
+
+JupyterGIS provides basic support for [QGIS](https://www.qgis.org) project files, allowing users to import and export
+projects seamlessly between QGIS and JupyterLab.
+This compatibility preserves layer styles, data sources, and project settings, enabling smooth transitions between GIS work
+in QGIS and collaborative, cloud-based work in JupyterLab.
+
+## 🐍 Python integration
+
+Python users can further extend JupyterGIS workflows by integrating with Python geospatial libraries, such as GeoPandas, Xarray
+and Rasterio, to perform custom analyses and automate processes.
+Together, these features make JupyterGIS a powerful tool for
+both collaborative mapping and in-depth geospatial analysis.


### PR DESCRIPTION
## Description

* The front page of our docs is pretty wordy! Extract long-form content to overview page. Add some :fire: emojis.
* Add pages/sections: "What is JupyterGIS?", "Roadmap".
* Move the "features" section from the user guide to the overview.
	* Move the "how-to setup up collaboration" instructions to a new how-tos section in the user guide. Cross-link.
* ...?

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
