### PR TITLE
Adding default classes to colormaps

### DIFF
--- a/packages/base/src/dialogs/symbology/colorRampUtils.ts
+++ b/packages/base/src/dialogs/symbology/colorRampUtils.ts
@@ -15,7 +15,7 @@ Object.assign(colorScale, cmocean);
 
 export const COLOR_RAMP_NAMES = [
   'jet',
-  // 'hsv', 11 steps min
+  'hsv',
   'hot',
   'cool',
   'spring',
@@ -30,7 +30,7 @@ export const COLOR_RAMP_NAMES = [
   'YiOrRd',
   'bluered',
   'RdBu',
-  // 'picnic', 11 steps min
+  'picnic',
   'rainbow',
   'portland',
   'blackbody',
@@ -41,7 +41,7 @@ export const COLOR_RAMP_NAMES = [
   'magma',
   'plasma',
   'warm',
-  // 'rainbow-soft', 11 steps min
+  'rainbow-soft',
   'bathymetry',
   'cdom',
   'chlorophyll',
@@ -56,7 +56,7 @@ export const COLOR_RAMP_NAMES = [
   'turbidity',
   'velocity-blue',
   'velocity-green',
-  // 'cubehelix' 16 steps min
+  'cubehelix',
   'ice',
   'oxy',
   'matter',
@@ -70,6 +70,13 @@ export const COLOR_RAMP_NAMES = [
   'diff',
   'tarn',
 ] as const;
+
+export const COLOR_RAMP_DEFAULTS: Partial<Record<ColorRampName, number>> = {
+  hsv: 11,
+  picnic: 11,
+  'rainbow-soft': 11,
+  cubehelix: 16,
+} as const;
 
 export type ColorRampName = (typeof COLOR_RAMP_NAMES)[number];
 


### PR DESCRIPTION
## Description

Adding default classes for `hsv`, `picnic`, `cubehelix`, and `rainbow-soft` so they work like the other colormaps. These colormaps were previously not in use because they require 11 and 16 classes, respectively (with cubehelix needing 16), while we were using a default of 9. With these changes, all colormaps should now function correctly, and these four now have their own default classes.

https://github.com/user-attachments/assets/667c2177-f3b5-4410-b46c-330dbdc558e5



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--922.org.readthedocs.build/en/922/
💡 JupyterLite preview: https://jupytergis--922.org.readthedocs.build/en/922/lite

<!-- readthedocs-preview jupytergis end -->