### PR TITLE
New PR triage workflow: Support hourly triage of PRs to a PR triage board

### DIFF
--- a/.github/workflows/triage-prs-to-board.yml
+++ b/.github/workflows/triage-prs-to-board.yml
@@ -1,18 +1,18 @@
-name: "PR Triage Bot"
+name: 'PR Triage Bot'
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: '0 * * * *'
   workflow_dispatch: true
 
 jobs:
   pr-triage:
-    uses: "yuvipanda/pr-triage-board-bot/.github/workflows/reusable-pr-triage.yml@main"
+    uses: 'yuvipanda/pr-triage-board-bot/.github/workflows/reusable-pr-triage.yml@main'
     with:
-      organization: "geojupyter"
-      project-number: "3"
-      gh-app-id: "1943749"
-      gh-installation-id: "85628873"
-      repositories: "jupytergis"
+      organization: 'geojupyter'
+      project-number: '3'
+      gh-app-id: '1943749'
+      gh-installation-id: '85628873'
+      repositories: 'jupytergis'
     secrets:
-      gh-app-private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"
+      gh-app-private-key: '${{ secrets.GH_APP_PRIVATE_KEY }}'


### PR DESCRIPTION
## Description

This uses Yuvi and Jason's awesome PR triage workflow:

<https://github.com/yuvipanda/pr-triage-board-bot>

to automatically categorize PRs for maintainer monitoring and decision-making.

You can view our PR triage board here: https://github.com/orgs/geojupyter/projects/3?query=sort%3Aupdated-desc+is%3Aopen

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--923.org.readthedocs.build/en/923/
💡 JupyterLite preview: https://jupytergis--923.org.readthedocs.build/en/923/lite

<!-- readthedocs-preview jupytergis end -->