### PR TITLE
PR triage workflow: Fixup `workflow_dispatch` YAML value

### DIFF
--- a/.github/workflows/triage-prs-to-board.yml
+++ b/.github/workflows/triage-prs-to-board.yml
@@ -3,7 +3,7 @@ name: 'PR Triage Bot'
 on:
   schedule:
     - cron: '0 * * * *'
-  workflow_dispatch: true
+  workflow_dispatch:
 
 jobs:
   pr-triage:


### PR DESCRIPTION
## Description

`workflow_dispatch` should be null to use default settings, shorthand is empty value.

Fixup bug introduced in #923 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--924.org.readthedocs.build/en/924/
💡 JupyterLite preview: https://jupytergis--924.org.readthedocs.build/en/924/lite

<!-- readthedocs-preview jupytergis end -->