### PR TITLE
PR triage workflow: Fixup incorrect parameter name

### DIFF
--- a/.github/workflows/triage-prs-to-board.yml
+++ b/.github/workflows/triage-prs-to-board.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Run PR Triage Bot'
-        uses: 'yuvipanda/pr-triage-board-bot@c350212c2bba8a47cc2b07e7ce40fd6748b6beef'
+        uses: 'yuvipanda/pr-triage-board-bot@b498c5a505480d4440fd747fe73ce925a675015a'
         with:
           organization: 'geojupyter'
           repositories: 'jupytergis'


### PR DESCRIPTION
## Description

Fix incorrect parameter name

TODO: update action version after https://github.com/yuvipanda/pr-triage-board-bot/issues/37 is fixed

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--930.org.readthedocs.build/en/930/
💡 JupyterLite preview: https://jupytergis--930.org.readthedocs.build/en/930/lite

<!-- readthedocs-preview jupytergis end -->