### PR TITLE
Disable lifecycle scripts for Yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,3 @@
 nodeLinker: node-modules
 enableImmutableInstalls: false
+enableScripts: false


### PR DESCRIPTION
## Description

This is a prevention measure for the [attack vector](https://yarnpkg.com/configuration/yarnrc#enableScripts) used in the recent NPM supply chain attacks.

See:

<https://www.upguard.com/blog/the-shai-hulud-attack-explained>
<https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised>
<https://socket.dev/blog/ongoing-supply-chain-attack-targets-crowdstrike-npm-packages>

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--932.org.readthedocs.build/en/932/
💡 JupyterLite preview: https://jupytergis--932.org.readthedocs.build/en/932/lite

<!-- readthedocs-preview jupytergis end -->