### PR TITLE
Forbid unnecessary type assertions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   plugins: ["@typescript-eslint", "import"],
   rules: {
+    "@typescript-eslint/ban-ts-comment": "warn",
     "@typescript-eslint/naming-convention": [
       "error",
       {
@@ -31,7 +32,7 @@ module.exports = {
     ],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-namespace": "off",
-    "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/quotes": [
       "error",

--- a/packages/base/src/classificationModes.ts
+++ b/packages/base/src/classificationModes.ts
@@ -347,7 +347,7 @@ export namespace GeoTiffClassifications {
       if (numValuesInCurrentBin + 1 < valuesPerBin) {
         numValuesInCurrentBin++;
       } else {
-        breaks.push(bandSortedValues[i] as number);
+        breaks.push(bandSortedValues[i]);
         numValuesInCurrentBin = 0;
       }
     }

--- a/packages/base/src/dialogs/symbology/classificationModes.ts
+++ b/packages/base/src/dialogs/symbology/classificationModes.ts
@@ -347,7 +347,7 @@ export namespace GeoTiffClassifications {
       if (numValuesInCurrentBin + 1 < valuesPerBin) {
         numValuesInCurrentBin++;
       } else {
-        breaks.push(bandSortedValues[i] as number);
+        breaks.push(bandSortedValues[i]);
         numValuesInCurrentBin = 0;
       }
     }

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -244,9 +244,9 @@ export class MainView extends React.Component<IProps, IStates> {
     const options = this._model.getOptions();
     const center =
       options.longitude !== undefined && options.latitude !== undefined
-        ? fromLonLat([options.longitude!, options.latitude!])
+        ? fromLonLat([options.longitude, options.latitude])
         : [0, 0];
-    const zoom = options.zoom !== undefined ? options.zoom! : 1;
+    const zoom = options.zoom !== undefined ? options.zoom : 1;
 
     await this.generateMap(center, zoom);
     this.addContextMenu();
@@ -871,7 +871,7 @@ export class MainView extends React.Component<IProps, IStates> {
     // create updated source
     await this.addSource(id, source);
     // change source of target layer
-    (mapLayer as Layer).setSource(this._sources[id]);
+    mapLayer.setSource(this._sources[id]);
   }
 
   /**
@@ -1957,7 +1957,7 @@ export class MainView extends React.Component<IProps, IStates> {
             return;
           }
         } else {
-          jsonData = data as IAnnotation;
+          jsonData = data;
         }
 
         newState[key] = jsonData;
@@ -2004,7 +2004,7 @@ export class MainView extends React.Component<IProps, IStates> {
 
     // The id is a layer
     let extent;
-    const layer = this.getLayer(id) as Layer;
+    const layer = this.getLayer(id);
     const source = layer?.getSource();
 
     if (source instanceof VectorSource) {

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -663,7 +663,7 @@ export const loadFile = async (fileInfo: {
         if (typeof file.content === 'string') {
           const { toGeoJson } = await import('geoparquet');
 
-          const arrayBuffer = await stringToArrayBuffer(file.content as string);
+          const arrayBuffer = await stringToArrayBuffer(file.content);
 
           return await toGeoJson({ file: arrayBuffer, compressors });
         } else {
@@ -959,7 +959,7 @@ export async function getGeoJSONDataFromLayerSource(
 ): Promise<string | null> {
   const vectorSourceTypes: SourceType[] = ['GeoJSONSource', 'ShapefileSource'];
 
-  if (!vectorSourceTypes.includes(source.type as SourceType)) {
+  if (!vectorSourceTypes.includes(source.type)) {
     console.error(
       `Invalid source type '${source.type}'. Expected one of: ${vectorSourceTypes.join(', ')}`,
     );

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -347,7 +347,7 @@ export class JupyterGISDoc
           needEmit = true;
         }
         changes.push({
-          id: key as string,
+          id: key,
           oldValue: change.oldValue,
           newValue: JSONExt.deepCopy(event.target.toJSON()[key]),
         });
@@ -376,7 +376,7 @@ export class JupyterGISDoc
           needEmit = true;
         }
         changes.push({
-          id: key as string,
+          id: key,
           newValue: JSONExt.deepCopy(event.target.toJSON()[key]),
         });
       });

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -209,7 +209,7 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
           );
         }
 
-        const sharedModel = drive!.sharedModelFactory.createNew({
+        const sharedModel = drive.sharedModelFactory.createNew({
           path: localPath,
           format: fileFormat,
           contentType,


### PR DESCRIPTION
## Description

Keep our codebase a little more readable by removing unnecessary type assertions. Those type assertions may mislead readers to believe that a value is incorrectly typed (or potentially undefined) when it is not. It's easy to introduce unnecessary type assertions during development as we tighten up our type information.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--933.org.readthedocs.build/en/933/
💡 JupyterLite preview: https://jupytergis--933.org.readthedocs.build/en/933/lite

<!-- readthedocs-preview jupytergis end -->