### PR TITLE
Ignore npmjs links in check links CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: 'lite/'
+          ignore_links: 'lite/ https://www.npmjs.com.*'
 
   build-lite:
     name: Build JupyterLite artifacts


### PR DESCRIPTION
## Description

Resolves #942 

I believe NPM added a new check for user agent which causes our link check job to fail when querying npmjs.com.


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--943.org.readthedocs.build/en/943/
💡 JupyterLite preview: https://jupytergis--943.org.readthedocs.build/en/943/lite

<!-- readthedocs-preview jupytergis end -->