### PR TITLE
Ignore absolute links in CI link check job, change relative docs links to absolute

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: 'lite/ https://www.npmjs.com.* $\/.*'
+          ignore_links: 'lite/ https://www.npmjs.com.* $/.*'
 
   build-lite:
     name: Build JupyterLite artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: 'lite/ https://www.npmjs.com.* $/.*'
+          ignore_links: 'lite/ https://www.npmjs.com.* ^/.*'
 
   build-lite:
     name: Build JupyterLite artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: 'lite/ https://www.npmjs.com.*'
+          ignore_links: 'lite/ https://www.npmjs.com.* $\/.*'
 
   build-lite:
     name: Build JupyterLite artifacts

--- a/docs/contributor_guide/how-tos/build-docs-locally.md
+++ b/docs/contributor_guide/how-tos/build-docs-locally.md
@@ -7,7 +7,7 @@ below, but they will not be as fast.
 
 ## 0. Build JupyterGIS JavaScript packages
 
-Follow the [development environment setup instructions](../development_setup.md) through running `jlpm run build` from the **root of the repo**.
+Follow the [development environment setup instructions](/contributor_guide/development_setup.md) through running `jlpm run build` from the **root of the repo**.
 
 :::{important}
 Navigate to the `docs/` directory before starting any of the following steps!

--- a/docs/contributor_guide/how-tos/code_quality.md
+++ b/docs/contributor_guide/how-tos/code_quality.md
@@ -1,7 +1,7 @@
 # Check code quality
 
 ```{seealso}
-Complete [dev install](../development_setup) instructions before continuing.
+Complete [dev install](/contributor_guide/development_setup) instructions before continuing.
 ```
 
 We have several tools configured for checking code quality:

--- a/docs/user_guide/features/collab.md
+++ b/docs/user_guide/features/collab.md
@@ -14,13 +14,13 @@ If you are using a local installation, your JupyterLab instance is not available
 
    In both cases, you should forward the port of the JupyterLab instance. The default port is `8888`.
 
-2. For a more scalable alternative, consider hosting JupyterGIS on a cloud-based or network-accessible instance. This setup allows multi-user cooperation with authentication and access restriction, without requiring a local installation. Once the instance is created using any of the options below, JupyterGIS needs to be installed on the created instance by opening a terminal window and following [the installation guide](../install.md).
+2. For a more scalable alternative, consider hosting JupyterGIS on a cloud-based or network-accessible instance. This setup allows multi-user cooperation with authentication and access restriction, without requiring a local installation. Once the instance is created using any of the options below, JupyterGIS needs to be installed on the created instance by opening a terminal window and following [the installation guide](/user_guide/install.md).
    - [JupyterHub](https://jupyter.org/hub): You can follow [the JupyterHub documentation](https://jupyter.org/hub#deploy-a-jupyterhub) for setup instructions. By default, JupyterHub creates isolated environments for each user. To enable real-time collaboration on the same environment, you can follow [this guide](https://jupyterhub.readthedocs.io/en/5.2.1/reference/sharing.html#sharing-reference).
    - [Binder](https://mybinder.readthedocs.io/en/latest/index.html): Check out [this tutorial](https://book.the-turing-way.org/communication/binder/zero-to-binder) to start using Binder. Note that when you share the link with a collaborator, they will be asked to enter the password or token to access the session. You can find out the token by opening a terminal window and running the command
      ```
      jupyter notebook list --json | python3 -c 'import json; import sys; print(json.load(sys.stdin)["token"])'
      ```
-     Note that if you have added JupyterGIS to the `requirements.txt` file, it will be installed automatically when you create the Binder instance. In this case you do not need to follow [the installation guide](../install.md).
+     Note that if you have added JupyterGIS to the `requirements.txt` file, it will be installed automatically when you create the Binder instance. In this case you do not need to follow [the installation guide](/user_guide/install.md).
    - [Amazon SageMaker AI](https://aws.amazon.com/sagemaker-ai): If you prefer to use Amazon SageMaker AI, you can follow [this tutorial](https://docs.aws.amazon.com/sagemaker/latest/dg/onboard-quick-start.html) to set up your environment. After opening SageMaker Studio, create a JupyterLab space, and make sure choosing `Share with my domain` option to enable access for your collaborators.
 
 :::{important}

--- a/docs/user_guide/features/extension.md
+++ b/docs/user_guide/features/extension.md
@@ -9,6 +9,6 @@ This extension allows you to:
 - Create new `.jGIS` files
 - Edit those files by adding new vector or raster layers, modifying geometries, and performing spatial operations.
 
-```{image} ../../assets/lab_ext.webp
+```{image} /assets/lab_ext.webp
 :alt: JupyterGIS JupyterLab extension
 ```

--- a/docs/user_guide/tutorials/02-collaboration/index.md
+++ b/docs/user_guide/tutorials/02-collaboration/index.md
@@ -19,7 +19,7 @@ By following this tutorial, you will be able to:
 
 :::{admonition} Prerequisites
 :class: warning
-Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS. Your choice may have implications for collaboration, so please read our [collaboration feature overview](../../features/collab.md) for more context.
+Before beginning this tutorial, JupyterGIS must be installed on your computer (see [Installation instructions](https://jupytergis.readthedocs.io/en/latest/user_guide/install.html)). Alternatively, you can use an online installation of JupyterGIS. Your choice may have implications for collaboration, so please read our [collaboration feature overview](/user_guide/features/collab.md) for more context.
 :::
 
 ---
@@ -63,7 +63,7 @@ When your colleagues join using the link, their usernames appear in the top righ
 
 ### Adding and Editing Layers
 
-When you add a new layer to your GIS file, the new layer appears immediately for all collaborators in your session. You can experiment by adding a layer from the layer browser or from the add layer menu, and customizing its symbology, such as changing the opacity or color. Observe that each change is instantly visible to your collaborators. You can check the [Getting Started with JupyterGIS](../01-intro/index.md) tutorial for more details on how to customize the layer appearance.
+When you add a new layer to your GIS file, the new layer appears immediately for all collaborators in your session. You can experiment by adding a layer from the layer browser or from the add layer menu, and customizing its symbology, such as changing the opacity or color. Observe that each change is instantly visible to your collaborators. You can check the [Getting Started with JupyterGIS](/user_guide/tutorials/01-intro/index.md) tutorial for more details on how to customize the layer appearance.
 
 ![Add Layers](images/add_layers.gif)
 


### PR DESCRIPTION
## Description

Relative links can be hard to read and are not portable when re-organizing files.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--944.org.readthedocs.build/en/944/
💡 JupyterLite preview: https://jupytergis--944.org.readthedocs.build/en/944/lite

<!-- readthedocs-preview jupytergis end -->