### PR TITLE
Fix docs build warnings, restore failure on warnings behavior

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -40,5 +40,5 @@ build:
       html:
         - |-
           /bin/bash --login -c "cd docs && micromamba run -n jupytergis-docs \
-          python -m sphinx --fail-on-warning --keep-going --nitpicky --show-traceback --builder html --doctree-dir _build/doctrees --define language=en . \
+          python -m sphinx --keep-going --nitpicky --show-traceback --builder html --doctree-dir _build/doctrees --define language=en . \
           $READTHEDOCS_OUTPUT/html"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -40,5 +40,5 @@ build:
       html:
         - |-
           /bin/bash --login -c "cd docs && micromamba run -n jupytergis-docs \
-          python -m sphinx --keep-going --nitpicky --show-traceback --builder html --doctree-dir _build/doctrees --define language=en . \
+          python -m sphinx --fail-on-warning --keep-going --nitpicky --show-traceback --builder html --doctree-dir _build/doctrees --define language=en . \
           $READTHEDOCS_OUTPUT/html"

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -50,7 +50,7 @@ class GISDocument(CommWidget):
 
     def __init__(
         self,
-        path: Optional[str | Path] = None,
+        path: str | Path | None = None,
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
         zoom: Optional[float] = None,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 import requests
 
@@ -192,7 +192,7 @@ class GISDocument(CommWidget):
         logical_op: str | None = None,
         feature: str | None = None,
         operator: str | None = None,
-        value: Union[str, float, float] | None = None,
+        value: str | float | float | None = None,
     ):
         """
         Add a Vector Tile Layer to the document.
@@ -249,7 +249,7 @@ class GISDocument(CommWidget):
         logical_op: str | None = None,
         feature: str | None = None,
         operator: str | None = None,
-        value: Union[str, int, float] | None = None,
+        value: str | int | float | None = None,
         color_expr=None,
     ):
         """
@@ -554,7 +554,7 @@ class GISDocument(CommWidget):
         logical_op: str | None = None,
         feature: str | None = None,
         operator: str | None = None,
-        value: Union[str, int, float] | None = None,
+        value: str | int | float | None = None,
         color_expr=None,
     ):
         """
@@ -688,7 +688,7 @@ class GISDocument(CommWidget):
         logical_op: str,
         feature: str,
         operator: str,
-        value: Union[str, int, float],
+        value: str | int | float,
     ):
         """
         Add a filter to a layer
@@ -734,7 +734,7 @@ class GISDocument(CommWidget):
         logical_op: str,
         feature: str,
         operator: str,
-        value: Union[str, int, float],
+        value: str | int | float,
     ):
         """
         Update a filter applied to a layer
@@ -854,15 +854,15 @@ class JGISLayer(BaseModel):
     name: str
     type: LayerType
     visible: bool
-    parameters: Union[
-        IRasterLayer,
-        IVectorLayer,
-        IVectorTileLayer,
-        IHillshadeLayer,
-        IImageLayer,
-        IWebGlLayer,
-        IHeatmapLayer,
-    ]
+    parameters: (
+        IRasterLayer
+        | IVectorLayer
+        | IVectorTileLayer
+        | IHillshadeLayer
+        | IImageLayer
+        | IWebGlLayer
+        | IHeatmapLayer
+    )
     _parent = Optional[GISDocument]
 
     def __init__(__pydantic_self__, parent, **data: Any) -> None:  # noqa
@@ -877,16 +877,16 @@ class JGISSource(BaseModel):
 
     name: str
     type: SourceType
-    parameters: Union[
-        IRasterSource,
-        IVectorTileSource,
-        IGeoJSONSource,
-        IImageSource,
-        IVideoSource,
-        IGeoTiffSource,
-        IRasterDemSource,
-        IGeoParquetSource,
-    ]
+    parameters: (
+        IRasterSource
+        | IVectorTileSource
+        | IGeoJSONSource
+        | IImageSource
+        | IVideoSource
+        | IGeoTiffSource
+        | IRasterDemSource
+        | IGeoParquetSource
+    )
     _parent = Optional[GISDocument]
 
     def __init__(__pydantic_self__, parent, **data: Any) -> None:  # noqa


### PR DESCRIPTION
## Description

No idea what's causing the warnings suddenly. :confounded: This is a guess.

Resolves #951 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
