### PR TITLE
Adding Legends for Heatmap

### DIFF
--- a/packages/base/src/panelview/components/legendItem.tsx
+++ b/packages/base/src/panelview/components/legendItem.tsx
@@ -236,6 +236,59 @@ export const LegendItem: React.FC<{
       return;
     }
 
+    // Heatmap
+    if (renderType === 'Heatmap') {
+      const colors = Array.isArray(symbology.color) ? symbology.color : [];
+      if (!colors.length) {
+        setContent(<p style={{ fontSize: '0.8em' }}>No heatmap colors</p>);
+        return;
+      }
+
+      const gradient = `linear-gradient(to right, ${colors.join(', ')})`;
+      const reversed = symbology.symbologyState?.reverse;
+
+      setContent(
+        <div style={{ padding: 6, width: '90%' }}>
+          <div style={{ fontSize: '1em', marginBottom: 10 }}>
+            <strong>Heatmap</strong>
+          </div>
+          <div
+            style={{
+              height: 12,
+              background: gradient,
+              border: '1px solid #ccc',
+              borderRadius: 3,
+              marginBottom: 4,
+            }}
+          />
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontSize: '0.75em',
+              marginBottom: 8,
+            }}
+          >
+            <span style={{ fontWeight: 'bold' }}>Low</span>
+            <span style={{ fontWeight: 'bold' }}>High</span>
+          </div>
+          <div
+            style={{
+              fontSize: '0.75em',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            {reversed && (
+              <span style={{ fontWeight: 'bold' }}>Reversed ramp</span>
+            )}
+          </div>
+        </div>,
+      );
+      return;
+    }
+
     setContent(<p>Unsupported symbology: {String(renderType)}</p>);
   }, [symbology, isLoading, error]);
 


### PR DESCRIPTION
## Description

This PR Implements Legends for Heatmap and shows `Reversed Ramp` label if Color Ramp is reversed.

<img width="1450" height="947" alt="Screenshot From 2025-10-14 12-04-17" src="https://github.com/user-attachments/assets/5e2a61be-dd75-4275-bc4e-7c2be342c8c4" />

-----

https://github.com/user-attachments/assets/c6420d69-df4b-489c-be1c-f805d94aa9d5


- Closes #905 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--956.org.readthedocs.build/en/956/
💡 JupyterLite preview: https://jupytergis--956.org.readthedocs.build/en/956/lite

<!-- readthedocs-preview jupytergis end -->