### PR TITLE
docs: update development setup doc to reference Micromamba installation

### DIFF
--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -30,7 +30,6 @@ It is recommended for setting up the JupyterGIS development environment. If you 
 ```
 
 ```bash
-
 # Create a virtual environment
 
 micromamba create --name jupytergis_dev -c conda-forge pip "nodejs<22" qgis


### PR DESCRIPTION
## Description

This PR updates the JupyterGIS development setup documentation to include a reference to the official Micromamba installation guide. This change improves clarity for new contributors and ensures the setup instructions are up-to-date.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. Resolves #XXX.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - pre-commit run --all-files
  - jlpm run lint


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--962.org.readthedocs.build/en/962/
💡 JupyterLite preview: https://jupytergis--962.org.readthedocs.build/en/962/lite

<!-- readthedocs-preview jupytergis end -->