### PR TITLE
Add descriptions for geoTiffSource normalization and wrapX options

### DIFF
--- a/packages/schema/src/schema/project/sources/geoTiffSource.json
+++ b/packages/schema/src/schema/project/sources/geoTiffSource.json
@@ -26,7 +26,7 @@
     },
     "normalize": {
       "type": "boolean",
-      "description": "Check to normalize values between min and max; Uncheck to see raw band values",
+      "description": "Enable to normalize values between 0 and 1 and displayed as RGB values; disable to keep raw band values",
       "default": true
     },
     "wrapX": {


### PR DESCRIPTION
## Description

This PR adds descriptions for geoTiffSource `normalization` and `wrapX` options

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--964.org.readthedocs.build/en/964/
💡 JupyterLite preview: https://jupytergis--964.org.readthedocs.build/en/964/lite

<!-- readthedocs-preview jupytergis end -->