### PR TITLE
Improve typing for react states

### DIFF
--- a/packages/base/src/dialogs/symbology/symbologyDialog.tsx
+++ b/packages/base/src/dialogs/symbology/symbologyDialog.tsx
@@ -49,7 +49,7 @@ const SymbologyDialog: React.FC<ISymbologyDialogProps> = ({
   const [componentToRender, setComponentToRender] =
     useState<JSX.Element | null>(null);
 
-  let LayerSymbology: React.JSX.Element | null = null;
+  let LayerSymbology: React.JSX.Element;
 
   useEffect(() => {
     const handleClientStateChanged = () => {


### PR DESCRIPTION
## Description

Fixed type errors in ProcessingFormDialog and SymbologyDialog components.
Updated useRef hooks with proper typing to avoid any and undefined issues.

## Checklist

- [X] PR has a descriptive title and content.
- [X] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [X] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [X] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--967.org.readthedocs.build/en/967/
💡 JupyterLite preview: https://jupytergis--967.org.readthedocs.build/en/967/lite

<!-- readthedocs-preview jupytergis end -->