### PR TITLE
Allow categorise rendering to accept string attributes as well

### DIFF
--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -5,6 +5,7 @@ import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 import {
   getColorCodeFeatureAttributes,
+  getFeatureAttributes,
   getNumericFeatureAttributes,
   objectEntries,
 } from '@/src/tools';
@@ -53,7 +54,7 @@ const RENDER_TYPE_OPTIONS: RenderTypeOptions = {
   },
   Categorized: {
     component: Categorized,
-    attributeChecker: getNumericFeatureAttributes,
+    attributeChecker: getFeatureAttributes,
     supportedLayerTypes: ['VectorLayer', 'VectorTileLayer', 'HeatmapLayer'],
     isTabbed: true,
   },

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -890,7 +890,7 @@ export const stringToArrayBuffer = async (
   return await base64Response.arrayBuffer();
 };
 
-const getFeatureAttributes = <T>(
+export const getFeatureAttributes = <T>(
   featureProperties: Record<string, Set<any>>,
   predicate: (key: string, value: any) => boolean = (key: string, value) =>
     true,


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--977.org.readthedocs.build/en/977/
💡 JupyterLite preview: https://jupytergis--977.org.readthedocs.build/en/977/lite

<!-- readthedocs-preview jupytergis end -->