### PR TITLE
Add keys to SourceForm and LayerForm

### DIFF
--- a/packages/base/src/formbuilder/editform.tsx
+++ b/packages/base/src/formbuilder/editform.tsx
@@ -1,6 +1,7 @@
 import {
   IDict,
   IJGISFormSchemaRegistry,
+  IJGISLayer,
   IJGISSource,
   IJupyterGISModel,
 } from '@jupytergis/schema';
@@ -46,8 +47,10 @@ export class EditForm extends React.Component<IEditFormProps, any> {
     let layerSchema: IDict | undefined = undefined;
     let LayerForm: typeof LayerPropertiesForm | undefined = undefined;
     let layerData: IDict | undefined = undefined;
+    let layer: IJGISLayer | undefined = undefined;
+
     if (this.props.layer) {
-      const layer = this.props.model.getLayer(this.props.layer);
+      layer = this.props.model.getLayer(this.props.layer);
       if (!layer) {
         return;
       }
@@ -92,6 +95,7 @@ export class EditForm extends React.Component<IEditFormProps, any> {
           <div>
             <h3 style={{ paddingLeft: '5px' }}>Layer Properties</h3>
             <LayerForm
+              key={`${this.props.layer}-${source?.type}`} // Force remount when source type changes
               formContext="update"
               sourceType={source?.type || 'RasterSource'}
               model={this.props.model}
@@ -108,6 +112,7 @@ export class EditForm extends React.Component<IEditFormProps, any> {
           <div>
             <h3 style={{ paddingLeft: '5px' }}>Source Properties</h3>
             <SourceForm
+              key={`${this.props.source}-${layer?.type}`} // Force remount when layer type changes
               formContext="update"
               model={this.props.model}
               filePath={this.props.model.filePath}


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Resolve #991 

The issue was that selecting a new layer would trigger a re-render for `EditForm`, and because both layers were `VectorLayer`'s, the `BaseForm` component would update, but not be recreated (whereas when switching between layers with different layer types, the components are different so the form is recreated so this bug didn't happen), so the `BaseForm` constructor wouldn't happen... and then I don't know, `processSchema` happens, but it finds the correct sources, so I'm not really sure where the old source value comes from? Basically RJSF wants to select the old value (I think) but it's not in the enum anymore so it selects nothing. This counts as a form change and triggers all that logic which writes to the file and stuff. 

So anyway I blame RJSF

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--992.org.readthedocs.build/en/992/
💡 JupyterLite preview: https://jupytergis--992.org.readthedocs.build/en/992/lite

<!-- readthedocs-preview jupytergis end -->