### PR TITLE
Fix SingleBand pseudocolor band selector bug, index bands from 1

### DIFF
--- a/packages/base/src/dialogs/symbology/hooks/useGetBandInfo.ts
+++ b/packages/base/src/dialogs/symbology/hooks/useGetBandInfo.ts
@@ -4,13 +4,6 @@ import { useEffect, useState } from 'react';
 
 import { loadFile } from '@/src/tools';
 
-export interface IBandHistogram {
-  buckets: number[];
-  count: number;
-  max: number;
-  min: number;
-}
-
 export interface IBandRow {
   band: number;
   colorInterpretation?: string;
@@ -30,7 +23,6 @@ const useGetBandInfo = (model: IJupyterGISModel, layer: IJGISLayer) => {
     setError(null);
 
     try {
-      const bandsArr: IBandRow[] = [];
       const source = model.getSource(layer?.parameters?.source);
       const sourceInfo = source?.parameters?.urls[0];
 
@@ -67,9 +59,10 @@ const useGetBandInfo = (model: IJupyterGISModel, layer: IJGISLayer) => {
       const image = await tiff.getImage();
       const numberOfBands = image.getSamplesPerPixel();
 
+      const bandsArr: IBandRow[] = [];
       for (let i = 0; i < numberOfBands; i++) {
         bandsArr.push({
-          band: i,
+          band: i + 1,
           stats: {
             minimum: sourceInfo.min ?? 0,
             maximum: sourceInfo.max ?? 100,

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/MultibandColor.tsx
@@ -129,10 +129,10 @@ const MultibandColor: React.FC<ISymbologyDialogProps> = ({
         <LoadingOverlay loading={loading} />
         <BandRow
           label="Red Band"
-          index={selectedBands.red - 1}
+          index={selectedBands.red - 1} // IMPORTANT: Bands are 1-indexed
           bandRow={bandRows[selectedBands.red - 1]}
           bandRows={bandRows}
-          setSelectedBand={val => updateBand('red', val >= 0 ? val + 1 : 0)}
+          setSelectedBand={val => updateBand('red', val >= 0 ? val : 0)}
           setBandRows={setBandRows}
           isMultibandColor={true}
         />
@@ -142,7 +142,7 @@ const MultibandColor: React.FC<ISymbologyDialogProps> = ({
           index={selectedBands.green - 1}
           bandRow={bandRows[selectedBands.green - 1]}
           bandRows={bandRows}
-          setSelectedBand={val => updateBand('green', val >= 0 ? val + 1 : 0)}
+          setSelectedBand={val => updateBand('green', val >= 0 ? val : 0)}
           setBandRows={setBandRows}
           isMultibandColor={true}
         />
@@ -152,7 +152,7 @@ const MultibandColor: React.FC<ISymbologyDialogProps> = ({
           index={selectedBands.blue - 1}
           bandRow={bandRows[selectedBands.blue - 1]}
           bandRows={bandRows}
-          setSelectedBand={val => updateBand('blue', val >= 0 ? val + 1 : 0)}
+          setSelectedBand={val => updateBand('blue', val >= 0 ? val : 0)}
           setBandRows={setBandRows}
           isMultibandColor={true}
         />
@@ -162,7 +162,7 @@ const MultibandColor: React.FC<ISymbologyDialogProps> = ({
           index={selectedBands.alpha - 1}
           bandRow={bandRows[selectedBands.alpha - 1]}
           bandRows={bandRows}
-          setSelectedBand={val => updateBand('alpha', val >= 0 ? val + 1 : 0)}
+          setSelectedBand={val => updateBand('alpha', val >= 0 ? val : 0)}
           setBandRows={setBandRows}
           isMultibandColor={true}
         />


### PR DESCRIPTION
## Description

Resolves #1063 

Fixing SingleBand pseudocolor band selector bug by separating hooks into `useGetSingleBandInfo` and `useGetMultiBandInfo`. The idea of separation of `useGetBandInfo` arise in https://github.com/geojupyter/jupytergis/pull/912#discussion_r2421048339 
<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

- Closes #958 

cc @mfisher87 @martinRenou 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--998.org.readthedocs.build/en/998/
💡 JupyterLite preview: https://jupytergis--998.org.readthedocs.build/en/998/lite

<!-- readthedocs-preview jupytergis end -->