### PR TITLE
CI: Ignore links to `blog.jupyter.org` in the link check job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,9 +239,9 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: |
+          ignore_links: >-
             lite/
-            https://www.npmjs.com.*
+            https://www\.npmjs\.com.*
             ^/.*
             https://blog\.jupyter\.org/.*
 


### PR DESCRIPTION
## Description

Shall close #1001 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1003.org.readthedocs.build/en/1003/
💡 JupyterLite preview: https://jupytergis--1003.org.readthedocs.build/en/1003/lite

<!-- readthedocs-preview jupytergis end -->