### PR TITLE
Enable layers with embedded GeoJSON to use graduated, categorized, and canoncal symbology

### DIFF
--- a/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
+++ b/packages/base/src/dialogs/symbology/hooks/useGetProperties.ts
@@ -26,13 +26,13 @@ async function getGeoJsonProperties({
   const result: Record<string, Set<any>> = {};
 
   const data = await (async () => {
-    if (source.parameters?.path) {
+    if (source.parameters.path) {
       return await loadFile({
-        filepath: source.parameters?.path,
+        filepath: source.parameters.path,
         type: 'GeoJSONSource',
         model,
       });
-    } else if (source.parameters?.data) {
+    } else if (source.parameters.data) {
       return source.parameters.data;
     }
   })();


### PR DESCRIPTION
## Description

Resolves #1016

I'd love to release this fix this week. I'm planning to demo the Python API at AGU and this bug was a blocker :)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1020.org.readthedocs.build/en/1020/
💡 JupyterLite preview: https://jupytergis--1020.org.readthedocs.build/en/1020/lite

<!-- readthedocs-preview jupytergis end -->