### PR TITLE
Fix unexpected lint errors

### DIFF
--- a/packages/base/src/dialogs/ProcessingFormDialog.tsx
+++ b/packages/base/src/dialogs/ProcessingFormDialog.tsx
@@ -28,8 +28,7 @@ export interface IProcessingFormDialogOptions extends IBaseFormProps {
 /**
  * Wrapper component to handle OK button state
  */
-export interface IProcessingFormWrapperProps
-  extends IProcessingFormDialogOptions {
+export interface IProcessingFormWrapperProps extends IProcessingFormDialogOptions {
   okSignalPromise: PromiseDelegate<Signal<Dialog<any>, number>>;
   formErrorSignalPromise?: PromiseDelegate<Signal<Dialog<any>, boolean>>;
 }

--- a/packages/base/src/dialogs/symbology/symbologyDialog.tsx
+++ b/packages/base/src/dialogs/symbology/symbologyDialog.tsx
@@ -17,8 +17,7 @@ export interface ISymbologyDialogProps {
   layerId?: string;
 }
 
-export interface ISymbologyDialogWithAttributesProps
-  extends ISymbologyDialogProps {
+export interface ISymbologyDialogWithAttributesProps extends ISymbologyDialogProps {
   selectableAttributesAndValues: Record<string, Set<any>>;
 }
 

--- a/packages/base/src/formbuilder/objectform/layer/webGlLayerForm.tsx
+++ b/packages/base/src/formbuilder/objectform/layer/webGlLayerForm.tsx
@@ -1,7 +1,7 @@
 import { IDict } from '@jupytergis/schema';
+import { ISubmitEvent } from '@rjsf/core';
 
 import { LayerPropertiesForm } from './layerform';
-import { ISubmitEvent } from '@rjsf/core';
 
 /**
  * The form to modify a hillshade layer.

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -150,7 +150,7 @@ export const LayersBodyComponent: React.FC<IBodyProps> = props => {
     } else {
       // Check if new selection is the same type as previous selections
       const isSelectedSameType = Object.values(selectedValue).some(
-        selection => (selection as ISelection).type === type,
+        selection => selection.type === type,
       );
 
       if (!isSelectedSameType) {

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -266,8 +266,10 @@ export interface IUserData {
   userData: User.IIdentity;
 }
 
-export interface IJupyterGISDocumentWidget
-  extends IDocumentWidget<SplitPanel, IJupyterGISModel> {
+export interface IJupyterGISDocumentWidget extends IDocumentWidget<
+  SplitPanel,
+  IJupyterGISModel
+> {
   readonly model: IJupyterGISModel;
 }
 

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -934,8 +934,7 @@ export namespace JupyterGISModel {
     return Private.layerTreeRecursion(model.sharedModel.layerTree);
   }
 
-  export interface IOptions
-    extends DocumentRegistry.IModelOptions<IJupyterGISDoc> {
+  export interface IOptions extends DocumentRegistry.IModelOptions<IJupyterGISDoc> {
     annotationModel?: IAnnotationModel;
     settingRegistry?: ISettingRegistry;
   }

--- a/python/jupytergis_core/src/externalcommand.ts
+++ b/python/jupytergis_core/src/externalcommand.ts
@@ -3,9 +3,7 @@ import {
   IJGISExternalCommandRegistry,
 } from '@jupytergis/schema';
 
-export class JupyterGISExternalCommandRegistry
-  implements IJGISExternalCommandRegistry
-{
+export class JupyterGISExternalCommandRegistry implements IJGISExternalCommandRegistry {
   constructor() {
     this._registry = new Set();
   }

--- a/python/jupytergis_core/src/jgisplugin/modelfactory.ts
+++ b/python/jupytergis_core/src/jgisplugin/modelfactory.ts
@@ -10,9 +10,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 /**
  * A Model factory to create new instances of JupyterGISModel.
  */
-export class JupyterGISModelFactory
-  implements DocumentRegistry.IModelFactory<JupyterGISModel>
-{
+export class JupyterGISModelFactory implements DocumentRegistry.IModelFactory<JupyterGISModel> {
   constructor(options: JupyterGISModelFactory.IOptions) {
     this._annotationModel = options.annotationModel;
     this._settingRegistry = options.settingRegistry;

--- a/python/jupytergis_core/src/layerBrowserRegistry.ts
+++ b/python/jupytergis_core/src/layerBrowserRegistry.ts
@@ -10,9 +10,7 @@ import {
  * @class JupyterGISLayerBrowserRegistry
  * @implements IJGISLayerBrowserRegistry
  */
-export class JupyterGISLayerBrowserRegistry
-  implements IJGISLayerBrowserRegistry
-{
+export class JupyterGISLayerBrowserRegistry implements IJGISLayerBrowserRegistry {
   private _registry: IRasterLayerGalleryEntry[];
 
   constructor() {

--- a/python/jupytergis_qgis/src/modelfactory.ts
+++ b/python/jupytergis_qgis/src/modelfactory.ts
@@ -10,9 +10,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 /**
  * A Model factory to create new instances of JupyterGISModel.
  */
-export class JupyterGISModelFactoryBase
-  implements DocumentRegistry.IModelFactory<JupyterGISModel>
-{
+export class JupyterGISModelFactoryBase implements DocumentRegistry.IModelFactory<JupyterGISModel> {
   constructor(options: JupyterGISModelFactoryBase.IOptions) {
     this._annotationModel = options.annotationModel;
   }


### PR DESCRIPTION
## Description

None of these errors were showing up on main prior to releasing 0.10.0: https://github.com/geojupyter/jupytergis/commit/557ee59b2e78f978ed0de7b6868d5b21b31e43ae

The prettier errors are seemingly explained by a release of prettier 3.7.x.

The eslint import error, I have no explanation for. It's a valid error, but I don't know why it wasn't caught before.


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1024.org.readthedocs.build/en/1024/
💡 JupyterLite preview: https://jupytergis--1024.org.readthedocs.build/en/1024/lite

<!-- readthedocs-preview jupytergis end -->