### PR TITLE
Remove `nclasses` and `mode` from `symbologyState` for categorized symbology

### DIFF
--- a/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
@@ -182,8 +182,6 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
       renderType: 'Categorized',
       value: selectedAttributeRef.current,
       colorRamp: colorRampOptionsRef.current?.selectedRamp,
-      nClasses: colorRampOptionsRef.current?.numberOfShades,
-      mode: colorRampOptionsRef.current?.selectedMode,
       symbologyTab,
       reverse: reverseRamp,
     };
@@ -216,8 +214,6 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
       // Reset color classification options
       if (layer.parameters.symbologyState) {
         layer.parameters.symbologyState.colorRamp = undefined;
-        layer.parameters.symbologyState.nClasses = undefined;
-        layer.parameters.symbologyState.mode = undefined;
       }
     }
 


### PR DESCRIPTION
## Description

Removing nclasses and mode from symbologyState because it makes tough to use user selected min and max values in pr #912.

Closes #1028 

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1029.org.readthedocs.build/en/1029/
💡 JupyterLite preview: https://jupytergis--1029.org.readthedocs.build/en/1029/lite

<!-- readthedocs-preview jupytergis end -->