### PR TITLE
Using raw github url for image

### DIFF
--- a/python/jupytergis/README.md
+++ b/python/jupytergis/README.md
@@ -10,7 +10,7 @@
 [jupytergis-badge]: https://labextensions.dev/api/badge/jupytergis?metric=downloads&leftColor=%23555&rightColor=%23F37620&style=flat
 [marketplace]: https://labextensions.dev/extensions/jupytergis
 
-![jupytergis](https://github.com/geojupyter/jupytergis/blob/main/jupytergis.png)
+![jupytergis](https://raw.githubusercontent.com/geojupyter/jupytergis/main/jupytergis.png)
 
 ## Features
 


### PR DESCRIPTION
## Description
Currently on [marketplace](https://marketplace.orbrx.io/extensions/jupytergis) jupytergis's demo image cannot visible but by using raw github url image is visible.

### Before

<img width="1917" height="1024" alt="without-Raw" src="https://github.com/user-attachments/assets/393c6367-3786-4d11-89f9-bdd934b01553" />


### After

<img width="1917" height="1024" alt="Raw_url" src="https://github.com/user-attachments/assets/2dcdb792-71f3-4552-8930-8438d00e4381" />

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`



<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1039.org.readthedocs.build/en/1039/
💡 JupyterLite preview: https://jupytergis--1039.org.readthedocs.build/en/1039/lite

<!-- readthedocs-preview jupytergis end -->

cc @martinRenou @arjxn-py 