### PR TITLE
Fix Zooming in or out with keys.

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -295,6 +295,7 @@ export class MainView extends React.Component<IProps, IStates> {
         }),
         controls: [new ScaleLine(), new FullScreen()],
       });
+      this._focusMapOnClick();
 
       // Add map interactions
       const dragAndDropInteraction = new DragAndDrop({
@@ -2391,6 +2392,16 @@ export class MainView extends React.Component<IProps, IStates> {
   private _handleWindowResize = (): void => {
     // TODO SOMETHING
   };
+
+  private _focusMapOnClick() {
+    const viewport = this._Map.getViewport();
+
+    viewport.setAttribute('tabindex', '0');
+
+    viewport.addEventListener('mousedown', () => {
+      viewport.focus();
+    });
+  }
 
   render(): JSX.Element {
     return (


### PR DESCRIPTION
## Description

Resolves #1047 

This PR Adds a  function to focus on map when clicked for zooming in or out.


https://github.com/user-attachments/assets/304ef115-3ba2-4398-a073-d0c7ac7defd9

Closes #1047 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1051.org.readthedocs.build/en/1051/
💡 JupyterLite preview: https://jupytergis--1051.org.readthedocs.build/en/1051/lite

<!-- readthedocs-preview jupytergis end -->