### PR TITLE
Focus on map without click on map while zooming

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -288,6 +288,7 @@ export class MainView extends React.Component<IProps, IStates> {
     if (this.divRef.current) {
       this._Map = new OlMap({
         target: this.divRef.current,
+        keyboardEventTarget: document,
         layers: [],
         view: new View({
           center,
@@ -295,7 +296,6 @@ export class MainView extends React.Component<IProps, IStates> {
         }),
         controls: [new ScaleLine(), new FullScreen()],
       });
-      this._focusMapOnClick();
 
       // Add map interactions
       const dragAndDropInteraction = new DragAndDrop({
@@ -2393,16 +2393,6 @@ export class MainView extends React.Component<IProps, IStates> {
     // TODO SOMETHING
   };
 
-  private _focusMapOnClick() {
-    const viewport = this._Map.getViewport();
-
-    viewport.setAttribute('tabindex', '0');
-
-    viewport.addEventListener('mousedown', () => {
-      viewport.focus();
-    });
-  }
-
   render(): JSX.Element {
     return (
       <>
@@ -2440,7 +2430,7 @@ export class MainView extends React.Component<IProps, IStates> {
           )}
           <div
             className="jGIS-Mainview data-jgis-keybinding"
-            tabIndex={-2}
+            tabIndex={0}
             style={{
               border: this.state.remoteUser
                 ? `solid 3px ${this.state.remoteUser.color}`


### PR DESCRIPTION
## Description
Focus on map without click on map while zooming.

This PR is a successor of #1051 
 
cc @mfisher87 
## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1053.org.readthedocs.build/en/1053/
💡 JupyterLite preview: https://jupytergis--1053.org.readthedocs.build/en/1053/lite

<!-- readthedocs-preview jupytergis end -->