### PR TITLE
Bot: provide negative response if the user has no permission

### DIFF
--- a/.github/workflows/update_galata_references.yaml
+++ b/.github/workflows/update_galata_references.yaml
@@ -35,10 +35,11 @@ jobs:
         if: |
           !contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), steps.association.outputs.association)
         run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=-1'
           echo "User not authorized to update snapshots"
           exit 1
 
-      - name: React to the triggering comment
+      - name: React positively to the triggering comment
         run: |
           gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
         env:


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1069.org.readthedocs.build/en/1069/
💡 JupyterLite preview: https://jupytergis--1069.org.readthedocs.build/en/1069/lite

<!-- readthedocs-preview jupytergis end -->