### PR TITLE
Bot: Reusable workflow for checking permissions

### DIFF
--- a/.github/workflows/update_galata_references.yaml
+++ b/.github/workflows/update_galata_references.yaml
@@ -20,32 +20,9 @@ jobs:
     if: github.event.issue.pull_request && contains(github.event.comment.body, 'please update snapshots')
 
     steps:
-      - name: Get commenter association
-        id: association
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          association=$(gh api \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }} \
-            --jq '.author_association')
-
-          echo "association=$association" >> $GITHUB_OUTPUT
-
-      - name: Fail if user is not authorized
-        if: |
-          !contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), steps.association.outputs.association)
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=-1'
-          echo "User not authorized to update snapshots"
-          exit 1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: React positively to the triggering comment
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: martinRenou/maintainer-tools/.github/actions/update-snapshots-check-permission@check_perm
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/update_lite_galata_references.yaml
+++ b/.github/workflows/update_lite_galata_references.yaml
@@ -20,30 +20,9 @@ jobs:
     if: github.event.issue.pull_request && contains(github.event.comment.body, 'please update snapshots')
 
     steps:
-      - name: Get commenter association
-        id: association
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          association=$(gh api \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }} \
-            --jq '.author_association')
-
-          echo "association=$association" >> $GITHUB_OUTPUT
-
-      - name: Fail if user is not authorized
-        if: |
-          !contains(fromJSON('["OWNER","COLLABORATOR","MEMBER"]'), steps.association.outputs.association)
-        run: |
-          echo "User not authorized to update snapshots"
-          exit 1
-
-    steps:
-      - name: React to the triggering comment
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: martinRenou/maintainer-tools/.github/actions/update-snapshots-check-permission@check_perm
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1072.org.readthedocs.build/en/1072/
💡 JupyterLite preview: https://jupytergis--1072.org.readthedocs.build/en/1072/lite

<!-- readthedocs-preview jupytergis end -->