### PR TITLE
Pin sphinx to 8.x to fix docs build

### DIFF
--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -9,7 +9,7 @@ dependencies:
   - jupyterlite-core
   - jupyterlite-xeus
   - jupyterlite-sphinx
-  - sphinx
+  - sphinx ~=8.2.3
   - sphinx-tabs
   - pydata-sphinx-theme
   - sphinx-autodoc-typehints


### PR DESCRIPTION
## Description

Failed build is using Sphinx 9.1.0: https://app.readthedocs.org/projects/jupytergis/builds/31116291/
Last passing build used Sphinx 8.2.3: https://app.readthedocs.org/projects/jupytergis/builds/31079760/

I don't know what caused the upgrade in the last 2 days; Sphinx 9 has been out for over a month.

Related issues:

https://github.com/executablebooks/sphinx-tabs/issues/212
https://github.com/executablebooks/sphinx-tabs/issues/209

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself

---

📚 Documentation preview: [jupytergis--1086.org.readthedocs.build/en/1086](https://jupytergis--1086.org.readthedocs.build/en/1086/)
💡 JupyterLite preview: [jupytergis--1086.org.readthedocs.build/en/1086/lite](https://jupytergis--1086.org.readthedocs.build/en/1086/lite)
