### PR TITLE
Pin jupytext in docs build: bring back our icons

### DIFF
--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -9,6 +9,7 @@ dependencies:
   - jupyterlite-core
   - jupyterlite-xeus
   - jupyterlite-sphinx
+  - jupytext =1.19.0
   - sphinx ~=8.2.3
   - sphinx-tabs
   - pydata-sphinx-theme


### PR DESCRIPTION
We stopped getting icons for JupyterGIS suddenly in our jupyterlite deployment, and I have a strange feeling jupytext could be responsible. Will try to provide more proof if the docs build here is fixed.