### PR TITLE
Restore functionality of zoom controls when enabled in settings

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -326,13 +326,12 @@ export class MainView extends React.Component<IProps, IStates> {
       target: this.controlsToolbarRef.current || undefined,
     });
 
-    this._zoomControl = new Zoom({
-      target: this.controlsToolbarRef.current || undefined,
-    });
-
     const controls: Control[] = [scaleLine, fullScreen];
 
     if (this._model.jgisSettings.zoomButtonsEnabled) {
+      this._zoomControl = new Zoom({
+        target: this.controlsToolbarRef.current || undefined,
+      });
       controls.push(this._zoomControl);
     }
 


### PR DESCRIPTION
## Description

Resolves #1097

However this is still affected by #1081, so when opening any document the zoom controls will not appear. #1083 fixes this. 

You can test this by toggling the Zoom Enabled setting while you have a document already open. On main/0.12, nothing happens, and on this PR the buttons appear or disappear. Once #1083 is merged, the buttons will appear in the correct state when opening the document (@nakul-py and I already tested this).

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1098.org.readthedocs.build/en/1098/
💡 JupyterLite preview: https://jupytergis--1098.org.readthedocs.build/en/1098/lite

<!-- readthedocs-preview jupytergis end -->