### PR TITLE
Story map: Use theme colors as fallback when bg/text colors not set in file

### DIFF
--- a/packages/base/src/formbuilder/objectform/StoryEditorForm.tsx
+++ b/packages/base/src/formbuilder/objectform/StoryEditorForm.tsx
@@ -1,7 +1,6 @@
 import { IDict } from '@jupytergis/schema';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 
-import { getCssVarAsColor } from '@/src/tools';
 import { BaseForm } from './baseform';
 
 /**
@@ -23,26 +22,5 @@ export class StoryEditorPropertiesForm extends BaseForm {
     uiSchema.presentationTextColor = {
       'ui:widget': 'color',
     };
-
-    // Set default values from theme CSS variables when not already in data
-    const schemaProps = schema.properties as IDict | undefined;
-    if (
-      schemaProps?.presentationBgColor &&
-      data?.presentationBgColor === undefined
-    ) {
-      const defaultBg = getCssVarAsColor('--jp-layout-color0');
-      if (defaultBg) {
-        schemaProps.presentationBgColor.default = defaultBg;
-      }
-    }
-    if (
-      schemaProps?.presentationTextColor &&
-      data?.presentationTextColor === undefined
-    ) {
-      const defaultText = getCssVarAsColor('--jp-ui-font-color0');
-      if (defaultText) {
-        schemaProps.presentationTextColor.default = defaultText;
-      }
-    }
   }
 }

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -169,16 +169,16 @@
   overflow: auto;
   background: linear-gradient(
     to left,
-    var(--jgis-specta-bg-color, --jp-layout-color0) 49%,
+    var(--jgis-specta-bg-color, var(--jp-layout-color0)) 49%,
     color-mix(
         in srgb,
-        var(--jgis-specta-bg-color, --jp-layout-color0) 60%,
+        var(--jgis-specta-bg-color, var(--jp-layout-color0)) 60%,
         transparent
       )
       65%,
     color-mix(
         in srgb,
-        var(--jgis-specta-bg-color, --jp-layout-color0) 50%,
+        var(--jgis-specta-bg-color, var(--jp-layout-color0)) 50%,
         transparent
       )
       70%,
@@ -190,7 +190,7 @@
   width: 45%;
   font-size: var(--jp-ui-font-size3);
   padding-right: 1.7rem;
-  color: var(--jgis-specta-text-color, var(--jp-ui-inverse-font-color1));
+  color: var(--jgis-specta-text-color, var(--jp-ui-font-color1));
   overflow-y: auto;
   max-height: 100%;
 }


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist
Respect theme colors when presentation bg/text colors are not explicitly set from the story editor. 

https://github.com/user-attachments/assets/603bcea2-da9c-4f48-9cfd-3fcc02c1337f


- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1104.org.readthedocs.build/en/1104/
💡 JupyterLite preview: https://jupytergis--1104.org.readthedocs.build/en/1104/lite

<!-- readthedocs-preview jupytergis end -->