### PR TITLE
Prevent layer updates when changing selected layer

### DIFF
--- a/packages/base/src/formbuilder/editform.tsx
+++ b/packages/base/src/formbuilder/editform.tsx
@@ -95,7 +95,7 @@ export class EditForm extends React.Component<IEditFormProps, any> {
           <div>
             <h3 style={{ paddingLeft: '5px' }}>Layer Properties</h3>
             <LayerForm
-              key={`${this.props.layer}-${source?.type}`} // Force remount when source type changes
+              key={`${this.props.layer}-${source?.type}`}
               formContext="update"
               sourceType={source?.type || 'RasterSource'}
               model={this.props.model}
@@ -112,7 +112,7 @@ export class EditForm extends React.Component<IEditFormProps, any> {
           <div>
             <h3 style={{ paddingLeft: '5px' }}>Source Properties</h3>
             <SourceForm
-              key={`${this.props.source}-${layer?.type}`} // Force remount when layer type changes
+              key={`${this.props.source}-${layer?.type}`}
               formContext="update"
               model={this.props.model}
               filePath={this.props.model.filePath}

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -89,6 +89,9 @@ const WrappedFormComponent: React.FC<any> = props => {
  * It will be up to the user of this class to actually perform the creation/edit using syncdata.
  */
 export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
+  /** Skip syncData for the initial onChange (RJSF populating form), only sync on user edits. */
+  private isInitialLoadRef = true;
+
   constructor(props: IBaseFormProps) {
     super(props);
     this.currentFormData = deepCopy(this.props.sourceData);
@@ -106,6 +109,7 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
       this.currentFormData = deepCopy(this.props.sourceData);
       const schema = deepCopy(this.props.schema);
       this.setState(old => ({ ...old, schema }));
+      this.isInitialLoadRef = true;
     }
   }
 
@@ -287,7 +291,11 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
       this.props.formErrorSignal.emit(extraErrors);
     }
     if (this.props.formContext === 'update') {
-      this.syncData(this.currentFormData);
+      if (!this.isInitialLoadRef) {
+        this.syncData(this.currentFormData);
+      } else {
+        this.isInitialLoadRef = false;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
When selecting a new layer, RJSF would trigger an onChange event, which ultimately ended with an unnecessary call to the shared models `updateLayer`, triggering layer updates in the `MainView`. This adds a little boolean to only sync the form with the shared model on user initiated changes. 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1105.org.readthedocs.build/en/1105/
💡 JupyterLite preview: https://jupytergis--1105.org.readthedocs.build/en/1105/lite

<!-- readthedocs-preview jupytergis end -->