### PR TITLE
Missed some renames

### DIFF
--- a/docs/user_guide/how-tos/story-maps.md
+++ b/docs/user_guide/how-tos/story-maps.md
@@ -58,7 +58,7 @@ Select a Story Segment layer in the left panel (under the **Segments** tab). The
   - **Immediate** jumps there with no animation.
   - **Linear** animates directly to the segment’s view.
   - **Smooth** zooms out, pans to the segment, then zooms back in.
-- **Symbology Override**: Optional overrides for other layers when this segment is active (e.g. visibility, opacity, or opening the symbology dialog for a target layer to set style). Add an override by choosing a target layer and configuring the options.
+- **Layer Override**: Optional overrides for other layers when this segment is active (e.g. visibility, opacity, or opening the symbology dialog for a target layer to set style). Add an override by choosing a target layer and configuring the options.
 
 Changes are saved as you edit; no separate “Save” step is required.
 

--- a/packages/base/src/formbuilder/objectform/components/SegmentFormSymbology.tsx
+++ b/packages/base/src/formbuilder/objectform/components/SegmentFormSymbology.tsx
@@ -62,7 +62,7 @@ function LayerOverrideItem({ item, formContext }: ILayerOverrideItemProps) {
       <div style={{ flex: 1 }}>{item.children}</div>
       <div style={{ display: 'flex', gap: '1rem' }}>
         <Button
-          title="Edit symbology override for the target layer"
+          title="Edit layer override for the target layer"
           onClick={handleOpenSymbology}
           style={{ width: '100%' }}
           disabled={!canOpenSymbology}
@@ -104,7 +104,7 @@ export function ArrayFieldTemplate(props: ArrayFieldTemplateProps) {
           />
         ))}
         {props.canAdd && (
-          <Button onClick={props.onAddClick}>Add Symbology Override</Button>
+          <Button onClick={props.onAddClick}>Add Layer Override</Button>
         )}
       </div>
     </>

--- a/packages/base/src/panelview/story-maps/StoryViewerPanel.tsx
+++ b/packages/base/src/panelview/story-maps/StoryViewerPanel.tsx
@@ -22,7 +22,7 @@ import StoryImageSection from './components/StoryImageSection';
 import StorySubtitleSection from './components/StorySubtitleSection';
 import StoryTitleSection from './components/StoryTitleSection';
 
-/** Entry for a layer affected by symbology override: remove (added clone) or restore (modified existing). */
+/** Entry for a layer affected by layer override: remove (added clone) or restore (modified existing). */
 interface IOverrideLayerEntry {
   layerId: string;
   action: 'remove' | 'restore';
@@ -99,7 +99,7 @@ const StoryViewerPanel = forwardRef<
       [model],
     );
 
-    /** Layers affected by symbology override
+    /** Layers affected by layer override
      * We want to remove added layers (ie Heatmap)
      * and Restore the original symbology for modified layers
      */
@@ -320,7 +320,7 @@ const StoryViewerPanel = forwardRef<
       };
     }, [model, storyData, setIndex]);
 
-    // Apply symbology overrides for the segment at the given index
+    // Apply layer overrides for the segment at the given index
     const overrideSymbology = (index: number) => {
       if (index < 0 || !storySegments[index]) {
         return;
@@ -334,7 +334,7 @@ const StoryViewerPanel = forwardRef<
         return;
       }
 
-      // Apply all symbology overrides for this segment
+      // Apply all layer overrides for this segment
       layerOverrides.forEach(override => {
         const {
           color,

--- a/packages/schema/src/schema/project/layers/storySegmentLayer.json
+++ b/packages/schema/src/schema/project/layers/storySegmentLayer.json
@@ -54,15 +54,15 @@
     },
     "layerOverride": {
       "type": "array",
-      "title": "Symbology Override",
-      "description": "Symbology overrides to apply to target layers when this story segment is active",
+      "title": "Layer Override",
+      "description": "Layer overrides to apply to target layers when this story segment is active",
       "items": {
         "type": "object",
         "properties": {
           "targetLayer": {
             "type": "string",
             "title": "Target Layer",
-            "description": "The name of the layer to apply a symbology override to when this story segment is active",
+            "description": "The name of the layer to apply a layer override to when this story segment is active",
             "default": ""
           },
           "visible": {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Missed some `symbology override` -> `layer override` renames. 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1108.org.readthedocs.build/en/1108/
💡 JupyterLite preview: https://jupytergis--1108.org.readthedocs.build/en/1108/lite

<!-- readthedocs-preview jupytergis end -->