### PR TITLE
Fixing default colorRamp display bug

### DIFF
--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampSelector.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampSelector.tsx
@@ -39,7 +39,7 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
   useColorMapList(setColorMaps);
 
   useEffect(() => {
-    if (colorMaps.length > 0 && selectedRamp) {
+    if (colorMaps.length > 0) {
       updateCanvas(selectedRamp);
     }
   }, [selectedRamp, colorMaps]);


### PR DESCRIPTION
## Description


https://github.com/user-attachments/assets/5fd51fc9-f4a2-44df-9aa9-9dc875b142b8

- Closes #1022

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1117.org.readthedocs.build/en/1117/
💡 JupyterLite preview: https://jupytergis--1117.org.readthedocs.build/en/1117/lite

<!-- readthedocs-preview jupytergis end -->