### PR TITLE
Increase timeout for STAC browser results viewer integration test

### DIFF
--- a/ui-tests/tests/stac-browser.spec.ts
+++ b/ui-tests/tests/stac-browser.spec.ts
@@ -87,6 +87,8 @@ test.describe('#stac-browser', () => {
     await page.getByRole('tab', { name: /Results/ }).click();
 
     const resultsList = page.locator('.jgis-stac-browser-results-list');
-    await expect(resultsList.locator('button')).toHaveCount(1);
+    await expect(resultsList.locator('button')).toHaveCount(1, {
+      timeout: 10000,
+    });
   });
 });


### PR DESCRIPTION
## Description

stac-browser integration test fix 

*Originally posted in* https://github.com/geojupyter/jupytergis/issues/1119#issuecomment-3901726827

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1120.org.readthedocs.build/en/1120/
💡 JupyterLite preview: https://jupytergis--1120.org.readthedocs.build/en/1120/lite

<!-- readthedocs-preview jupytergis end -->