### PR TITLE
Dont show segments in layer selection dropdown

### DIFF
--- a/packages/base/src/formbuilder/objectform/components/LayerSelect.tsx
+++ b/packages/base/src/formbuilder/objectform/components/LayerSelect.tsx
@@ -51,7 +51,8 @@ export function LayerSelect(props: FieldProps) {
 
   const availableLayers = model.getLayers();
   const optionsList = Object.entries(availableLayers).filter(
-    ([layerId]) => !usedTargetLayerIds.has(layerId),
+    ([layerId, layer]) =>
+      !usedTargetLayerIds.has(layerId) && layer.type !== 'StorySegmentLayer',
   );
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
This filters out segments from the overrides layer select dropdown 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1143.org.readthedocs.build/en/1143/
💡 JupyterLite preview: https://jupytergis--1143.org.readthedocs.build/en/1143/lite
💡 Specta preview: https://jupytergis--1143.org.readthedocs.build/en/1143/lite/specta

<!-- readthedocs-preview jupytergis end -->