### PR TITLE
Fix symbology value selection

### DIFF
--- a/packages/schema/src/schema/project/layers/vectorLayer.json
+++ b/packages/schema/src/schema/project/layers/vectorLayer.json
@@ -33,8 +33,7 @@
           "default": "Single Symbol"
         },
         "value": {
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "method": {
           "type": "string",
@@ -68,7 +67,6 @@
       "additionalProperties": false,
       "default": {
         "renderType": "Single Symbol",
-        "value": "",
         "method": "color",
         "colorRamp": "viridis",
         "nClasses": "9",


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix #1151

I saw this issue when messing with the form stuff so I'm just opening this real quick. 

The empty-string default wasn’t treated as “no selection,” so the symbology dialogs used it as the attribute instead of selecting one.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1153.org.readthedocs.build/en/1153/
💡 JupyterLite preview: https://jupytergis--1153.org.readthedocs.build/en/1153/lite
💡 Specta preview: https://jupytergis--1153.org.readthedocs.build/en/1153/lite/specta

<!-- readthedocs-preview jupytergis end -->