### PR TITLE
Add keybinding class into toolbar section

### DIFF
--- a/packages/base/src/keybindings.json
+++ b/packages/base/src/keybindings.json
@@ -2,22 +2,22 @@
   {
     "command": "jupytergis:undo",
     "keys": ["Accel Z"],
-    "selector": ".jp-LabShell"
+    "selector": ".data-jgis-keybinding"
   },
   {
     "command": "jupytergis:redo",
     "keys": ["Accel Shift Z"],
-    "selector": ".jp-LabShell"
+    "selector": ".data-jgis-keybinding"
   },
   {
     "command": "jupytergis:identify",
     "keys": ["Escape"],
-    "selector": ".jp-LabShell"
+    "selector": ".data-jgis-keybinding"
   },
   {
     "command": "jupytergis:identify",
     "keys": ["Accel I"],
-    "selector": ".jp-LabShell"
+    "selector": ".data-jgis-keybinding"
   },
   {
     "command": "jupytergis:removeSource",
@@ -32,12 +32,12 @@
   {
     "command": "jupytergis:removeSelected",
     "keys": ["Delete"],
-    "selector": ".jp-LabShell"
+    "selector": ".data-jgis-keybinding"
   },
   {
     "command": "jupytergis:renameSelected",
     "keys": ["F2"],
-    "selector": ".jp-LabShell"
+    "selector": ".data-jgis-keybinding"
   },
   {
     "command": "jupytergis:executeConsole",

--- a/packages/base/src/toolbar/widget.tsx
+++ b/packages/base/src/toolbar/widget.tsx
@@ -71,7 +71,7 @@ export class ToolbarWidget extends ReactiveToolbar {
     super();
 
     this._model = options.model;
-    this.addClass('jGIS-toolbar-widget');
+    this.node.classList.add('jGIS-toolbar-widget', 'data-jgis-keybinding');
 
     // Listen for settings changes
     this._model.settingsChanged.connect(this._onSettingsChanged, this);
@@ -187,7 +187,9 @@ export class ToolbarWidget extends ReactiveToolbar {
       this.addItem('Toggle console', toggleConsoleButton);
       toggleConsoleButton.node.dataset.testid = 'toggle-console-button';
 
-      this.addItem('spacer', ReactiveToolbar.createSpacerItem());
+      const spacer = ReactiveToolbar.createSpacerItem();
+      spacer.node.tabIndex = -1;
+      this.addItem('spacer', spacer);
 
       // Users
       const iconRenderer = createUserIconRenderer(this._model);


### PR DESCRIPTION
## Description
This PR adds `data-jgis-keybinding` class to the toolbar

https://github.com/user-attachments/assets/93fd66c4-162b-4c62-b9ef-60e0794e5eae



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1156.org.readthedocs.build/en/1156/
💡 JupyterLite preview: https://jupytergis--1156.org.readthedocs.build/en/1156/lite
💡 Specta preview: https://jupytergis--1156.org.readthedocs.build/en/1156/lite/specta

<!-- readthedocs-preview jupytergis end -->