### PR TITLE
Fix Marker SVG icon rendering issue in Chrome

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -912,12 +912,17 @@ export class MainView extends React.Component<IProps, IStates> {
 
         // Replace color placeholder in SVG with the parameter color
         const markerColor = parameters.color || '#3463a0';
-        const svgString = markerIcon.svgstr.replace('{{COLOR}}', markerColor);
+        const svgString = markerIcon.svgstr
+          .replace('{{COLOR}}', markerColor)
+          .replace('<svg', '<svg width="128" height="128"');
 
         const iconStyle = new Style({
           image: new Icon({
             src: `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgString)}`,
             scale: 0.25,
+            anchor: [0.5, 1],
+            anchorXUnits: 'fraction',
+            anchorYUnits: 'fraction',
           }),
         });
 


### PR DESCRIPTION
## Description
Fixes the bug where marker SVG icons were not visible in Chrome.

The Marker SVG only defines a `viewBox`, which can result in a 0×0 intrinsic size
when rendered on canvas. Firefox handled this case gracefully but Chrome did not render the icon.

This change ensures the SVG has explicit `width` and `height` attributes
before creating the data URL so it renders consistently across browsers.

https://github.com/user-attachments/assets/46f74878-88f8-408d-8e91-4bba5f05bc6f

- Closes #1162 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1163.org.readthedocs.build/en/1163/
💡 JupyterLite preview: https://jupytergis--1163.org.readthedocs.build/en/1163/lite
💡 Specta preview: https://jupytergis--1163.org.readthedocs.build/en/1163/lite/specta

<!-- readthedocs-preview jupytergis end -->