### PR TITLE
Re-enable strict docs build (fail on warning)

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -8,7 +8,7 @@ ${THIS_DIR}/clean.sh
 
 python -m sphinx \
     --nitpicky --show-traceback \
-    --keep-going \
+    --fail-on-warning --keep-going \
     --builder html --doctree-dir _build/doctrees --define language=en \
    . \
    ./_build/html


### PR DESCRIPTION
## Description

Disabled in #1147 ([here](https://github.com/geojupyter/jupytergis/pull/1147#pullrequestreview-3930786351)) . This protects us from broken internal links that the check links job doesn't catch and other docs breakage that would normally not fail the build.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1164.org.readthedocs.build/en/1164/
💡 JupyterLite preview: https://jupytergis--1164.org.readthedocs.build/en/1164/lite
💡 Specta preview: https://jupytergis--1164.org.readthedocs.build/en/1164/lite/specta

<!-- readthedocs-preview jupytergis end -->