### PR TITLE
StopRow now supports strings values

### DIFF
--- a/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopRow.tsx
@@ -12,7 +12,7 @@ import { SymbologyValue, SizeValue, ColorValue } from '@/src/types';
 
 const StopRow: React.FC<{
   index: number;
-  dataValue: number;
+  dataValue: number | string;
   symbologyValue: SymbologyValue;
   stopRows: IStopRow[];
   setStopRows: (stopRows: IStopRow[]) => void;
@@ -37,7 +37,8 @@ const StopRow: React.FC<{
 
   const handleStopChange = (event: { target: { value: string } }) => {
     const newRows = [...stopRows];
-    newRows[index].stop = +event.target.value;
+    const value = event.target.value;
+    newRows[index].stop = useNumber ? +value : value;
     setStopRows(newRows);
   };
 
@@ -67,7 +68,7 @@ const StopRow: React.FC<{
     <div className="jp-gis-color-row">
       <input
         id={`jp-gis-color-value-${index}`}
-        type="number"
+        type={useNumber ? 'number' : 'text'}
         value={dataValue}
         onChange={handleStopChange}
         onBlur={handleBlur}

--- a/packages/base/src/dialogs/symbology/symbologyDialog.tsx
+++ b/packages/base/src/dialogs/symbology/symbologyDialog.tsx
@@ -36,7 +36,7 @@ export interface ISymbologyWidgetOptions {
 }
 
 export interface IStopRow {
-  stop: number;
+  stop: number | string;
   output: SymbologyValue;
 }
 

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
@@ -375,7 +375,11 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
     return (bandValue * (max - min)) / (1 - 0) + min;
   };
 
-  const unscaleValue = (value: number, isQuantile: boolean) => {
+  const unscaleValue = (value: number | string, isQuantile: boolean) => {
+    if (typeof value !== 'number') {
+      throw new Error('unscaleValue expects a number');
+    }
+
     const currentBand = bandRowsRef.current[selectedBand - 1];
 
     const min = isQuantile ? 1 : currentBand.stats.minimum;


### PR DESCRIPTION
## Description


https://github.com/user-attachments/assets/999ed861-b500-404d-8978-492d19240493



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1183.org.readthedocs.build/en/1183/
💡 JupyterLite preview: https://jupytergis--1183.org.readthedocs.build/en/1183/lite
💡 Specta preview: https://jupytergis--1183.org.readthedocs.build/en/1183/lite/specta

<!-- readthedocs-preview jupytergis end -->