### PR TITLE
Fix Canonical symbology on VectorTile layers

### DIFF
--- a/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Canonical.tsx
@@ -29,9 +29,11 @@ const Canonical: React.FC<ISymbologyDialogWithAttributesProps> = ({
 
   useEffect(() => {
     const layerParams = layer.parameters as IVectorLayer;
+    const savedValue = layerParams.symbologyState?.value;
     const value =
-      layerParams.symbologyState?.value ??
-      Object.keys(selectableAttributesAndValues)[0];
+      savedValue && savedValue in selectableAttributesAndValues
+        ? savedValue
+        : Object.keys(selectableAttributesAndValues)[0];
 
     setSelectedValue(value);
   }, [selectableAttributesAndValues]);
@@ -41,7 +43,14 @@ const Canonical: React.FC<ISymbologyDialogWithAttributesProps> = ({
       return;
     }
 
-    const colorExpr: ExpressionValue[] = ['get', selectedValueRef.current];
+    // Use coalesce so that features missing the color property (e.g. boundary
+    // or line features in a multi-layer MVT) fall back to transparent instead
+    // of returning undefined, which would cause OL to throw at render time.
+    const colorExpr: ExpressionValue = [
+      'coalesce',
+      ['get', selectedValueRef.current],
+      'rgba(0,0,0,0)',
+    ];
     const newStyle = { ...layer.parameters.color };
     newStyle['fill-color'] = colorExpr;
     newStyle['stroke-color'] = colorExpr;


### PR DESCRIPTION
Fixes #1187

Tested with the MacroStrat vector tile layer from the gallery.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1188.org.readthedocs.build/en/1188/
💡 JupyterLite preview: https://jupytergis--1188.org.readthedocs.build/en/1188/lite
💡 Specta preview: https://jupytergis--1188.org.readthedocs.build/en/1188/lite/specta

<!-- readthedocs-preview jupytergis end -->