### PR TITLE
fix: use stable IDs as React keys for StopRow components

### DIFF
--- a/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_stops/StopContainer.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@jupyterlab/ui-components';
 import React from 'react';
+import { UUID } from '@lumino/coreutils';
 
 import { IStopRow } from '@/src/dialogs/symbology/symbologyDialog';
 import StopRow from './StopRow';
@@ -18,6 +19,7 @@ const StopContainer: React.FC<IStopContainerProps> = ({
   const addStopRow = () => {
     setStopRows([
       {
+        id: UUID.uuid4(),
         stop: 0,
         output: [0, 0, 0, 1],
       },
@@ -41,7 +43,7 @@ const StopContainer: React.FC<IStopContainerProps> = ({
         </div>
         {stopRows.map((stop, index) => (
           <StopRow
-            key={index}
+            key={stop.id}
             index={index}
             dataValue={stop.stop}
             symbologyValue={stop.output}

--- a/packages/base/src/dialogs/symbology/symbologyDialog.tsx
+++ b/packages/base/src/dialogs/symbology/symbologyDialog.tsx
@@ -36,6 +36,7 @@ export interface ISymbologyWidgetOptions {
 }
 
 export interface IStopRow {
+  id: string;
   stop: number | string;
   output: SymbologyValue;
 }

--- a/packages/base/src/dialogs/symbology/symbologyUtils.ts
+++ b/packages/base/src/dialogs/symbology/symbologyUtils.ts
@@ -5,6 +5,7 @@ import {
   IWebGlLayer,
 } from '@jupytergis/schema';
 import colormap from 'colormap';
+import { UUID } from '@lumino/coreutils';
 
 import { ColorRampName, findExprNode } from './colorRampUtils';
 import { IStopRow } from './symbologyDialog';
@@ -177,6 +178,7 @@ export namespace VectorUtils {
           const pairKey = `${interpolate[i]}-${interpolate[i + 1]}`;
           if (!seenPairs.has(pairKey)) {
             valueColorPairs.push({
+              id: UUID.uuid4(),
               stop: interpolate[i] as number,
               output: interpolate[i + 1] as IStopRow['output'],
             });
@@ -192,6 +194,7 @@ export namespace VectorUtils {
             const pairKey = `${condition[2]}-${caseExpr[i + 1]}`;
             if (!seenPairs.has(pairKey)) {
               valueColorPairs.push({
+                id: UUID.uuid4(),
                 stop: condition[2] as IStopRow['stop'],
                 output: caseExpr[i + 1] as IStopRow['output'],
               });
@@ -230,6 +233,7 @@ export namespace VectorUtils {
 
     for (let i = COLOR_EXPR_STOPS_START; i < circleRadius.length; i += 2) {
       const obj: IStopRow = {
+        id: UUID.uuid4(),
         stop: circleRadius[i],
         output: circleRadius[i + 1],
       };
@@ -263,7 +267,11 @@ export namespace Utils {
     for (let i = 0; i < nClasses; i++) {
       const colorIndex =
         nClasses === 1 ? 0 : Math.round((i / (nClasses - 1)) * (nShades - 1));
-      valueColorPairs.push({ stop: stops[i], output: colorMap[colorIndex] });
+      valueColorPairs.push({
+        id: UUID.uuid4(),
+        stop: stops[i],
+        output: colorMap[colorIndex],
+      });
     }
 
     return valueColorPairs;

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
@@ -2,6 +2,7 @@ import { IWebGlLayer } from '@jupytergis/schema';
 import { Button } from '@jupyterlab/ui-components';
 import { ReadonlyJSONObject } from '@lumino/coreutils';
 import { ExpressionValue } from 'ol/expr/expression';
+import { UUID } from '@lumino/coreutils';
 import React, { useEffect, useState } from 'react';
 
 import { GeoTiffClassifications } from '@/src/dialogs/symbology/classificationModes';
@@ -131,6 +132,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
         // Sixth and on is value:color pairs
         for (let i = 5; i < color.length; i += 2) {
           const obj: IStopRow = {
+            id: UUID.uuid4(),
             stop: scaleValue(Number(color[i]), isQuantile),
             output: color[i + 1] as IStopRow['output'],
           };
@@ -153,6 +155,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
               : color[i],
           );
           const obj: IStopRow = {
+            id: UUID.uuid4(),
             stop: scaleValue(stopVal, isQuantile),
             output: color[i + 1] as IStopRow['output'],
           };
@@ -284,6 +287,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
   const addStopRow = () => {
     setStopRows([
       {
+        id: UUID.uuid4(),
         stop: 0,
         output: [0, 0, 0, 1],
       },
@@ -450,7 +454,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
         </div>
         {stopRows.map((stop, index) => (
           <StopRow
-            key={`${index}-${stop.output}`}
+            key={stop.id}
             index={index}
             dataValue={stop.stop}
             symbologyValue={stop.output}

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
@@ -1,5 +1,6 @@
 import { IVectorLayer } from '@jupytergis/schema';
 import { ExpressionValue } from 'ol/expr/expression';
+import { UUID } from '@lumino/coreutils';
 import React, { useEffect, useState } from 'react';
 
 import { VectorClassifications } from '@/src/dialogs/symbology/classificationModes';
@@ -334,7 +335,7 @@ const Graduated: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
 
     const stopOutputPairs =
       symbologyTab === 'radius'
-        ? stops.map(v => ({ stop: v, output: v }))
+        ? stops.map(v => ({ id: UUID.uuid4(), stop: v, output: v }))
         : Utils.getValueColorPairs(
             stops,
             selectedRamp,


### PR DESCRIPTION
## Description

Resolves #1209.

Replaces array indices with stable UUIDs as React keys for `StopRow` components. Adds an `id` field to `IStopRow` and generates UUIDs at all stop creation points across `StopContainer`, `SingleBandPseudoColor`, `Graduated`, and `symbologyUtils`.

Also switches from `uuid@10` (no bundled types) + `@types/uuid` to `uuid@^11` which ships its own TypeScript declarations.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1210.org.readthedocs.build/en/1210/
💡 JupyterLite preview: https://jupytergis--1210.org.readthedocs.build/en/1210/lite
💡 Specta preview: https://jupytergis--1210.org.readthedocs.build/en/1210/lite/specta

<!-- readthedocs-preview jupytergis end -->