### PR TITLE
feat: add RGBA inputs and transparent checkbox to color picker

### DIFF
--- a/packages/base/src/dialogs/symbology/colorRampUtils.ts
+++ b/packages/base/src/dialogs/symbology/colorRampUtils.ts
@@ -4,7 +4,11 @@ import { useEffect } from 'react';
 
 import rawCmocean from '@/src/dialogs/symbology/components/color_ramp/cmocean.json';
 
+// RgbaColor is an array because OpenLayers and colormap expect arrays directly.
+// RGBA_INDEX bridges that to the named-channel style used by react-colorful and the color picker UI.
 export type RgbaColor = [number, number, number, number];
+export const RGBA_INDEX = { r: 0, g: 1, b: 2, a: 3 } as const;
+export type RgbaChannel = keyof typeof RGBA_INDEX;
 
 /** OpenLayers default blue, used as the fallback color throughout symbology dialogs. */
 export const DEFAULT_COLOR: RgbaColor = [51, 153, 204, 1];

--- a/packages/base/src/dialogs/symbology/components/color_ramp/RgbaColorPicker.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/RgbaColorPicker.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { RgbaColorPicker as ReactColorfulRgba } from 'react-colorful';
 
-import { RgbaColor } from '@/src/dialogs/symbology/colorRampUtils';
+import {
+  RgbaChannel,
+  RgbaColor,
+  RGBA_INDEX,
+} from '@/src/dialogs/symbology/colorRampUtils';
 
 export type { RgbaColor };
 
@@ -22,6 +26,24 @@ const RgbaColorPicker: React.FC<IRgbaColorPickerProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const [r, g, b, a] = color;
+
+  const [inputs, setInputs] = useState({
+    r: String(Math.round(r)),
+    g: String(Math.round(g)),
+    b: String(Math.round(b)),
+    a: String(Math.round(a * 100)),
+  });
+
+  // Sync text inputs when color changes externally (e.g. picker drag)
+  useEffect(() => {
+    setInputs({
+      r: String(Math.round(r)),
+      g: String(Math.round(g)),
+      b: String(Math.round(b)),
+      a: String(Math.round(a * 100)),
+    });
+  }, [r, g, b, a]);
+
   const swatchStyle = {
     background: `rgba(${r},${g},${b},${a})`,
     width: 28,
@@ -32,12 +54,34 @@ const RgbaColorPicker: React.FC<IRgbaColorPickerProps> = ({
     flexShrink: 0,
   };
 
-  const handleChange = useCallback(
+  const handlePickerChange = useCallback(
     (c: { r: number; g: number; b: number; a: number }) => {
       onChange([c.r, c.g, c.b, c.a]);
     },
     [onChange],
   );
+
+  const handleChannelInput = (channel: RgbaChannel, value: string) => {
+    setInputs(prev => ({ ...prev, [channel]: value }));
+    const num = Number(value);
+    if (channel === 'a') {
+      if (num >= 0 && num <= 100) {
+        onChange([r, g, b, num / 100]);
+      }
+    } else {
+      if (num >= 0 && num <= 255) {
+        const newColor: RgbaColor = [...color];
+        newColor[RGBA_INDEX[channel]] = Math.round(num);
+        onChange(newColor);
+      }
+    }
+  };
+
+  const handleTransparentChange = (checked: boolean) => {
+    // Always restore to fully opaque rather than the previous alpha,
+    // which could have been near-zero and appear broken to the user.
+    onChange([r, g, b, checked ? 0 : 1]);
+  };
 
   useEffect(() => {
     if (!open) {
@@ -76,7 +120,44 @@ const RgbaColorPicker: React.FC<IRgbaColorPickerProps> = ({
             boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
           }}
         >
-          <ReactColorfulRgba color={{ r, g, b, a }} onChange={handleChange} />
+          <ReactColorfulRgba
+            color={{ r, g, b, a }}
+            onChange={handlePickerChange}
+          />
+          <div className="jp-gis-rgba-inputs">
+            {(['r', 'g', 'b'] as const).map(ch => (
+              <div key={ch} className="jp-gis-rgba-field">
+                <label>{ch.toUpperCase()}</label>
+                <input
+                  className="jp-mod-styled"
+                  type="number"
+                  min={0}
+                  max={255}
+                  value={inputs[ch]}
+                  onChange={e => handleChannelInput(ch, e.target.value)}
+                />
+              </div>
+            ))}
+            <div className="jp-gis-rgba-field">
+              <label>A%</label>
+              <input
+                className="jp-mod-styled"
+                type="number"
+                min={0}
+                max={100}
+                value={inputs.a}
+                onChange={e => handleChannelInput('a', e.target.value)}
+              />
+            </div>
+          </div>
+          <label className="jp-gis-transparent-label">
+            <input
+              type="checkbox"
+              checked={a === 0}
+              onChange={e => handleTransparentChange(e.target.checked)}
+            />
+            No color
+          </label>
         </div>
       )}
     </div>

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -229,3 +229,46 @@ select option {
 .jp-gis-selected-entry {
   width: 100%;
 }
+
+.jp-gis-rgba-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.jp-gis-rgba-field {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 2px;
+}
+
+.jp-gis-rgba-field label {
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+  line-height: 1;
+}
+
+.jp-gis-rgba-field input {
+  width: 4ch;
+  text-align: center;
+  padding: 1px 2px;
+  -moz-appearance: textfield;
+}
+
+.jp-gis-rgba-field input::-webkit-outer-spin-button,
+.jp-gis-rgba-field input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+.jp-gis-transparent-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  font-size: var(--jp-ui-font-size1);
+  cursor: pointer;
+  user-select: none;
+}


### PR DESCRIPTION
## Description

Resolves #1203.

Adds RGBA number fields and a "No color" checkbox inside the color picker popup:

- R, G, B (0–255) and A% (0–100) inputs arranged in a 2×2 grid below the color wheel
- "No color" checkbox sets alpha to 0; unchecking restores to fully opaque
- Adds `RGBA_INDEX` and `RgbaChannel` to `colorRampUtils` to bridge between the array format used by OpenLayers/colormap and the named-channel style used by the picker UI

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1211.org.readthedocs.build/en/1211/
💡 JupyterLite preview: https://jupytergis--1211.org.readthedocs.build/en/1211/lite
💡 Specta preview: https://jupytergis--1211.org.readthedocs.build/en/1211/lite/specta

<!-- readthedocs-preview jupytergis end -->