### PR TITLE
fix: hide panel scrollbars when content does not overflow

### DIFF
--- a/packages/base/style/shared/tabs.css
+++ b/packages/base/style/shared/tabs.css
@@ -17,7 +17,7 @@
   gap: 1rem;
   width: 100%;
   font-size: 9px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .jgis-tabs-list:active {
@@ -60,7 +60,7 @@
 .jgis-tabs-content {
   outline: none;
   width: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
   /* max-height: 480px; */
   padding-top: 1rem;
 }


### PR DESCRIPTION
## Summary

Replace `overflow: scroll` with `overflow: auto` in `.jgis-tabs-list` and `.jgis-tabs-content` in `tabs.css`. Scrollbars now only appear when content actually overflows, which looks much cleaner.

Open a map with the left/right panels and verify scrollbars only appear when content overflows.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1213.org.readthedocs.build/en/1213/
💡 JupyterLite preview: https://jupytergis--1213.org.readthedocs.build/en/1213/lite
💡 Specta preview: https://jupytergis--1213.org.readthedocs.build/en/1213/lite/specta

<!-- readthedocs-preview jupytergis end -->