### PR TITLE
Add array into source to fix length error in Heatmap symbology.

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -1619,7 +1619,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
       // Save original features on first filter application
       if (!Object.keys(this._originalFeatures).includes(id)) {
-        this._originalFeatures[id] = source.getFeatures();
+        this._originalFeatures[id] = source.getFeatures() ?? [];
       }
 
       // clear current features
@@ -1628,10 +1628,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       const startTime = activeFilter.betweenMin ?? 0;
       const endTime = activeFilter.betweenMax ?? 1000;
 
-      const filteredFeatures = this._originalFeatures[id].filter(feature => {
-        const featureTime = feature.get(activeFilter.feature);
-        return featureTime >= startTime && featureTime <= endTime;
-      });
+      const filteredFeatures = (this._originalFeatures[id] ?? []).filter(
+        feature => {
+          const featureTime = feature.get(activeFilter.feature);
+          return featureTime >= startTime && featureTime <= endTime;
+        },
+      );
 
       // set state for restoration
       this.setState(old => ({
@@ -1645,7 +1647,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       source.addFeatures(filteredFeatures);
     } else {
       // Restore original features when no filters are applied
-      source.addFeatures(this._originalFeatures[id]);
+      source.addFeatures(this._originalFeatures[id] ?? []);
       delete this._originalFeatures[id];
     }
   };


### PR DESCRIPTION
## Description


Before `source.addFeatures()` was being called with `undefined` instead of an array.
That gives `length = undefined` error in console every time we change symbology.

Now we have added array to `_originalFeatures` so it allows Normalize features to always be an array instead of getting `undefined`.


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1220.org.readthedocs.build/en/1220/
💡 JupyterLite preview: https://jupytergis--1220.org.readthedocs.build/en/1220/lite
💡 Specta preview: https://jupytergis--1220.org.readthedocs.build/en/1220/lite/specta

<!-- readthedocs-preview jupytergis end -->