### PR TITLE
poc: grammar-based symbology render type

### DIFF
--- a/packages/base/src/dialogs/symbology/colorRampUtils.ts
+++ b/packages/base/src/dialogs/symbology/colorRampUtils.ts
@@ -178,15 +178,29 @@ export const ensureHexColorCode = (color: number[] | string): string => {
  */
 export function colorToRgba(color: unknown): RgbaColor {
   if (typeof color === 'string') {
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
-    if (!result) {
+    // rgb(...) / rgba(...) format
+    const rgbaResult =
+      /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+))?\s*\)$/i.exec(
+        color,
+      );
+    if (rgbaResult) {
+      return [
+        parseInt(rgbaResult[1], 10),
+        parseInt(rgbaResult[2], 10),
+        parseInt(rgbaResult[3], 10),
+        rgbaResult[4] !== undefined ? parseFloat(rgbaResult[4]) : 1,
+      ];
+    }
+    // #RRGGBB hex format
+    const hexResult = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
+    if (!hexResult) {
       console.warn('Unable to parse hex color, using default');
       return DEFAULT_COLOR;
     }
     return [
-      parseInt(result[1], 16),
-      parseInt(result[2], 16),
-      parseInt(result[3], 16),
+      parseInt(hexResult[1], 16),
+      parseInt(hexResult[2], 16),
+      parseInt(hexResult[3], 16),
       1,
     ];
   }

--- a/packages/base/src/dialogs/symbology/components/color_ramp/RgbaColorPicker.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/RgbaColorPicker.tsx
@@ -88,10 +88,13 @@ const RgbaColorPicker: React.FC<IRgbaColorPickerProps> = ({
       return;
     }
     const handleClickOutside = (e: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
+      const target = e.target as Node;
+      // Ignore clicks on detached nodes (can happen when a React re-render
+      // removes the target between pointerdown and mousedown).
+      if (!document.documentElement.contains(target)) {
+        return;
+      }
+      if (containerRef.current && !containerRef.current.contains(target)) {
         setOpen(false);
       }
     };
@@ -119,6 +122,7 @@ const RgbaColorPicker: React.FC<IRgbaColorPickerProps> = ({
             padding: 8,
             boxShadow: '0 4px 12px rgba(0,0,0,0.2)',
           }}
+          onMouseDown={e => e.stopPropagation()}
         >
           <ReactColorfulRgba
             color={{ r, g, b, a }}

--- a/packages/base/src/dialogs/symbology/grammar/components/MappingEditor.tsx
+++ b/packages/base/src/dialogs/symbology/grammar/components/MappingEditor.tsx
@@ -1,0 +1,595 @@
+import { UUID } from '@lumino/coreutils';
+import React from 'react';
+
+import { VectorClassifications } from '@/src/dialogs/symbology/classificationModes';
+import ColorRampSelector from '@/src/dialogs/symbology/components/color_ramp/ColorRampSelector';
+import RgbaColorPicker from '@/src/dialogs/symbology/components/color_ramp/RgbaColorPicker';
+import StopContainer from '@/src/dialogs/symbology/components/color_stops/StopContainer';
+import {
+  colorToRgba,
+  ensureHexColorCode,
+  RgbaColor,
+} from '@/src/dialogs/symbology/colorRampUtils';
+import {
+  CATEGORICAL_PALETTE,
+  computeDomain,
+} from '@/src/dialogs/symbology/grammar/grammarUtils';
+import {
+  IEncodingRule,
+  IScale,
+} from '@/src/dialogs/symbology/grammar/types';
+import { COLOR_CHANNELS } from '@/src/dialogs/symbology/grammar/grammarUtils';
+import { IStopRow } from '@/src/dialogs/symbology/symbologyDialog';
+import { ColorRampName } from '../../colorRampUtils';
+import { Utils } from '../../symbologyUtils';
+
+type ClassificationMode =
+  | 'quantile'
+  | 'equal interval'
+  | 'jenks'
+  | 'pretty'
+  | 'logarithmic';
+
+const CLASSIFICATION_MODES: ClassificationMode[] = [
+  'equal interval',
+  'quantile',
+  'jenks',
+  'pretty',
+  'logarithmic',
+];
+
+// ---------------------------------------------------------------------------
+// ColorRampScaleEditor
+// ---------------------------------------------------------------------------
+
+interface IColorRampScaleEditorProps {
+  scale: Extract<IScale, { scheme: 'colorRamp' }>;
+  field: string;
+  featureProperties: Record<string, Set<any>>;
+  onChange: (scale: IScale) => void;
+}
+
+const ColorRampScaleEditor: React.FC<IColorRampScaleEditorProps> = ({
+  scale,
+  field,
+  featureProperties,
+  onChange,
+}) => {
+  const autoComputed = computeDomain(featureProperties[field] ?? new Set());
+  const domain = scale.domain ?? autoComputed;
+  const mode = scale.mode;
+  const nShades = scale.nShades;
+
+  const update = (patch: Partial<Extract<IScale, { scheme: 'colorRamp' }>>) => {
+    onChange({ ...scale, ...patch });
+  };
+
+  const handleClassify = () => {
+    const allValues = Array.from(featureProperties[field] ?? new Set());
+    const values = allValues.filter(v => Number.isFinite(v));
+    if (values.length === 0) {
+      return;
+    }
+
+    const rangeMin = domain[0];
+    const rangeMax = domain[1];
+    const rangeValues = [rangeMin, rangeMax];
+
+    let breaks: number[];
+    switch (mode) {
+      case 'quantile':
+        breaks = VectorClassifications.calculateQuantileBreaks(values, nShades);
+        break;
+      case 'jenks':
+        breaks = VectorClassifications.calculateJenksBreaks(values, nShades);
+        break;
+      case 'equal interval':
+        breaks = VectorClassifications.calculateEqualIntervalBreaks(rangeValues, nShades);
+        break;
+      case 'pretty':
+        breaks = VectorClassifications.calculatePrettyBreaks(rangeValues, nShades);
+        break;
+      case 'logarithmic':
+        breaks = VectorClassifications.calculateLogarithmicBreaks(rangeValues, nShades);
+        break;
+      default:
+        return;
+    }
+
+    if (breaks.length > 0) {
+      breaks[0] = rangeMin;
+      breaks[breaks.length - 1] = rangeMax;
+    }
+
+    const stopRows = Utils.getValueColorPairs(
+      breaks,
+      scale.name as ColorRampName,
+      nShades,
+      scale.reverse,
+    );
+
+    const colorStops = stopRows.map(row => ({
+      stop: row.stop as number,
+      color: row.output as [number, number, number, number],
+    }));
+
+    update({ colorStops });
+  };
+
+  const stopRows: IStopRow[] = (scale.colorStops ?? []).map(cs => ({
+    id: UUID.uuid4(),
+    stop: cs.stop,
+    output: cs.color as RgbaColor,
+  }));
+
+  const handleStopRowsChange = (rows: IStopRow[]) => {
+    const colorStops = rows.map(row => ({
+      stop: row.stop as number,
+      color: row.output as [number, number, number, number],
+    }));
+    update({ colorStops });
+  };
+
+  return (
+    <div className="jp-gis-scale-editor jp-gis-color-ramp-container">
+      <div className="jp-gis-symbology-row">
+        <label>Color Ramp:</label>
+        <ColorRampSelector
+          selectedRamp={scale.name as ColorRampName}
+          setSelected={name => update({ name, colorStops: undefined })}
+          reverse={scale.reverse}
+          setReverse={action => {
+            const reverse =
+              typeof action === 'function'
+                ? action(scale.reverse)
+                : action;
+            update({ reverse, colorStops: undefined });
+          }}
+        />
+      </div>
+
+      <div className="jp-gis-symbology-row">
+        <label>Mode:</label>
+        <div className="jp-select-wrapper">
+          <select
+            className="jp-mod-styled"
+            value={mode}
+            onChange={e =>
+              update({
+                mode: e.target.value as ClassificationMode,
+                colorStops: undefined,
+              })
+            }
+          >
+            {CLASSIFICATION_MODES.map(m => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="jp-gis-symbology-row">
+        <label>Classes:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          min={2}
+          max={256}
+          value={nShades}
+          onChange={e =>
+            update({
+              nShades: Math.max(2, parseInt(e.target.value) || 9),
+              colorStops: undefined,
+            })
+          }
+        />
+      </div>
+
+      <div className="jp-gis-symbology-row">
+        <label>Min:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          value={domain[0]}
+          onChange={e =>
+            update({
+              domain: [parseFloat(e.target.value) || 0, domain[1]],
+              colorStops: undefined,
+            })
+          }
+        />
+        <label>Max:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          value={domain[1]}
+          onChange={e =>
+            update({
+              domain: [domain[0], parseFloat(e.target.value) || 1],
+              colorStops: undefined,
+            })
+          }
+        />
+      </div>
+
+      <button
+        className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+        onClick={handleClassify}
+      >
+        Classify
+      </button>
+
+      {stopRows.length > 0 && (
+        <StopContainer
+          selectedMethod="color"
+          stopRows={stopRows}
+          setStopRows={handleStopRowsChange}
+        />
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// CategoricalScaleEditor
+// ---------------------------------------------------------------------------
+
+interface ICategoricalScaleEditorProps {
+  scale: Extract<IScale, { scheme: 'categorical' }>;
+  field: string;
+  featureProperties: Record<string, Set<any>>;
+  onChange: (scale: IScale) => void;
+}
+
+const CategoricalScaleEditor: React.FC<ICategoricalScaleEditorProps> = ({
+  scale,
+  field,
+  featureProperties,
+  onChange,
+}) => {
+  const fieldValues = Array.from(featureProperties[field] ?? new Set())
+    .filter(v => v !== null && v !== undefined)
+    .slice(0, 20);
+
+  const mapping = { ...scale.mapping };
+  fieldValues.forEach((v, i) => {
+    const key = String(v);
+    if (!mapping[key]) {
+      mapping[key] = CATEGORICAL_PALETTE[i % CATEGORICAL_PALETTE.length];
+    }
+  });
+
+  const updateColor = (key: string, color: RgbaColor) => {
+    onChange({
+      ...scale,
+      mapping: { ...mapping, [key]: ensureHexColorCode(color) },
+    });
+  };
+
+  const updateFallback = (color: RgbaColor) => {
+    onChange({ ...scale, fallback: ensureHexColorCode(color) });
+  };
+
+  return (
+    <div className="jp-gis-scale-editor">
+      {fieldValues.length === 0 && (
+        <p className="jp-gis-mapping-empty">No values found for this field.</p>
+      )}
+      {fieldValues.map(v => {
+        const key = String(v);
+        return (
+          <div key={key} className="jp-gis-color-row">
+            <span
+              className="jp-mod-styled jp-gis-color-row-value-input"
+              style={{ display: 'flex', alignItems: 'center' }}
+            >
+              {key}
+            </span>
+            <RgbaColorPicker
+              color={colorToRgba(mapping[key] ?? '#888888')}
+              onChange={color => updateColor(key, color)}
+            />
+          </div>
+        );
+      })}
+      <div className="jp-gis-color-row">
+        <span
+          className="jp-mod-styled jp-gis-color-row-value-input"
+          style={{ display: 'flex', alignItems: 'center' }}
+        >
+          Other
+        </span>
+        <RgbaColorPicker
+          color={colorToRgba(scale.fallback ?? '#000000')}
+          onChange={updateFallback}
+        />
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ScalarScaleEditor
+// ---------------------------------------------------------------------------
+
+interface IScalarScaleEditorProps {
+  scale: Extract<IScale, { scheme: 'scalar' }>;
+  field: string;
+  featureProperties: Record<string, Set<any>>;
+  onChange: (scale: IScale) => void;
+}
+
+const ScalarScaleEditor: React.FC<IScalarScaleEditorProps> = ({
+  scale,
+  field,
+  featureProperties,
+  onChange,
+}) => {
+  const autoComputed = computeDomain(featureProperties[field] ?? new Set());
+  const domain = scale.domain ?? autoComputed;
+  const mode = scale.mode;
+  const nShades = 9;
+
+  const update = (patch: Partial<Extract<IScale, { scheme: 'scalar' }>>) => {
+    onChange({ ...scale, ...patch });
+  };
+
+  const handleClassify = () => {
+    const allValues = Array.from(featureProperties[field] ?? new Set());
+    const values = allValues.filter(v => Number.isFinite(v));
+    if (values.length === 0) {
+      return;
+    }
+
+    const rangeValues = [domain[0], domain[1]];
+    let breaks: number[];
+    switch (mode) {
+      case 'quantile':
+        breaks = VectorClassifications.calculateQuantileBreaks(values, nShades);
+        break;
+      case 'jenks':
+        breaks = VectorClassifications.calculateJenksBreaks(values, nShades);
+        break;
+      case 'equal interval':
+        breaks = VectorClassifications.calculateEqualIntervalBreaks(rangeValues, nShades);
+        break;
+      case 'pretty':
+        breaks = VectorClassifications.calculatePrettyBreaks(rangeValues, nShades);
+        break;
+      case 'logarithmic':
+        breaks = VectorClassifications.calculateLogarithmicBreaks(rangeValues, nShades);
+        break;
+      default:
+        return;
+    }
+
+    if (breaks.length > 0) {
+      breaks[0] = domain[0];
+      breaks[breaks.length - 1] = domain[1];
+    }
+
+    const scalarStops = breaks.map((stop, i) => {
+      const t = breaks.length === 1 ? 0 : i / (breaks.length - 1);
+      const output = scale.range[0] + t * (scale.range[1] - scale.range[0]);
+      return { stop, output };
+    });
+
+    update({ scalarStops });
+  };
+
+  const stopRows: IStopRow[] = (scale.scalarStops ?? []).map(ss => ({
+    id: UUID.uuid4(),
+    stop: ss.stop,
+    output: ss.output,
+  }));
+
+  const handleStopRowsChange = (rows: IStopRow[]) => {
+    const scalarStops = rows.map(row => ({
+      stop: row.stop as number,
+      output: row.output as number,
+    }));
+    update({ scalarStops });
+  };
+
+  return (
+    <div className="jp-gis-scale-editor jp-gis-color-ramp-container">
+      <div className="jp-gis-symbology-row">
+        <label>Mode:</label>
+        <div className="jp-select-wrapper">
+          <select
+            className="jp-mod-styled"
+            value={mode}
+            onChange={e =>
+              update({
+                mode: e.target.value as ClassificationMode,
+                scalarStops: undefined,
+              })
+            }
+          >
+            {CLASSIFICATION_MODES.map(m => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="jp-gis-symbology-row">
+        <label>Input Min:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          value={domain[0]}
+          onChange={e =>
+            update({ domain: [parseFloat(e.target.value) || 0, domain[1]], scalarStops: undefined })
+          }
+        />
+        <label>Max:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          value={domain[1]}
+          onChange={e =>
+            update({ domain: [domain[0], parseFloat(e.target.value) || 1], scalarStops: undefined })
+          }
+        />
+      </div>
+
+      <div className="jp-gis-symbology-row">
+        <label>Output Min:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          value={scale.range[0]}
+          onChange={e =>
+            update({ range: [parseFloat(e.target.value) || 0, scale.range[1]], scalarStops: undefined })
+          }
+        />
+        <label>Max:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          value={scale.range[1]}
+          onChange={e =>
+            update({ range: [scale.range[0], parseFloat(e.target.value) || 1], scalarStops: undefined })
+          }
+        />
+      </div>
+
+      <button
+        className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+        onClick={handleClassify}
+      >
+        Classify
+      </button>
+
+      {stopRows.length > 0 && (
+        <StopContainer
+          selectedMethod="radius"
+          stopRows={stopRows}
+          setStopRows={handleStopRowsChange}
+        />
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ConstantScaleEditor
+// ---------------------------------------------------------------------------
+
+interface IConstantScaleEditorProps {
+  scale: Extract<IScale, { scheme: 'constant' }>;
+  channel: IEncodingRule['channel'];
+  onChange: (scale: IScale) => void;
+}
+
+const ConstantScaleEditor: React.FC<IConstantScaleEditorProps> = ({
+  scale,
+  channel,
+  onChange,
+}) => {
+  const isColorChannel = (COLOR_CHANNELS as string[]).includes(channel);
+
+  if (isColorChannel) {
+    // Parse current value as RgbaColor for the picker.
+    const currentColor: RgbaColor =
+      typeof scale.value === 'string'
+        ? colorToRgba(scale.value)
+        : Array.isArray(scale.value)
+          ? [scale.value[0], scale.value[1], scale.value[2], scale.value[3] ?? 1] as RgbaColor
+          : colorToRgba('#888888');
+
+    return (
+      <div className="jp-gis-scale-editor">
+        <div className="jp-gis-symbology-row">
+          <label>Color:</label>
+          <RgbaColorPicker
+            color={currentColor}
+            onChange={color => onChange({ ...scale, value: ensureHexColorCode(color) })}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Numeric channel (stroke-width, circle-radius, circle-stroke-width).
+  return (
+    <div className="jp-gis-scale-editor">
+      <div className="jp-gis-symbology-row">
+        <label>Value:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          value={typeof scale.value === 'number' ? scale.value : 1}
+          min={0}
+          onChange={e =>
+            onChange({ ...scale, value: parseFloat(e.target.value) || 0 })
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// MappingEditor
+// ---------------------------------------------------------------------------
+
+interface IMappingEditorProps {
+  rule: IEncodingRule;
+  featureProperties: Record<string, Set<any>>;
+  onChange: (rule: IEncodingRule) => void;
+}
+
+const MappingEditor: React.FC<IMappingEditorProps> = ({
+  rule,
+  featureProperties,
+  onChange,
+}) => {
+  const updateScale = (scale: IScale) => onChange({ ...rule, scale });
+
+  return (
+    <div className="jp-gis-mapping-editor">
+      {rule.scale.scheme === 'colorRamp' && (
+        <ColorRampScaleEditor
+          scale={rule.scale}
+          field={rule.field ?? ''}
+          featureProperties={featureProperties}
+          onChange={updateScale}
+        />
+      )}
+      {rule.scale.scheme === 'categorical' && (
+        <CategoricalScaleEditor
+          scale={rule.scale}
+          field={rule.field ?? ''}
+          featureProperties={featureProperties}
+          onChange={updateScale}
+        />
+      )}
+      {rule.scale.scheme === 'scalar' && (
+        <ScalarScaleEditor
+          scale={rule.scale}
+          field={rule.field ?? ''}
+          featureProperties={featureProperties}
+          onChange={updateScale}
+        />
+      )}
+      {rule.scale.scheme === 'constant' && (
+        <ConstantScaleEditor
+          scale={rule.scale}
+          channel={rule.channel}
+          onChange={updateScale}
+        />
+      )}
+      {rule.scale.scheme === 'identity' && (
+        <p className="jp-gis-mapping-empty">
+          Field value used directly — no configuration needed.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default MappingEditor;

--- a/packages/base/src/dialogs/symbology/grammar/components/MappingEditor.tsx
+++ b/packages/base/src/dialogs/symbology/grammar/components/MappingEditor.tsx
@@ -7,9 +7,13 @@ import RgbaColorPicker from '@/src/dialogs/symbology/components/color_ramp/RgbaC
 import StopContainer from '@/src/dialogs/symbology/components/color_stops/StopContainer';
 import {
   colorToRgba,
-  ensureHexColorCode,
   RgbaColor,
 } from '@/src/dialogs/symbology/colorRampUtils';
+
+/** Convert RgbaColor [r,g,b,a] (a in 0-1) to a CSS rgba string preserving alpha. */
+function colorToString(color: RgbaColor): string {
+  return `rgba(${color[0]},${color[1]},${color[2]},${color[3]})`;
+}
 import {
   CATEGORICAL_PALETTE,
   computeDomain,
@@ -187,7 +191,7 @@ const ColorRampScaleEditor: React.FC<IColorRampScaleEditorProps> = ({
         />
       </div>
 
-      <div className="jp-gis-symbology-row">
+      <div className="jp-gis-symbology-row jp-gis-symbology-row-pair">
         <label>Min:</label>
         <input
           type="number"
@@ -264,12 +268,12 @@ const CategoricalScaleEditor: React.FC<ICategoricalScaleEditorProps> = ({
   const updateColor = (key: string, color: RgbaColor) => {
     onChange({
       ...scale,
-      mapping: { ...mapping, [key]: ensureHexColorCode(color) },
+      mapping: { ...mapping, [key]: colorToString(color) },
     });
   };
 
   const updateFallback = (color: RgbaColor) => {
-    onChange({ ...scale, fallback: ensureHexColorCode(color) });
+    onChange({ ...scale, fallback: colorToString(color) });
   };
 
   return (
@@ -330,7 +334,7 @@ const ScalarScaleEditor: React.FC<IScalarScaleEditorProps> = ({
   const autoComputed = computeDomain(featureProperties[field] ?? new Set());
   const domain = scale.domain ?? autoComputed;
   const mode = scale.mode;
-  const nShades = 9;
+  const nShades = scale.nStops ?? 9;
 
   const update = (patch: Partial<Extract<IScale, { scheme: 'scalar' }>>) => {
     onChange({ ...scale, ...patch });
@@ -370,7 +374,7 @@ const ScalarScaleEditor: React.FC<IScalarScaleEditorProps> = ({
       breaks[breaks.length - 1] = domain[1];
     }
 
-    const scalarStops = breaks.map((stop, i) => {
+    const scalarStops = breaks.map((stop: number, i: number) => {
       const t = breaks.length === 1 ? 0 : i / (breaks.length - 1);
       const output = scale.range[0] + t * (scale.range[1] - scale.range[0]);
       return { stop, output };
@@ -416,6 +420,23 @@ const ScalarScaleEditor: React.FC<IScalarScaleEditorProps> = ({
       </div>
 
       <div className="jp-gis-symbology-row">
+        <label>Stops:</label>
+        <input
+          type="number"
+          className="jp-mod-styled"
+          min={2}
+          max={256}
+          value={nShades}
+          onChange={e =>
+            update({
+              nStops: Math.max(2, parseInt(e.target.value) || 9),
+              scalarStops: undefined,
+            })
+          }
+        />
+      </div>
+
+      <div className="jp-gis-symbology-row">
         <label>Input Min:</label>
         <input
           type="number"
@@ -436,7 +457,7 @@ const ScalarScaleEditor: React.FC<IScalarScaleEditorProps> = ({
         />
       </div>
 
-      <div className="jp-gis-symbology-row">
+      <div className="jp-gis-symbology-row jp-gis-symbology-row-pair">
         <label>Output Min:</label>
         <input
           type="number"
@@ -507,7 +528,7 @@ const ConstantScaleEditor: React.FC<IConstantScaleEditorProps> = ({
           <label>Color:</label>
           <RgbaColorPicker
             color={currentColor}
-            onChange={color => onChange({ ...scale, value: ensureHexColorCode(color) })}
+            onChange={color => onChange({ ...scale, value: colorToString(color) })}
           />
         </div>
       </div>

--- a/packages/base/src/dialogs/symbology/grammar/components/MappingTable.tsx
+++ b/packages/base/src/dialogs/symbology/grammar/components/MappingTable.tsx
@@ -1,0 +1,439 @@
+import React from 'react';
+
+import {
+  ALL_CHANNELS,
+  CATEGORICAL_PALETTE,
+  CHANNEL_LABELS,
+  computeDomain,
+  createDefaultRule,
+  defaultColorRampScale,
+  defaultScale,
+} from '@/src/dialogs/symbology/grammar/grammarUtils';
+import {
+  IEncodingRule,
+  IPredicate,
+  IScale,
+  OLStyleChannel,
+} from '@/src/dialogs/symbology/grammar/types';
+import MappingEditor from './MappingEditor';
+
+// ---------------------------------------------------------------------------
+// Scale schemes
+// ---------------------------------------------------------------------------
+
+const SCALE_SCHEMES: IScale['scheme'][] = [
+  'colorRamp',
+  'categorical',
+  'scalar',
+  'constant',
+  'identity',
+];
+
+// ---------------------------------------------------------------------------
+// Predicate chip — displays one `when` condition with a remove button
+// ---------------------------------------------------------------------------
+
+interface IPredicateChipProps {
+  predicate: IPredicate;
+  onRemove: () => void;
+}
+
+const PredicateChip: React.FC<IPredicateChipProps> = ({ predicate, onRemove }) => {
+  let label: string;
+  switch (predicate.type) {
+    case 'geometryType':
+      label = `geom = ${predicate.value}`;
+      break;
+    case 'hasField':
+      label = `has ${predicate.field}`;
+      break;
+    case 'fieldEquals':
+      label = `${predicate.field} = ${predicate.value}`;
+      break;
+  }
+  return (
+    <span className="jp-gis-predicate-chip">
+      {label}
+      <button
+        className="jp-gis-predicate-remove"
+        title="Remove condition"
+        onClick={e => {
+          e.stopPropagation();
+          onRemove();
+        }}
+      >
+        ×
+      </button>
+    </span>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// AddPredicatePopover — inline form for adding a new predicate
+// ---------------------------------------------------------------------------
+
+interface IAddPredicateProps {
+  fields: string[];
+  onAdd: (predicate: IPredicate) => void;
+  onCancel: () => void;
+}
+
+const AddPredicateForm: React.FC<IAddPredicateProps> = ({ fields, onAdd, onCancel }) => {
+  const [predicateType, setPredicateType] = React.useState<IPredicate['type']>('geometryType');
+  const [geomValue, setGeomValue] = React.useState<'point' | 'line' | 'polygon'>('point');
+  const [fieldName, setFieldName] = React.useState(fields[0] ?? '');
+  const [fieldValue, setFieldValue] = React.useState('');
+
+  const handleAdd = () => {
+    let predicate: IPredicate;
+    switch (predicateType) {
+      case 'geometryType':
+        predicate = { type: 'geometryType', value: geomValue };
+        break;
+      case 'hasField':
+        predicate = { type: 'hasField', field: fieldName };
+        break;
+      case 'fieldEquals':
+        predicate = { type: 'fieldEquals', field: fieldName, value: fieldValue };
+        break;
+    }
+    onAdd(predicate);
+  };
+
+  return (
+    <div className="jp-gis-predicate-form" onClick={e => e.stopPropagation()}>
+      <div className="jp-select-wrapper">
+        <select
+          className="jp-mod-styled"
+          value={predicateType}
+          onChange={e => setPredicateType(e.target.value as IPredicate['type'])}
+        >
+          <option value="geometryType">geometry type</option>
+          <option value="hasField">has field</option>
+          <option value="fieldEquals">field equals</option>
+        </select>
+      </div>
+
+      {predicateType === 'geometryType' && (
+        <div className="jp-select-wrapper">
+          <select
+            className="jp-mod-styled"
+            value={geomValue}
+            onChange={e => setGeomValue(e.target.value as typeof geomValue)}
+          >
+            <option value="point">point</option>
+            <option value="line">line</option>
+            <option value="polygon">polygon</option>
+          </select>
+        </div>
+      )}
+
+      {(predicateType === 'hasField' || predicateType === 'fieldEquals') && (
+        <div className="jp-select-wrapper">
+          <select
+            className="jp-mod-styled"
+            value={fieldName}
+            onChange={e => setFieldName(e.target.value)}
+          >
+            {fields.map(f => (
+              <option key={f} value={f}>{f}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {predicateType === 'fieldEquals' && (
+        <input
+          type="text"
+          className="jp-mod-styled"
+          placeholder="value"
+          value={fieldValue}
+          onChange={e => setFieldValue(e.target.value)}
+          onClick={e => e.stopPropagation()}
+        />
+      )}
+
+      <button
+        className="jp-Dialog-button jp-mod-accept jp-mod-styled jp-gis-predicate-add-ok"
+        onClick={handleAdd}
+      >
+        Add
+      </button>
+      <button
+        className="jp-Dialog-button jp-mod-styled jp-gis-predicate-add-cancel"
+        onClick={onCancel}
+      >
+        Cancel
+      </button>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// MappingRow — one triple: field | [scheme ▾ + config] | channel, expandable
+// ---------------------------------------------------------------------------
+
+interface IMappingRowProps {
+  rule: IEncodingRule;
+  fields: string[];
+  featureProperties: Record<string, Set<any>>;
+  isExpanded: boolean;
+  onToggle: () => void;
+  onChange: (rule: IEncodingRule) => void;
+  onDelete: () => void;
+}
+
+const MappingRow: React.FC<IMappingRowProps> = ({
+  rule,
+  fields,
+  featureProperties,
+  isExpanded,
+  onToggle,
+  onChange,
+  onDelete,
+}) => {
+  const [showAddPredicate, setShowAddPredicate] = React.useState(false);
+  const isConstant = rule.scale.scheme === 'constant';
+
+  const handleFieldChange = (field: string) => {
+    onChange({ ...rule, field, scale: defaultScale(field, featureProperties) });
+  };
+
+  const handleChannelChange = (channel: OLStyleChannel) => {
+    onChange({ ...rule, channel });
+  };
+
+  const handleSchemeChange = (scheme: IScale['scheme']) => {
+    const values = featureProperties[rule.field ?? ''] ?? new Set();
+    let scale: IScale;
+    switch (scheme) {
+      case 'colorRamp':
+        scale = defaultColorRampScale(values);
+        break;
+      case 'categorical': {
+        const mapping: Record<string, string> = {};
+        Array.from(values)
+          .slice(0, 20)
+          .forEach((v, i) => {
+            mapping[String(v)] =
+              CATEGORICAL_PALETTE[i % CATEGORICAL_PALETTE.length];
+          });
+        scale = { scheme: 'categorical', mapping, fallback: 'rgba(0,0,0,0)' };
+        break;
+      }
+      case 'scalar':
+        scale = {
+          scheme: 'scalar',
+          domain: computeDomain(values),
+          range: [0, 10],
+          mode: 'equal interval',
+          fallback: 0,
+        };
+        break;
+      case 'constant':
+        scale = { scheme: 'constant', value: '#888888' };
+        break;
+      case 'identity':
+      default:
+        scale = { scheme: 'identity' };
+    }
+    onChange({ ...rule, scale });
+  };
+
+  const handleAddPredicate = (predicate: IPredicate) => {
+    const when = [...(rule.when ?? []), predicate];
+    onChange({ ...rule, when });
+    setShowAddPredicate(false);
+  };
+
+  const handleRemovePredicate = (index: number) => {
+    const when = (rule.when ?? []).filter((_, i) => i !== index);
+    onChange({ ...rule, when: when.length > 0 ? when : undefined });
+  };
+
+  return (
+    <div className={`jp-gis-mapping-row-wrapper${isExpanded ? ' jp-gis-mapping-row-expanded' : ''}`}>
+      {/* Triple header row */}
+      <div
+        className="jp-gis-mapping-row"
+        onClick={onToggle}
+      >
+        {/* Subject: input field (hidden for constant — no field needed) */}
+        {!isConstant && (
+          <div className="jp-select-wrapper">
+            <select
+              className="jp-mod-styled"
+              value={rule.field ?? ''}
+              onClick={e => e.stopPropagation()}
+              onChange={e => handleFieldChange(e.target.value)}
+            >
+              {fields.map(f => (
+                <option key={f} value={f}>
+                  {f}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Verb: scheme selector */}
+        <div className="jp-gis-mapping-verb">
+          {!isConstant && <span className="jp-gis-mapping-arrow">──[</span>}
+          <div className="jp-select-wrapper">
+            <select
+              className="jp-mod-styled"
+              value={rule.scale.scheme}
+              onClick={e => e.stopPropagation()}
+              onChange={e => handleSchemeChange(e.target.value as IScale['scheme'])}
+            >
+              {SCALE_SCHEMES.map(s => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </div>
+          <span className="jp-gis-mapping-arrow">]──▶</span>
+        </div>
+
+        {/* Object: output channel */}
+        <div className="jp-select-wrapper">
+          <select
+            className="jp-mod-styled"
+            value={rule.channel}
+            onClick={e => e.stopPropagation()}
+            onChange={e => handleChannelChange(e.target.value as OLStyleChannel)}
+          >
+            {ALL_CHANNELS.map(c => (
+              <option key={c} value={c}>
+                {CHANNEL_LABELS[c]}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <button
+          className="jp-gis-mapping-delete"
+          title="Remove mapping"
+          onClick={e => {
+            e.stopPropagation();
+            onDelete();
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* When-conditions row */}
+      <div className="jp-gis-when-row" onClick={e => e.stopPropagation()}>
+        {(rule.when ?? []).map((pred, i) => (
+          <PredicateChip
+            key={i}
+            predicate={pred}
+            onRemove={() => handleRemovePredicate(i)}
+          />
+        ))}
+        {!showAddPredicate && (
+          <button
+            className="jp-gis-predicate-add-btn"
+            title="Add condition"
+            onClick={e => {
+              e.stopPropagation();
+              setShowAddPredicate(true);
+            }}
+          >
+            + when
+          </button>
+        )}
+        {showAddPredicate && (
+          <AddPredicateForm
+            fields={fields}
+            onAdd={handleAddPredicate}
+            onCancel={() => setShowAddPredicate(false)}
+          />
+        )}
+      </div>
+
+      {/* Inline method editor — expands below the row */}
+      {isExpanded && (
+        <div className="jp-gis-mapping-editor-inline">
+          <MappingEditor
+            rule={rule}
+            featureProperties={featureProperties}
+            onChange={onChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// MappingTable
+// ---------------------------------------------------------------------------
+
+interface IMappingTableProps {
+  rules: IEncodingRule[];
+  featureProperties: Record<string, Set<any>>;
+  selectedRuleId: string | null;
+  onSelectRule: (id: string) => void;
+  onRulesChange: (rules: IEncodingRule[]) => void;
+}
+
+const MappingTable: React.FC<IMappingTableProps> = ({
+  rules,
+  featureProperties,
+  selectedRuleId,
+  onSelectRule,
+  onRulesChange,
+}) => {
+  const fields = Object.keys(featureProperties);
+
+  const handleAdd = () => {
+    const newRule = createDefaultRule(featureProperties, rules);
+    onRulesChange([...rules, newRule]);
+    onSelectRule(newRule.id);
+  };
+
+  const handleChange = (updated: IEncodingRule) => {
+    onRulesChange(rules.map(r => (r.id === updated.id ? updated : r)));
+  };
+
+  const handleDelete = (id: string) => {
+    const updated = rules.filter(r => r.id !== id);
+    onRulesChange(updated);
+  };
+
+  return (
+    <div className="jp-gis-mapping-table">
+      {rules.length === 0 && (
+        <p className="jp-gis-mapping-empty">
+          No mappings yet. Click &quot;+ Add Mapping&quot; to start.
+        </p>
+      )}
+      {rules.map(rule => (
+        <MappingRow
+          key={rule.id}
+          rule={rule}
+          fields={fields}
+          featureProperties={featureProperties}
+          isExpanded={rule.id === selectedRuleId}
+          onToggle={() =>
+            onSelectRule(rule.id === selectedRuleId ? '' : rule.id)
+          }
+          onChange={handleChange}
+          onDelete={() => handleDelete(rule.id)}
+        />
+      ))}
+      <button
+        className="jp-Dialog-button jp-mod-accept jp-mod-styled jp-gis-mapping-add"
+        onClick={handleAdd}
+        disabled={fields.length === 0}
+      >
+        + Add Mapping
+      </button>
+    </div>
+  );
+};
+
+export default MappingTable;

--- a/packages/base/src/dialogs/symbology/grammar/components/MappingTable.tsx
+++ b/packages/base/src/dialogs/symbology/grammar/components/MappingTable.tsx
@@ -4,10 +4,13 @@ import {
   ALL_CHANNELS,
   CATEGORICAL_PALETTE,
   CHANNEL_LABELS,
+  channelType,
   computeDomain,
   createDefaultRule,
   defaultColorRampScale,
-  defaultScale,
+  defaultScaleForChannel,
+  isSchemeCompatible,
+  scaleOutputType,
 } from '@/src/dialogs/symbology/grammar/grammarUtils';
 import {
   IEncodingRule,
@@ -15,13 +18,156 @@ import {
   IScale,
   OLStyleChannel,
 } from '@/src/dialogs/symbology/grammar/types';
+import { Utils } from '@/src/dialogs/symbology/symbologyUtils';
 import MappingEditor from './MappingEditor';
 
 // ---------------------------------------------------------------------------
-// Scale schemes
+// ScalePreview — compact inline indicator shown in the collapsed row
 // ---------------------------------------------------------------------------
 
-const SCALE_SCHEMES: IScale['scheme'][] = [
+const MODE_ABBR: Record<string, string> = {
+  'equal interval': 'EI',
+  'quantile':       'Q',
+  'jenks':          'J',
+  'pretty':         'P',
+  'logarithmic':    'log',
+};
+
+/** Format a number compactly for the preview label (≤ ~5 chars). */
+function fmtNum(n: number): string {
+  if (!isFinite(n)) {
+    return '?';
+  }
+  return parseFloat(n.toPrecision(3)).toString();
+}
+
+/** Build a CSS linear-gradient string for a colorRamp scale. */
+function buildRampGradientCss(
+  scale: Extract<IScale, { scheme: 'colorRamp' }>,
+): string {
+  if (scale.colorStops && scale.colorStops.length >= 2) {
+    const [dMin, dMax] = scale.domain;
+    const range = dMax - dMin || 1;
+    const stops = scale.colorStops.map(cs => {
+      const pct = ((cs.stop - dMin) / range) * 100;
+      const [r, g, b, a] = cs.color;
+      return `rgba(${r},${g},${b},${a ?? 1}) ${pct.toFixed(1)}%`;
+    });
+    return `linear-gradient(to right, ${stops.join(', ')})`;
+  }
+  // No classified stops yet — generate from ramp name.
+  try {
+    const breaks = Array.from({ length: 9 }, (_, i) => i / 8);
+    const pairs = Utils.getValueColorPairs(
+      breaks,
+      scale.name as any,
+      9,
+      scale.reverse,
+    );
+    const stops = pairs.map((p, i) => {
+      const [r, g, b, a] = p.output as [number, number, number, number];
+      return `rgba(${r},${g},${b},${a ?? 1}) ${((i / (pairs.length - 1)) * 100).toFixed(1)}%`;
+    });
+    return `linear-gradient(to right, ${stops.join(', ')})`;
+  } catch {
+    return 'linear-gradient(to right, #888, #888)';
+  }
+}
+
+interface IScalePreviewProps {
+  scale: IScale;
+  channel: OLStyleChannel;
+}
+
+const ScalePreview: React.FC<IScalePreviewProps> = ({ scale, channel }) => {
+  switch (scale.scheme) {
+    case 'constant': {
+      if (channelType(channel) === 'color') {
+        const color =
+          typeof scale.value === 'string'
+            ? scale.value
+            : Array.isArray(scale.value)
+              ? `rgba(${(scale.value as number[]).join(',')})`
+              : '#888';
+        return (
+          <span
+            className="jp-gis-scale-preview-swatch"
+            style={{ background: color }}
+            title={color}
+          />
+        );
+      }
+      return (
+        <span className="jp-gis-scale-preview-text" title={String(scale.value)}>
+          {scale.value}
+        </span>
+      );
+    }
+    case 'colorRamp': {
+      const gradient = buildRampGradientCss(scale);
+      const abbr = MODE_ABBR[scale.mode] ?? scale.mode;
+      return (
+        <span
+          className="jp-gis-scale-preview-ramp"
+          title={`${scale.name} · ${scale.mode} · [${fmtNum(scale.domain[0])}–${fmtNum(scale.domain[1])}]`}
+        >
+          <span
+            className="jp-gis-scale-preview-ramp-bar"
+            style={{ background: gradient }}
+          />
+          <span className="jp-gis-scale-preview-ramp-label">
+            {fmtNum(scale.domain[0])}–{fmtNum(scale.domain[1])}{' '}
+            <em>{abbr}</em>
+          </span>
+        </span>
+      );
+    }
+    case 'categorical': {
+      const colors = Object.values(scale.mapping).slice(0, 6);
+      const nTotal = Object.keys(scale.mapping).length;
+      return (
+        <span
+          className="jp-gis-scale-preview-categorical"
+          title={`${nTotal} categories`}
+        >
+          {colors.map((c, i) => (
+            <span
+              key={i}
+              className="jp-gis-scale-preview-swatch"
+              style={{ background: c }}
+            />
+          ))}
+          {nTotal > 6 && (
+            <span className="jp-gis-scale-preview-more">+{nTotal - 6}</span>
+          )}
+        </span>
+      );
+    }
+    case 'scalar': {
+      const abbr = MODE_ABBR[scale.mode] ?? scale.mode;
+      return (
+        <span
+          className="jp-gis-scale-preview-text jp-gis-scale-preview-scalar"
+          title={`[${fmtNum(scale.domain[0])}–${fmtNum(scale.domain[1])}] → [${fmtNum(scale.range[0])}–${fmtNum(scale.range[1])}] (${scale.mode})`}
+        >
+          {fmtNum(scale.domain[0])}–{fmtNum(scale.domain[1])}
+          <span className="jp-gis-scale-preview-arrow">→</span>
+          {fmtNum(scale.range[0])}–{fmtNum(scale.range[1])}{' '}
+          <em>{abbr}</em>
+        </span>
+      );
+    }
+    case 'identity':
+    default:
+      return null;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Scale schemes — ordered so color-output schemes come first
+// ---------------------------------------------------------------------------
+
+const ALL_SCHEMES: IScale['scheme'][] = [
   'colorRamp',
   'categorical',
   'scalar',
@@ -29,13 +175,21 @@ const SCALE_SCHEMES: IScale['scheme'][] = [
   'identity',
 ];
 
+const SCHEME_LABELS: Record<IScale['scheme'], string> = {
+  colorRamp:   'color ramp  (number → color)',
+  categorical: 'categorical (value → color)',
+  scalar:      'scalar      (number → number)',
+  constant:    'constant    (fixed value)',
+  identity:    'identity    (pass-through)',
+};
+
 // ---------------------------------------------------------------------------
 // Predicate chip — displays one `when` condition with a remove button
 // ---------------------------------------------------------------------------
 
 interface IPredicateChipProps {
   predicate: IPredicate;
-  onRemove: () => void;
+  onRemove?: () => void;
 }
 
 const PredicateChip: React.FC<IPredicateChipProps> = ({ predicate, onRemove }) => {
@@ -54,16 +208,18 @@ const PredicateChip: React.FC<IPredicateChipProps> = ({ predicate, onRemove }) =
   return (
     <span className="jp-gis-predicate-chip">
       {label}
-      <button
-        className="jp-gis-predicate-remove"
-        title="Remove condition"
-        onClick={e => {
-          e.stopPropagation();
-          onRemove();
-        }}
-      >
-        ×
-      </button>
+      {onRemove && (
+        <button
+          className="jp-gis-predicate-remove"
+          title="Remove condition"
+          onClick={e => {
+            e.stopPropagation();
+            onRemove();
+          }}
+        >
+          ×
+        </button>
+      )}
     </span>
   );
 };
@@ -196,11 +352,25 @@ const MappingRow: React.FC<IMappingRowProps> = ({
   const isConstant = rule.scale.scheme === 'constant';
 
   const handleFieldChange = (field: string) => {
-    onChange({ ...rule, field, scale: defaultScale(field, featureProperties) });
+    // Keep current scheme if compatible with current channel, else reset.
+    const scale = isSchemeCompatible(rule.scale.scheme, rule.channel)
+      ? rule.scale
+      : defaultScaleForChannel(rule.channel, field, featureProperties);
+    onChange({ ...rule, field, scale });
   };
 
   const handleChannelChange = (channel: OLStyleChannel) => {
-    onChange({ ...rule, channel });
+    // If the current scheme is incompatible with the new channel, auto-switch
+    // to the sensible default for that channel.
+    if (!isSchemeCompatible(rule.scale.scheme, channel)) {
+      onChange({
+        ...rule,
+        channel,
+        scale: defaultScaleForChannel(channel, rule.field ?? '', featureProperties),
+      });
+    } else {
+      onChange({ ...rule, channel });
+    }
   };
 
   const handleSchemeChange = (scheme: IScale['scheme']) => {
@@ -227,11 +397,16 @@ const MappingRow: React.FC<IMappingRowProps> = ({
           domain: computeDomain(values),
           range: [0, 10],
           mode: 'equal interval',
+          nStops: 9,
           fallback: 0,
         };
         break;
       case 'constant':
-        scale = { scheme: 'constant', value: '#888888' };
+        // Default constant value depends on channel type.
+        scale = {
+          scheme: 'constant',
+          value: channelType(rule.channel) === 'color' ? '#888888' : 1,
+        };
         break;
       case 'identity':
       default:
@@ -239,6 +414,8 @@ const MappingRow: React.FC<IMappingRowProps> = ({
     }
     onChange({ ...rule, scale });
   };
+
+  const schemeCompatible = isSchemeCompatible(rule.scale.scheme, rule.channel);
 
   const handleAddPredicate = (predicate: IPredicate) => {
     const when = [...(rule.when ?? []), predicate];
@@ -258,42 +435,49 @@ const MappingRow: React.FC<IMappingRowProps> = ({
         className="jp-gis-mapping-row"
         onClick={onToggle}
       >
-        {/* Subject: input field (hidden for constant — no field needed) */}
-        {!isConstant && (
-          <div className="jp-select-wrapper">
-            <select
-              className="jp-mod-styled"
-              value={rule.field ?? ''}
-              onClick={e => e.stopPropagation()}
-              onChange={e => handleFieldChange(e.target.value)}
-            >
-              {fields.map(f => (
-                <option key={f} value={f}>
-                  {f}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
+        {/* Subject: input field (invisible for constant, but keeps layout space) */}
+        <div className="jp-select-wrapper" style={isConstant ? { visibility: 'hidden' } : undefined}>
+          <select
+            className="jp-mod-styled"
+            value={rule.field ?? ''}
+            onClick={e => e.stopPropagation()}
+            onChange={e => handleFieldChange(e.target.value)}
+          >
+            {fields.map(f => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+        </div>
 
         {/* Verb: scheme selector */}
         <div className="jp-gis-mapping-verb">
-          {!isConstant && <span className="jp-gis-mapping-arrow">──[</span>}
-          <div className="jp-select-wrapper">
+          <span className="jp-gis-mapping-arrow" style={isConstant ? { visibility: 'hidden' } : undefined}>──[</span>
+          <div className={`jp-select-wrapper${!schemeCompatible ? ' jp-gis-scheme-mismatch' : ''}`}>
             <select
               className="jp-mod-styled"
               value={rule.scale.scheme}
+              title={!schemeCompatible ? `"${rule.scale.scheme}" outputs ${scaleOutputType(rule.scale.scheme)} but channel expects ${channelType(rule.channel)}` : undefined}
               onClick={e => e.stopPropagation()}
               onChange={e => handleSchemeChange(e.target.value as IScale['scheme'])}
             >
-              {SCALE_SCHEMES.map(s => (
-                <option key={s} value={s}>
-                  {s}
-                </option>
-              ))}
+              {ALL_SCHEMES.map(s => {
+                const compatible = isSchemeCompatible(s, rule.channel);
+                return (
+                  <option key={s} value={s} disabled={false}>
+                    {compatible ? SCHEME_LABELS[s] : `⚠ ${SCHEME_LABELS[s]}`}
+                  </option>
+                );
+              })}
             </select>
           </div>
           <span className="jp-gis-mapping-arrow">]──▶</span>
+        </div>
+
+        {/* Preview indicator */}
+        <div className="jp-gis-scale-preview-container">
+          <ScalePreview scale={rule.scale} channel={rule.channel} />
         </div>
 
         {/* Object: output channel */}
@@ -324,35 +508,37 @@ const MappingRow: React.FC<IMappingRowProps> = ({
         </button>
       </div>
 
-      {/* When-conditions row */}
-      <div className="jp-gis-when-row" onClick={e => e.stopPropagation()}>
-        {(rule.when ?? []).map((pred, i) => (
-          <PredicateChip
-            key={i}
-            predicate={pred}
-            onRemove={() => handleRemovePredicate(i)}
-          />
-        ))}
-        {!showAddPredicate && (
-          <button
-            className="jp-gis-predicate-add-btn"
-            title="Add condition"
-            onClick={e => {
-              e.stopPropagation();
-              setShowAddPredicate(true);
-            }}
-          >
-            + when
-          </button>
-        )}
-        {showAddPredicate && (
-          <AddPredicateForm
-            fields={fields}
-            onAdd={handleAddPredicate}
-            onCancel={() => setShowAddPredicate(false)}
-          />
-        )}
-      </div>
+      {/* When-conditions row — hidden when empty and collapsed */}
+      {((rule.when ?? []).length > 0 || isExpanded) && (
+        <div className="jp-gis-when-row" onClick={e => e.stopPropagation()}>
+          {(rule.when ?? []).map((pred, i) => (
+            <PredicateChip
+              key={i}
+              predicate={pred}
+              onRemove={isExpanded ? () => handleRemovePredicate(i) : undefined}
+            />
+          ))}
+          {isExpanded && !showAddPredicate && (
+            <button
+              className="jp-gis-predicate-add-btn"
+              title="Add condition"
+              onClick={e => {
+                e.stopPropagation();
+                setShowAddPredicate(true);
+              }}
+            >
+              + when
+            </button>
+          )}
+          {isExpanded && showAddPredicate && (
+            <AddPredicateForm
+              fields={fields}
+              onAdd={handleAddPredicate}
+              onCancel={() => setShowAddPredicate(false)}
+            />
+          )}
+        </div>
+      )}
 
       {/* Inline method editor — expands below the row */}
       {isExpanded && (

--- a/packages/base/src/dialogs/symbology/grammar/grammarConversions.ts
+++ b/packages/base/src/dialogs/symbology/grammar/grammarConversions.ts
@@ -1,0 +1,325 @@
+/**
+ * Conversions between Grammar rules and the other render-type states.
+ *
+ * Direction A (any → Grammar): called when the user switches TO Grammar.
+ * Direction B (Grammar → other): called when the user switches FROM Grammar.
+ */
+
+import { UUID } from '@lumino/coreutils';
+
+import { IColorRampScale, IEncodingRule, IGrammarSymbologyState, OLStyleChannel } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers: parse compiled OL expressions back to stop arrays
+// ---------------------------------------------------------------------------
+
+function extractInterpolateExpr(expr: any): any[] | null {
+  if (!Array.isArray(expr)) {
+    return null;
+  }
+  // New format: ['case', ['has', field], interpolateExpr, fallback]
+  if (expr[0] === 'case' && expr.length >= 3) {
+    expr = expr[2];
+  }
+  if (Array.isArray(expr) && expr[0] === 'interpolate') {
+    return expr;
+  }
+  return null;
+}
+
+function extractColorStops(
+  expr: any,
+): Array<{ stop: number; color: [number, number, number, number] }> {
+  const interp = extractInterpolateExpr(expr);
+  if (!interp) {
+    return [];
+  }
+  const stops: Array<{ stop: number; color: [number, number, number, number] }> = [];
+  for (let i = 3; i < interp.length - 1; i += 2) {
+    const stop = interp[i];
+    const color = interp[i + 1];
+    if (typeof stop === 'number' && Array.isArray(color)) {
+      stops.push({
+        stop,
+        color: [color[0], color[1], color[2], color[3] ?? 1] as [number, number, number, number],
+      });
+    }
+  }
+  return stops;
+}
+
+function extractScalarStops(
+  expr: any,
+): Array<{ stop: number; output: number }> {
+  const interp = extractInterpolateExpr(expr);
+  if (!interp) {
+    return [];
+  }
+  const stops: Array<{ stop: number; output: number }> = [];
+  for (let i = 3; i < interp.length - 1; i += 2) {
+    const stop = interp[i];
+    const output = interp[i + 1];
+    if (typeof stop === 'number' && typeof output === 'number') {
+      stops.push({ stop, output });
+    }
+  }
+  return stops;
+}
+
+function colorArrayToCss(c: any): string {
+  if (typeof c === 'string') {
+    return c;
+  }
+  if (Array.isArray(c) && c.length >= 3) {
+    return `rgba(${c[0]},${c[1]},${c[2]},${c[3] ?? 1})`;
+  }
+  return 'rgba(0,0,0,0)';
+}
+
+// ---------------------------------------------------------------------------
+// Direction A: any render type → Grammar rules
+// ---------------------------------------------------------------------------
+
+export function graduatedToGrammarRules(
+  symbologyState: any,
+  color: Record<string, any>,
+): IEncodingRule[] {
+  const field = symbologyState?.value;
+  if (!field) {
+    return [];
+  }
+
+  const fillExpr = color?.['fill-color'];
+  const colorStops = extractColorStops(fillExpr);
+
+  const domain: [number, number] =
+    colorStops.length >= 2
+      ? [colorStops[0].stop, colorStops[colorStops.length - 1].stop]
+      : [symbologyState?.vmin ?? 0, symbologyState?.vmax ?? 1];
+
+  const baseScale: IColorRampScale = {
+    scheme: 'colorRamp',
+    name: symbologyState?.colorRamp ?? 'viridis',
+    domain,
+    nShades: symbologyState?.nClasses ?? 9,
+    mode: symbologyState?.mode ?? 'equal interval',
+    reverse: symbologyState?.reverseRamp ?? false,
+    fallback: symbologyState?.fallbackColor ?? [0, 0, 0, 0],
+    colorStops: colorStops.length >= 2 ? colorStops : undefined,
+  };
+
+  const rules: IEncodingRule[] = [
+    {
+      id: UUID.uuid4(),
+      field,
+      channel: 'fill-color',
+      scale: { ...baseScale },
+    },
+    {
+      id: UUID.uuid4(),
+      field,
+      channel: 'circle-fill-color',
+      scale: { ...baseScale },
+    },
+  ];
+
+  const radiusExpr = color?.['circle-radius'];
+  const scalarStops = extractScalarStops(radiusExpr);
+  if (scalarStops.length >= 2) {
+    rules.push({
+      id: UUID.uuid4(),
+      field,
+      channel: 'circle-radius',
+      scale: {
+        scheme: 'scalar',
+        domain: [scalarStops[0].stop, scalarStops[scalarStops.length - 1].stop],
+        range: [scalarStops[0].output, scalarStops[scalarStops.length - 1].output],
+        mode: symbologyState?.mode ?? 'equal interval',
+        nStops: symbologyState?.nClasses ?? 9,
+        fallback: 0,
+        scalarStops,
+      },
+    });
+  }
+
+  return rules;
+}
+
+export function categorizedToGrammarRules(
+  symbologyState: any,
+  color: Record<string, any>,
+): IEncodingRule[] {
+  const field = symbologyState?.value;
+  if (!field) {
+    return [];
+  }
+
+  const fillExpr = color?.['fill-color'];
+  const mapping: Record<string, string> = {};
+  let fallback = 'rgba(0,0,0,0)';
+
+  if (Array.isArray(fillExpr) && fillExpr[0] === 'case') {
+    for (let i = 1; i < fillExpr.length - 1; i += 2) {
+      const cond = fillExpr[i];
+      const colorVal = fillExpr[i + 1];
+      if (
+        Array.isArray(cond) &&
+        cond[0] === '==' &&
+        Array.isArray(cond[1]) &&
+        cond[1][0] === 'get'
+      ) {
+        mapping[String(cond[2])] = colorArrayToCss(colorVal);
+      }
+    }
+    fallback = colorArrayToCss(fillExpr[fillExpr.length - 1]);
+  }
+
+  return [
+    {
+      id: UUID.uuid4(),
+      field,
+      channel: 'fill-color',
+      scale: { scheme: 'categorical', mapping, fallback },
+    },
+    {
+      id: UUID.uuid4(),
+      field,
+      channel: 'circle-fill-color',
+      scale: { scheme: 'categorical', mapping, fallback },
+    },
+  ];
+}
+
+export function singleSymbolToGrammarRules(
+  color: Record<string, any>,
+): IEncodingRule[] {
+  if (!color) {
+    return [];
+  }
+  const rules: IEncodingRule[] = [];
+  const COLOR_CH: OLStyleChannel[] = ['fill-color', 'stroke-color', 'circle-fill-color', 'circle-stroke-color'];
+  const NUM_CH: OLStyleChannel[] = ['stroke-width', 'circle-radius', 'circle-stroke-width'];
+
+  for (const ch of COLOR_CH) {
+    const val = color[ch];
+    if (val !== undefined) {
+      rules.push({
+        id: UUID.uuid4(),
+        channel: ch,
+        scale: { scheme: 'constant', value: colorArrayToCss(val) },
+      });
+    }
+  }
+  for (const ch of NUM_CH) {
+    const val = color[ch];
+    if (typeof val === 'number') {
+      rules.push({
+        id: UUID.uuid4(),
+        channel: ch,
+        scale: { scheme: 'constant', value: val },
+      });
+    }
+  }
+  return rules;
+}
+
+/**
+ * Convert any non-Grammar symbologyState → Grammar rules.
+ * Returns null if the state is already Grammar or conversion is not possible.
+ */
+export function anyStateToGrammarRules(
+  symbologyState: any,
+  color: Record<string, any>,
+): IEncodingRule[] | null {
+  switch (symbologyState?.renderType) {
+    case 'Graduated':
+      return graduatedToGrammarRules(symbologyState, color);
+    case 'Categorized':
+      return categorizedToGrammarRules(symbologyState, color);
+    case 'Single Symbol':
+      return singleSymbolToGrammarRules(color ?? {});
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Direction B: Grammar rules → other render-type state seeds
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract Graduated-compatible state from Grammar rules.
+ * Returns partial overrides for symbologyState; caller merges with existing.
+ */
+export function grammarRulesToGraduatedSeed(
+  grammarState: IGrammarSymbologyState,
+): Partial<Record<string, any>> {
+  const colorRule = grammarState.rules.find(
+    r =>
+      (r.channel === 'fill-color' || r.channel === 'circle-fill-color') &&
+      r.scale.scheme === 'colorRamp',
+  );
+  const radiusRule = grammarState.rules.find(
+    r => r.channel === 'circle-radius' && r.scale.scheme === 'scalar',
+  );
+
+  if (!colorRule && !radiusRule) {
+    return {};
+  }
+
+  const seed: Record<string, any> = {};
+
+  if (colorRule && colorRule.scale.scheme === 'colorRamp') {
+    const s = colorRule.scale;
+    seed.value = colorRule.field;
+    seed.colorRamp = s.name;
+    seed.nClasses = s.nShades;
+    seed.mode = s.mode;
+    seed.reverseRamp = s.reverse;
+    seed.vmin = s.domain[0];
+    seed.vmax = s.domain[1];
+    seed.fallbackColor = s.fallback;
+  } else if (radiusRule && radiusRule.scale.scheme === 'scalar') {
+    const s = radiusRule.scale;
+    seed.value = radiusRule.field;
+    seed.mode = s.mode;
+    seed.vmin = s.domain[0];
+    seed.vmax = s.domain[1];
+    seed.method = 'radius';
+  }
+
+  return seed;
+}
+
+/**
+ * Extract Categorized-compatible state from Grammar rules.
+ */
+export function grammarRulesToCategorizedSeed(
+  grammarState: IGrammarSymbologyState,
+): Partial<Record<string, any>> {
+  const catRule = grammarState.rules.find(
+    r =>
+      (r.channel === 'fill-color' || r.channel === 'circle-fill-color') &&
+      r.scale.scheme === 'categorical',
+  );
+  if (!catRule || catRule.scale.scheme !== 'categorical') {
+    return {};
+  }
+  return { value: catRule.field };
+}
+
+/**
+ * Pick the best reverse-conversion target based on Grammar rule types present.
+ */
+export function grammarToSuggestedRenderType(
+  grammarState: IGrammarSymbologyState,
+): 'Graduated' | 'Categorized' | 'Single Symbol' {
+  const schemes = grammarState.rules.map(r => r.scale.scheme);
+  if (schemes.includes('colorRamp') || schemes.includes('scalar')) {
+    return 'Graduated';
+  }
+  if (schemes.includes('categorical')) {
+    return 'Categorized';
+  }
+  return 'Single Symbol';
+}

--- a/packages/base/src/dialogs/symbology/grammar/grammarToOLStyle.ts
+++ b/packages/base/src/dialogs/symbology/grammar/grammarToOLStyle.ts
@@ -37,32 +37,63 @@ export function grammarToOLStyle(
 ): Record<string, any> {
   const style: Record<string, any> = { ...(state.baseStyle ?? {}) };
 
+  // Group rules by channel so we can merge multiple rules on the same channel
+  // into a single `case` chain rather than silently overwriting.
+  const byChannel = new Map<OLStyleChannel, IEncodingRule[]>();
   for (const rule of state.rules) {
-    style[rule.channel] = compileRule(rule);
+    if (!byChannel.has(rule.channel)) {
+      byChannel.set(rule.channel, []);
+    }
+    byChannel.get(rule.channel)!.push(rule);
+  }
+
+  for (const [channel, rules] of byChannel) {
+    style[channel] = compileChannelRules(rules, channel, state.fallback?.[channel]);
   }
 
   return style;
 }
 
-// ---------------------------------------------------------------------------
-// Rule compilation
-// ---------------------------------------------------------------------------
+/**
+ * Compile all rules targeting the same channel into a single OL expression.
+ *
+ * Rules with `when` predicates form the branches of a `case` expression.
+ * The last unconditional rule (no `when`) — if any — is the default branch.
+ * Remaining unconditional rules earlier in the list are ignored (last wins).
+ */
+function compileChannelRules(
+  rules: IEncodingRule[],
+  channel: OLStyleChannel,
+  fallbackValue?: any,
+): ExpressionValue {
+  const conditional = rules.filter(r => r.when && r.when.length > 0);
+  const unconditional = rules.filter(r => !r.when || r.when.length === 0);
 
-function compileRule(rule: IEncodingRule): ExpressionValue {
-  const expr = compileScale(rule.field, rule.scale);
+  // Last unconditional rule wins; otherwise use explicit fallback or transparent zero.
+  const baseRule = unconditional[unconditional.length - 1];
+  const baseExpr: ExpressionValue = baseRule
+    ? compileScale(baseRule.field, baseRule.scale)
+    : (fallbackValue ?? channelFallback(channel));
 
-  if (!rule.when || rule.when.length === 0) {
-    return expr;
+  if (conditional.length === 0) {
+    return baseExpr;
   }
 
-  // Compile each predicate and AND them together.
-  const conditions = rule.when.map(compilePredicate);
-  const guard: ExpressionValue =
-    conditions.length === 1 ? conditions[0] : ['all', ...conditions];
-
-  // Features that don't match fall through to a typed zero-value for the channel.
-  return ['case', guard, expr, channelFallback(rule.channel)];
+  // Build ['case', cond1, expr1, cond2, expr2, ..., baseExpr]
+  const caseExpr: ExpressionValue[] = ['case'];
+  for (const rule of conditional) {
+    const conditions = rule.when!.map(compilePredicate);
+    const guard: ExpressionValue =
+      conditions.length === 1 ? conditions[0] : ['all', ...conditions];
+    caseExpr.push(guard, compileScale(rule.field, rule.scale));
+  }
+  caseExpr.push(baseExpr);
+  return caseExpr;
 }
+
+// ---------------------------------------------------------------------------
+// Predicate compilation
+// ---------------------------------------------------------------------------
 
 function compilePredicate(predicate: IPredicate): ExpressionValue {
   switch (predicate.type) {

--- a/packages/base/src/dialogs/symbology/grammar/grammarToOLStyle.ts
+++ b/packages/base/src/dialogs/symbology/grammar/grammarToOLStyle.ts
@@ -1,0 +1,206 @@
+/**
+ * Grammar → OL FlatStyle compiler.
+ *
+ * grammarToOLStyle(state) takes an IGrammarSymbologyState and returns a merged
+ * OL FlatStyle object ready to be stored in layer.parameters.color.
+ *
+ * Each rule produces one OL expression for rule.channel.  When a rule has
+ * `when` predicates they are compiled to OL conditions and the expression is
+ * wrapped in a `['case', ...]` guard.
+ */
+
+import colormap from 'colormap';
+import { ExpressionValue } from 'ol/expr/expression';
+
+import { IEncodingRule, IGrammarSymbologyState, IPredicate, IScale, OLStyleChannel } from './types';
+
+const COLOR_CHANNELS = new Set<OLStyleChannel>([
+  'fill-color', 'stroke-color', 'circle-fill-color', 'circle-stroke-color',
+]);
+
+/** Convert an RGBA quad to a CSS color string safe for use in OL case expressions. */
+function rgbaToCss(c: [number, number, number, number]): string {
+  return `rgba(${c[0]},${c[1]},${c[2]},${c[3]})`;
+}
+
+/** Typed zero-value fallback for channels not matched by a guard. */
+function channelFallback(channel: OLStyleChannel): ExpressionValue {
+  return COLOR_CHANNELS.has(channel) ? 'rgba(0,0,0,0)' : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function grammarToOLStyle(
+  state: IGrammarSymbologyState,
+): Record<string, any> {
+  const style: Record<string, any> = { ...(state.baseStyle ?? {}) };
+
+  for (const rule of state.rules) {
+    style[rule.channel] = compileRule(rule);
+  }
+
+  return style;
+}
+
+// ---------------------------------------------------------------------------
+// Rule compilation
+// ---------------------------------------------------------------------------
+
+function compileRule(rule: IEncodingRule): ExpressionValue {
+  const expr = compileScale(rule.field, rule.scale);
+
+  if (!rule.when || rule.when.length === 0) {
+    return expr;
+  }
+
+  // Compile each predicate and AND them together.
+  const conditions = rule.when.map(compilePredicate);
+  const guard: ExpressionValue =
+    conditions.length === 1 ? conditions[0] : ['all', ...conditions];
+
+  // Features that don't match fall through to a typed zero-value for the channel.
+  return ['case', guard, expr, channelFallback(rule.channel)];
+}
+
+function compilePredicate(predicate: IPredicate): ExpressionValue {
+  switch (predicate.type) {
+    case 'geometryType':
+      return ['==', ['geometry-type'], olGeomType(predicate.value)];
+    case 'hasField':
+      return ['has', predicate.field];
+    case 'fieldEquals':
+      return ['==', ['get', predicate.field], predicate.value];
+  }
+}
+
+function olGeomType(value: 'point' | 'line' | 'polygon'): string {
+  const map: Record<string, string> = {
+    point: 'Point',
+    line: 'LineString',
+    polygon: 'Polygon',
+  };
+  return map[value];
+}
+
+function compileScale(field: string | undefined, scale: IScale): ExpressionValue {
+  switch (scale.scheme) {
+    case 'colorRamp':
+      return compileColorRamp(field!, scale);
+    case 'categorical':
+      return compileCategorical(field!, scale);
+    case 'scalar':
+      return compileScalar(field!, scale);
+    case 'constant':
+      return scale.value;
+    case 'identity':
+      return ['get', field!];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scale compilers
+// ---------------------------------------------------------------------------
+
+/**
+ * colorRamp: numeric field → color via a named palette.
+ *
+ * Produces:
+ *   ['case', ['has', field],
+ *     ['interpolate', ['linear'], ['get', field], stop0, color0, ...],
+ *     fallback]
+ */
+function compileColorRamp(
+  field: string,
+  scale: Extract<IScale, { scheme: 'colorRamp' }>,
+): ExpressionValue {
+  let colors: number[][] = colormap({
+    colormap: scale.name,
+    nshades: Math.max(scale.nShades, 9),
+    format: 'rgba',
+  });
+
+  if (scale.reverse) {
+    colors = [...colors].reverse();
+  }
+
+  const interpolateExpr: ExpressionValue[] = [
+    'interpolate',
+    ['linear'],
+    ['get', field],
+  ];
+
+  if (scale.colorStops && scale.colorStops.length >= 2) {
+    scale.colorStops.forEach(({ stop, color }) => {
+      interpolateExpr.push(stop, color);
+    });
+  } else {
+    // Evenly-spaced stops across the domain from the ramp.
+    const n = scale.nShades;
+    for (let i = 0; i < n; i++) {
+      const t = n === 1 ? 0 : i / (n - 1);
+      const stopValue = scale.domain[0] + t * (scale.domain[1] - scale.domain[0]);
+      const colorIndex = Math.round(t * (colors.length - 1));
+      interpolateExpr.push(stopValue, colors[colorIndex]);
+    }
+  }
+
+  // Use a CSS string for the fallback — OL's CPU evaluator cannot parse a
+  // bare [r,g,b,a] array as a color-like expression inside a `case` branch.
+  return ['case', ['has', field], interpolateExpr, rgbaToCss(scale.fallback)];
+}
+
+/**
+ * categorical: nominal field → color via an explicit value→color mapping.
+ *
+ * Produces:
+ *   ['case',
+ *     ['==', ['get', field], val0], color0, ...
+ *     fallback]
+ */
+function compileCategorical(
+  field: string,
+  scale: Extract<IScale, { scheme: 'categorical' }>,
+): ExpressionValue {
+  const caseExpr: ExpressionValue[] = ['case'];
+
+  for (const [value, color] of Object.entries(scale.mapping)) {
+    caseExpr.push(['==', ['get', field], value], color);
+  }
+
+  caseExpr.push(scale.fallback);
+  return caseExpr;
+}
+
+/**
+ * scalar: numeric field → numeric output (e.g. radius, stroke-width).
+ *
+ * Produces:
+ *   ['case', ['has', field],
+ *     ['interpolate', ['linear'], ['get', field], stop0, out0, ...],
+ *     fallback]
+ */
+function compileScalar(
+  field: string,
+  scale: Extract<IScale, { scheme: 'scalar' }>,
+): ExpressionValue {
+  const interpolateExpr: ExpressionValue[] = [
+    'interpolate',
+    ['linear'],
+    ['get', field],
+  ];
+
+  if (scale.scalarStops && scale.scalarStops.length >= 2) {
+    scale.scalarStops.forEach(({ stop, output }) => {
+      interpolateExpr.push(stop, output);
+    });
+  } else {
+    interpolateExpr.push(
+      scale.domain[0], scale.range[0],
+      scale.domain[1], scale.range[1],
+    );
+  }
+
+  return ['case', ['has', field], interpolateExpr, scale.fallback];
+}

--- a/packages/base/src/dialogs/symbology/grammar/grammarUtils.ts
+++ b/packages/base/src/dialogs/symbology/grammar/grammarUtils.ts
@@ -1,0 +1,118 @@
+import { UUID } from '@lumino/coreutils';
+
+import { FieldType, IColorRampScale, IEncodingRule, IScale, OLStyleChannel } from './types';
+
+export const COLOR_CHANNELS: OLStyleChannel[] = [
+  'fill-color',
+  'stroke-color',
+  'circle-fill-color',
+  'circle-stroke-color',
+];
+
+export const ALL_CHANNELS: OLStyleChannel[] = [
+  ...COLOR_CHANNELS,
+  'stroke-width',
+  'circle-radius',
+  'circle-stroke-width',
+];
+
+export const CHANNEL_LABELS: Record<OLStyleChannel, string> = {
+  'fill-color': 'Fill Color',
+  'stroke-color': 'Stroke Color',
+  'circle-fill-color': 'Marker Fill',
+  'circle-stroke-color': 'Marker Stroke',
+  'stroke-width': 'Stroke Width',
+  'circle-radius': 'Marker Size',
+  'circle-stroke-width': 'Marker Stroke Width',
+};
+
+/** Colors from ColorBrewer Set1, used for auto-assigning categorical values. */
+export const CATEGORICAL_PALETTE = [
+  '#e41a1c',
+  '#377eb8',
+  '#4daf4a',
+  '#984ea3',
+  '#ff7f00',
+  '#a65628',
+  '#f781bf',
+  '#999999',
+  '#ffff33',
+];
+
+export function inferFieldType(values: Set<any>): FieldType {
+  const arr = Array.from(values).filter(v => v !== null && v !== undefined);
+  if (arr.length === 0) {
+    return 'nominal';
+  }
+  const numericCount = arr.filter(
+    v => typeof v === 'number' && isFinite(v),
+  ).length;
+  return numericCount > arr.length / 2 ? 'quantitative' : 'nominal';
+}
+
+export function computeDomain(values: Set<any>): [number, number] {
+  const nums = Array.from(values)
+    .map(v => (typeof v === 'number' ? v : parseFloat(String(v))))
+    .filter(v => isFinite(v));
+  if (nums.length === 0) {
+    return [0, 1];
+  }
+  return [Math.min(...nums), Math.max(...nums)];
+}
+
+export function defaultColorRampScale(
+  values: Set<any>,
+): IColorRampScale {
+  return {
+    scheme: 'colorRamp',
+    name: 'viridis',
+    domain: computeDomain(values),
+    nShades: 9,
+    mode: 'equal interval',
+    reverse: false,
+    fallback: [0, 0, 0, 0],
+  };
+}
+
+export function defaultScale(
+  field: string,
+  featureProperties: Record<string, Set<any>>,
+): IScale {
+  const values = featureProperties[field] ?? new Set();
+  const fieldType = inferFieldType(values);
+
+  if (fieldType === 'quantitative') {
+    return defaultColorRampScale(values);
+  }
+
+  // nominal/ordinal: build categorical mapping with auto-assigned colors
+  const mapping: Record<string, string> = {};
+  Array.from(values)
+    .slice(0, 20)
+    .forEach((v, i) => {
+      mapping[String(v)] = CATEGORICAL_PALETTE[i % CATEGORICAL_PALETTE.length];
+    });
+  return {
+    scheme: 'categorical',
+    mapping,
+    fallback: 'rgba(0,0,0,0)',
+  };
+}
+
+export function createDefaultRule(
+  featureProperties: Record<string, Set<any>>,
+  existingRules: IEncodingRule[],
+): IEncodingRule {
+  const fields = Object.keys(featureProperties);
+  const field = fields[0] ?? '';
+  const usedChannels = new Set(existingRules.map(r => r.channel));
+  const channel =
+    COLOR_CHANNELS.find(c => !usedChannels.has(c)) ?? 'fill-color';
+
+  return {
+    id: UUID.uuid4(),
+    field,
+    channel,
+    scale: defaultScale(field, featureProperties),
+  };
+}

--- a/packages/base/src/dialogs/symbology/grammar/grammarUtils.ts
+++ b/packages/base/src/dialogs/symbology/grammar/grammarUtils.ts
@@ -2,6 +2,10 @@ import { UUID } from '@lumino/coreutils';
 
 import { FieldType, IColorRampScale, IEncodingRule, IScale, OLStyleChannel } from './types';
 
+// ---------------------------------------------------------------------------
+// Channel groups
+// ---------------------------------------------------------------------------
+
 export const COLOR_CHANNELS: OLStyleChannel[] = [
   'fill-color',
   'stroke-color',
@@ -9,11 +13,15 @@ export const COLOR_CHANNELS: OLStyleChannel[] = [
   'circle-stroke-color',
 ];
 
-export const ALL_CHANNELS: OLStyleChannel[] = [
-  ...COLOR_CHANNELS,
+export const NUMERIC_CHANNELS: OLStyleChannel[] = [
   'stroke-width',
   'circle-radius',
   'circle-stroke-width',
+];
+
+export const ALL_CHANNELS: OLStyleChannel[] = [
+  ...COLOR_CHANNELS,
+  ...NUMERIC_CHANNELS,
 ];
 
 export const CHANNEL_LABELS: Record<OLStyleChannel, string> = {
@@ -25,6 +33,61 @@ export const CHANNEL_LABELS: Record<OLStyleChannel, string> = {
   'circle-radius': 'Marker Size',
   'circle-stroke-width': 'Marker Stroke Width',
 };
+
+// ---------------------------------------------------------------------------
+// Type system: input / output types for scales and channels
+// ---------------------------------------------------------------------------
+
+/**
+ * The value type a channel expects to receive.
+ *   color  → fill-color, stroke-color, circle-fill-color, circle-stroke-color
+ *   number → stroke-width, circle-radius, circle-stroke-width
+ */
+export type ChannelValueType = 'color' | 'number';
+
+/**
+ * The value type a scale produces.
+ *   color  → colorRamp, categorical
+ *   number → scalar
+ *   any    → constant (depends on user-supplied value), identity (pass-through)
+ */
+export type ScaleOutputType = 'color' | 'number' | 'any';
+
+export function channelType(channel: OLStyleChannel): ChannelValueType {
+  return (COLOR_CHANNELS as OLStyleChannel[]).includes(channel) ? 'color' : 'number';
+}
+
+export function scaleOutputType(scheme: IScale['scheme']): ScaleOutputType {
+  switch (scheme) {
+    case 'colorRamp':
+    case 'categorical':
+      return 'color';
+    case 'scalar':
+      return 'number';
+    case 'constant':
+    case 'identity':
+      return 'any';
+  }
+}
+
+/**
+ * Returns true when the scale's output type is compatible with the channel.
+ * 'any' scales (constant, identity) are always compatible.
+ */
+export function isSchemeCompatible(
+  scheme: IScale['scheme'],
+  channel: OLStyleChannel,
+): boolean {
+  const out = scaleOutputType(scheme);
+  if (out === 'any') {
+    return true;
+  }
+  return out === channelType(channel);
+}
+
+// ---------------------------------------------------------------------------
+// Categorical palette
+// ---------------------------------------------------------------------------
 
 /** Colors from ColorBrewer Set1, used for auto-assigning categorical values. */
 export const CATEGORICAL_PALETTE = [
@@ -38,6 +101,10 @@ export const CATEGORICAL_PALETTE = [
   '#999999',
   '#ffff33',
 ];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 export function inferFieldType(values: Set<any>): FieldType {
   const arr = Array.from(values).filter(v => v !== null && v !== undefined);
@@ -60,9 +127,7 @@ export function computeDomain(values: Set<any>): [number, number] {
   return [Math.min(...nums), Math.max(...nums)];
 }
 
-export function defaultColorRampScale(
-  values: Set<any>,
-): IColorRampScale {
+export function defaultColorRampScale(values: Set<any>): IColorRampScale {
   return {
     scheme: 'colorRamp',
     name: 'viridis',
@@ -72,6 +137,25 @@ export function defaultColorRampScale(
     reverse: false,
     fallback: [0, 0, 0, 0],
   };
+}
+
+export function defaultScaleForChannel(
+  channel: OLStyleChannel,
+  field: string,
+  featureProperties: Record<string, Set<any>>,
+): IScale {
+  if (channelType(channel) === 'number') {
+    const values = featureProperties[field] ?? new Set();
+    return {
+      scheme: 'scalar',
+      domain: computeDomain(values),
+      range: [0, 10],
+      mode: 'equal interval',
+      nStops: 9,
+      fallback: 0,
+    };
+  }
+  return defaultScale(field, featureProperties);
 }
 
 export function defaultScale(
@@ -113,6 +197,6 @@ export function createDefaultRule(
     id: UUID.uuid4(),
     field,
     channel,
-    scale: defaultScale(field, featureProperties),
+    scale: defaultScaleForChannel(channel, field, featureProperties),
   };
 }

--- a/packages/base/src/dialogs/symbology/grammar/types.ts
+++ b/packages/base/src/dialogs/symbology/grammar/types.ts
@@ -89,6 +89,7 @@ export interface IScalarScale {
   domain: [number, number]; // always explicit; set from data on rule creation
   range: [number, number];  // output range in channel units (e.g. px)
   mode: ClassificationMode; // default: 'equal interval'
+  nStops: number;           // default: 9
   fallback: number;         // default: 0
   scalarStops?: Array<{ stop: number; output: number }>;
 }
@@ -155,11 +156,16 @@ export interface IEncodingRule {
 
 export interface IGrammarSymbologyState {
   renderType: 'Grammar';
-  /** Ordered list of encoding rules. Compiled in order; last rule wins on channel conflicts. */
+  /** Ordered list of encoding rules. Compiled in order; conditional rules chain into a case expression. */
   rules: IEncodingRule[];
   /**
-   * Fallback OL FlatStyle for channels not covered by any rule.
-   * Optional: defaults to {} at runtime. Not persisted to avoid schema conflicts.
+   * Per-channel fallback values: used as the final `else` branch in the compiled case chain
+   * when no unconditional rule covers a channel.  Exposed in the UI as a "Fallback Style" section.
+   */
+  fallback?: Partial<Record<OLStyleChannel, any>>;
+  /**
+   * Extra OL FlatStyle properties merged into the output *before* compiled rules.
+   * Optional: not persisted to avoid schema conflicts.
    */
   baseStyle?: Record<string, any>;
 }

--- a/packages/base/src/dialogs/symbology/grammar/types.ts
+++ b/packages/base/src/dialogs/symbology/grammar/types.ts
@@ -1,0 +1,165 @@
+/**
+ * Grammar Symbology types.
+ *
+ * An IEncodingRule maps one feature attribute (field) to one OL style channel
+ * via a scale, optionally guarded by a list of predicates (when).
+ *
+ * Composition model (inspired by functional programming):
+ *
+ *   rule  = encode(field, scale) | constant(value)
+ *   guard = when(predicates[], rule)          -- predicates are AND-ed
+ *
+ * The compiler emits:
+ *   no conditions  → scale expression directly
+ *   with conditions → ['case', ['all', ...conditions], scaleExpr, channelFallback]
+ */
+
+export type ClassificationMode =
+  | 'quantile'
+  | 'equal interval'
+  | 'jenks'
+  | 'pretty'
+  | 'logarithmic';
+
+// ---------------------------------------------------------------------------
+// Predicates — composable guards on rules
+// ---------------------------------------------------------------------------
+
+export type IPredicate =
+  | { type: 'geometryType'; value: 'point' | 'line' | 'polygon' }
+  | { type: 'hasField'; field: string }
+  | { type: 'fieldEquals'; field: string; value: string | number };
+
+// ---------------------------------------------------------------------------
+// Channels
+// ---------------------------------------------------------------------------
+
+/** OL FlatStyle properties that Grammar rules may target. */
+export type OLStyleChannel =
+  | 'fill-color'
+  | 'stroke-color'
+  | 'stroke-width'
+  | 'circle-fill-color'
+  | 'circle-stroke-color'
+  | 'circle-stroke-width'
+  | 'circle-radius';
+
+/**
+ * The semantic type of the input field.
+ * Optional: if absent, the compiler infers it from the scale scheme
+ * (colorRamp/scalar → quantitative; categorical → nominal).
+ * Can be set explicitly to treat e.g. a numeric ID as nominal.
+ */
+export type FieldType = 'quantitative' | 'ordinal' | 'nominal';
+
+// ---------------------------------------------------------------------------
+// Scales — explicit defaults, no implicit fallbacks in the compiler
+// ---------------------------------------------------------------------------
+
+/**
+ * colorRamp: number → RGBA color via a named palette.
+ * All fields have explicit defaults; nothing is left implicit.
+ */
+export interface IColorRampScale {
+  scheme: 'colorRamp';
+  name: string;            // default: 'viridis'
+  domain: [number, number]; // always explicit; set from data on rule creation
+  nShades: number;         // default: 9
+  mode: ClassificationMode; // default: 'equal interval'
+  reverse: boolean;        // default: false
+  fallback: [number, number, number, number]; // default: [0,0,0,0]
+  colorStops?: Array<{ stop: number; color: [number, number, number, number] }>;
+}
+
+/**
+ * categorical: any field value → explicit color or number mapping.
+ */
+export interface ICategoricalScale {
+  scheme: 'categorical';
+  mapping: Record<string, string>; // value → hex/rgba color string
+  fallback: string;                // default: 'rgba(0,0,0,0)'
+}
+
+/**
+ * scalar: number → number (e.g. circle-radius, stroke-width).
+ * Supports the same classification modes as colorRamp.
+ */
+export interface IScalarScale {
+  scheme: 'scalar';
+  domain: [number, number]; // always explicit; set from data on rule creation
+  range: [number, number];  // output range in channel units (e.g. px)
+  mode: ClassificationMode; // default: 'equal interval'
+  fallback: number;         // default: 0
+  scalarStops?: Array<{ stop: number; output: number }>;
+}
+
+/**
+ * constant: always outputs the same value regardless of feature data.
+ * No field input needed.
+ */
+export interface IConstantScale {
+  scheme: 'constant';
+  value: any; // literal channel value (color array, hex string, or number)
+}
+
+/**
+ * identity: field value used directly as the channel value.
+ */
+export interface IIdentityScale {
+  scheme: 'identity';
+}
+
+export type IScale =
+  | IColorRampScale
+  | ICategoricalScale
+  | IScalarScale
+  | IConstantScale
+  | IIdentityScale;
+
+// ---------------------------------------------------------------------------
+// Encoding rule
+// ---------------------------------------------------------------------------
+
+export interface IEncodingRule {
+  /**
+   * Stable UUID (UUID.uuid4() from @lumino/coreutils).
+   * Used as React key and for story-segment override merging.
+   */
+  id: string;
+
+  /**
+   * Input: feature attribute name.
+   * Optional for constant rules (which need no field input).
+   */
+  field?: string;
+
+  /** Output: which OL style property this rule drives. */
+  channel: OLStyleChannel;
+
+  /** Optional explicit field type. Inferred from scale scheme if absent. */
+  type?: FieldType;
+
+  /**
+   * Guard conditions (AND-ed). If all pass for a feature, the rule applies;
+   * otherwise the channel falls back to its baseStyle value.
+   * Replaces the old single geometryFilter field.
+   */
+  when?: IPredicate[];
+
+  scale: IScale;
+}
+
+// ---------------------------------------------------------------------------
+// Grammar symbology state
+// ---------------------------------------------------------------------------
+
+export interface IGrammarSymbologyState {
+  renderType: 'Grammar';
+  /** Ordered list of encoding rules. Compiled in order; last rule wins on channel conflicts. */
+  rules: IEncodingRule[];
+  /**
+   * Fallback OL FlatStyle for channels not covered by any rule.
+   * Optional: defaults to {} at runtime. Not persisted to avoid schema conflicts.
+   */
+  baseStyle?: Record<string, any>;
+}

--- a/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/VectorRendering.tsx
@@ -13,6 +13,7 @@ import {
 import { SymbologyTab, VectorRenderType } from '@/src/types';
 import Canonical from './types/Canonical';
 import Categorized from './types/Categorized';
+import Grammar from './types/Grammar';
 import Graduated from './types/Graduated';
 import Heatmap from './types/Heatmap';
 import SimpleSymbol from './types/SimpleSymbol';
@@ -62,6 +63,11 @@ const RENDER_TYPE_OPTIONS: RenderTypeOptions = {
   Heatmap: {
     component: Heatmap,
     supportedLayerTypes: ['VectorLayer', 'HeatmapLayer'],
+    isTabbed: false,
+  },
+  Grammar: {
+    component: Grammar,
+    supportedLayerTypes: ['VectorLayer', 'VectorTileLayer'],
     isTabbed: false,
   },
 } as const;

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
@@ -25,6 +25,10 @@ import {
   saveSymbology,
 } from '@/src/dialogs/symbology/symbologyUtils';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
+import {
+  grammarRulesToCategorizedSeed,
+} from '@/src/dialogs/symbology/grammar/grammarConversions';
+import { IGrammarSymbologyState } from '@/src/dialogs/symbology/grammar/types';
 import { useLatest } from '@/src/shared/hooks/useLatest';
 import { SymbologyTab, ClassificationMode } from '@/src/types';
 import { ColorRampName } from '../../colorRampUtils';
@@ -81,6 +85,13 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     return;
   }
 
+  const normalizedState =
+    params.symbologyState?.renderType === 'Grammar'
+      ? grammarRulesToCategorizedSeed(
+          params.symbologyState as unknown as IGrammarSymbologyState,
+        )
+      : params.symbologyState;
+
   useEffect(() => {
     const valueColorPairs = VectorUtils.buildColorInfo(params);
 
@@ -119,13 +130,13 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     }
 
     setFallbackColor(
-      colorToRgba(params.symbologyState?.fallbackColor ?? [0, 0, 0, 0]),
+      colorToRgba(normalizedState?.fallbackColor ?? [0, 0, 0, 0]),
     );
-    setStrokeFollowsFill(params.symbologyState?.strokeFollowsFill ?? false);
+    setStrokeFollowsFill(normalizedState?.strokeFollowsFill ?? false);
   }, [layerId]);
 
   useEffect(() => {
-    const savedValue = params.symbologyState?.value;
+    const savedValue = normalizedState?.value;
     const attribute =
       savedValue && savedValue in selectableAttributesAndValues
         ? savedValue

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
@@ -28,6 +28,10 @@ import {
   VectorUtils,
 } from '@/src/dialogs/symbology/symbologyUtils';
 import ValueSelect from '@/src/dialogs/symbology/vector_layer/components/ValueSelect';
+import {
+  grammarRulesToGraduatedSeed,
+} from '@/src/dialogs/symbology/grammar/grammarConversions';
+import { IGrammarSymbologyState } from '@/src/dialogs/symbology/grammar/types';
 import { useLatest } from '@/src/shared/hooks/useLatest';
 import { ClassificationMode } from '@/src/types';
 import { ColorRampName } from '../../colorRampUtils';
@@ -99,6 +103,21 @@ const Graduated: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     return;
   }
 
+  // When coming from Grammar, substitute a Graduated-compatible seed so that
+  // the existing useEffects and child components can read value/colorRamp/etc.
+  const normalizedState =
+    params.symbologyState?.renderType === 'Grammar'
+      ? grammarRulesToGraduatedSeed(
+          params.symbologyState as unknown as IGrammarSymbologyState,
+        )
+      : params.symbologyState;
+
+  // Params with normalizedState merged in, used where symbologyState fields are needed.
+  const normalizedParams =
+    normalizedState !== params.symbologyState
+      ? { ...params, symbologyState: normalizedState }
+      : params;
+
   useEffect(() => {
     updateStopRowsBasedOnLayer();
   }, []);
@@ -128,13 +147,13 @@ const Graduated: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     }
 
     setFallbackColor(
-      colorToRgba(params.symbologyState?.fallbackColor ?? [0, 0, 0, 0]),
+      colorToRgba(normalizedState?.fallbackColor ?? [0, 0, 0, 0]),
     );
-    setStrokeFollowsFill(params.symbologyState?.strokeFollowsFill ?? false);
+    setStrokeFollowsFill(normalizedState?.strokeFollowsFill ?? false);
   }, [layerId]);
 
   useEffect(() => {
-    const savedValue = params.symbologyState?.value;
+    const savedValue = normalizedState?.value;
     const attribute =
       savedValue && savedValue in selectableAttributesAndValues
         ? savedValue
@@ -150,9 +169,9 @@ const Graduated: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     ) {
       return;
     }
-    if (params.symbologyState?.vmin !== undefined) {
-      setVmin(String(params.symbologyState.vmin));
-      setVmax(String(params.symbologyState.vmax ?? ''));
+    if (normalizedState?.vmin !== undefined) {
+      setVmin(String(normalizedState.vmin));
+      setVmax(String(normalizedState.vmax ?? ''));
       return;
     }
     const values = Array.from(
@@ -536,7 +555,7 @@ const Graduated: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
             />
           </div>
           <ColorRampControls
-            layerParams={params}
+            layerParams={normalizedParams}
             modeOptions={modeOptions}
             classifyFunc={buildColorInfoFromClassification}
             showModeRow={true}

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Grammar.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Grammar.tsx
@@ -1,18 +1,114 @@
 import React, { useEffect, useState } from 'react';
 
+import { colorToRgba, RgbaColor } from '@/src/dialogs/symbology/colorRampUtils';
+import RgbaColorPicker from '@/src/dialogs/symbology/components/color_ramp/RgbaColorPicker';
 import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
 import { useOkSignal } from '@/src/dialogs/symbology/hooks/useOkSignal';
 import MappingTable from '@/src/dialogs/symbology/grammar/components/MappingTable';
+import { anyStateToGrammarRules } from '@/src/dialogs/symbology/grammar/grammarConversions';
 import { grammarToOLStyle } from '@/src/dialogs/symbology/grammar/grammarToOLStyle';
 import {
   IEncodingRule,
   IGrammarSymbologyState,
+  OLStyleChannel,
 } from '@/src/dialogs/symbology/grammar/types';
 import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
 import {
   getEffectiveSymbologyParams,
   saveSymbology,
 } from '@/src/dialogs/symbology/symbologyUtils';
+
+// ---------------------------------------------------------------------------
+// FallbackEditor — per-channel default values used as the case-chain else branch
+// ---------------------------------------------------------------------------
+
+const FALLBACK_COLOR_CHANNELS: OLStyleChannel[] = [
+  'fill-color',
+  'stroke-color',
+  'circle-fill-color',
+  'circle-stroke-color',
+];
+
+const FALLBACK_NUMERIC_CHANNELS: OLStyleChannel[] = [
+  'stroke-width',
+  'circle-radius',
+  'circle-stroke-width',
+];
+
+const FALLBACK_LABELS: Partial<Record<OLStyleChannel, string>> = {
+  'fill-color': 'Fill',
+  'stroke-color': 'Stroke',
+  'circle-fill-color': 'Marker Fill',
+  'circle-stroke-color': 'Marker Stroke',
+  'stroke-width': 'Stroke Width',
+  'circle-radius': 'Marker Size',
+  'circle-stroke-width': 'Marker Stroke Width',
+};
+
+interface IFallbackEditorProps {
+  fallback: Partial<Record<OLStyleChannel, any>>;
+  onChange: (fallback: Partial<Record<OLStyleChannel, any>>) => void;
+}
+
+const FallbackEditor: React.FC<IFallbackEditorProps> = ({ fallback, onChange }) => {
+  const [open, setOpen] = useState(false);
+
+  const setChannel = (ch: OLStyleChannel, value: any) => {
+    onChange({ ...fallback, [ch]: value });
+  };
+
+  return (
+    <div className="jp-gis-grammar-fallback">
+      <button
+        className="jp-gis-grammar-fallback-toggle"
+        onClick={() => setOpen(v => !v)}
+      >
+        {open ? '▾' : '▸'} Fallback Style
+      </button>
+      {open && (
+        <div className="jp-gis-grammar-fallback-body">
+          <p className="jp-gis-mapping-empty">
+            Applied to features not matched by any conditional rule.
+          </p>
+          {FALLBACK_COLOR_CHANNELS.map(ch => {
+            const raw = fallback[ch] ?? 'rgba(0,0,0,0)';
+            const color: RgbaColor = colorToRgba(raw);
+            return (
+              <div key={ch} className="jp-gis-color-row">
+                <span className="jp-mod-styled jp-gis-color-row-value-input" style={{ display: 'flex', alignItems: 'center' }}>
+                  {FALLBACK_LABELS[ch]}
+                </span>
+                <RgbaColorPicker
+                  color={color}
+                  onChange={c => setChannel(ch, `rgba(${c[0]},${c[1]},${c[2]},${c[3]})`)}
+                />
+              </div>
+            );
+          })}
+          {FALLBACK_NUMERIC_CHANNELS.map(ch => {
+            const val = typeof fallback[ch] === 'number' ? fallback[ch] : 0;
+            return (
+              <div key={ch} className="jp-gis-symbology-row">
+                <label>{FALLBACK_LABELS[ch]}:</label>
+                <input
+                  type="number"
+                  className="jp-mod-styled"
+                  min={0}
+                  value={val}
+                  onChange={e => setChannel(ch, parseFloat(e.target.value) || 0)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Grammar component
+// ---------------------------------------------------------------------------
 
 const Grammar: React.FC<ISymbologyDialogProps> = ({
   model,
@@ -22,6 +118,7 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
   segmentId,
 }) => {
   const [rules, setRules] = useState<IEncodingRule[]>([]);
+  const [fallback, setFallback] = useState<Partial<Record<OLStyleChannel, any>>>({});
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
 
   const { featureProperties, isLoading } = useGetProperties({
@@ -29,7 +126,6 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
     model,
   });
 
-  // Restore existing grammar state, respecting story segment overrides.
   useEffect(() => {
     if (!layerId) {
       return;
@@ -43,8 +139,20 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
       segmentId,
     );
     const state = params?.symbologyState as IGrammarSymbologyState | undefined;
+
     if (state?.renderType === 'Grammar' && state.rules) {
+      // Already Grammar — restore persisted state.
       setRules(state.rules);
+      setFallback(state.fallback ?? {});
+    } else {
+      // Convert from another render type (pre-fill).
+      const converted = anyStateToGrammarRules(
+        params?.symbologyState,
+        (params?.color ?? {}) as Record<string, any>,
+      );
+      if (converted && converted.length > 0) {
+        setRules(converted);
+      }
     }
   }, [layerId]);
 
@@ -52,7 +160,11 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
     if (!layerId) {
       return;
     }
-    const state: IGrammarSymbologyState = { renderType: 'Grammar', rules };
+    const state: IGrammarSymbologyState = {
+      renderType: 'Grammar',
+      rules,
+      fallback: Object.keys(fallback).length > 0 ? fallback : undefined,
+    };
     saveSymbology({
       model,
       layerId,
@@ -84,6 +196,7 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
         onSelectRule={setSelectedRuleId}
         onRulesChange={setRules}
       />
+      <FallbackEditor fallback={fallback} onChange={setFallback} />
     </div>
   );
 };

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Grammar.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Grammar.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+
+import { useGetProperties } from '@/src/dialogs/symbology/hooks/useGetProperties';
+import { useOkSignal } from '@/src/dialogs/symbology/hooks/useOkSignal';
+import MappingTable from '@/src/dialogs/symbology/grammar/components/MappingTable';
+import { grammarToOLStyle } from '@/src/dialogs/symbology/grammar/grammarToOLStyle';
+import {
+  IEncodingRule,
+  IGrammarSymbologyState,
+} from '@/src/dialogs/symbology/grammar/types';
+import { ISymbologyDialogProps } from '@/src/dialogs/symbology/symbologyDialog';
+import {
+  getEffectiveSymbologyParams,
+  saveSymbology,
+} from '@/src/dialogs/symbology/symbologyUtils';
+
+const Grammar: React.FC<ISymbologyDialogProps> = ({
+  model,
+  okSignalPromise,
+  layerId,
+  isStorySegmentOverride,
+  segmentId,
+}) => {
+  const [rules, setRules] = useState<IEncodingRule[]>([]);
+  const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
+
+  const { featureProperties, isLoading } = useGetProperties({
+    layerId,
+    model,
+  });
+
+  // Restore existing grammar state, respecting story segment overrides.
+  useEffect(() => {
+    if (!layerId) {
+      return;
+    }
+    const layer = model.getLayer(layerId);
+    const params = getEffectiveSymbologyParams(
+      model,
+      layerId,
+      layer,
+      isStorySegmentOverride,
+      segmentId,
+    );
+    const state = params?.symbologyState as IGrammarSymbologyState | undefined;
+    if (state?.renderType === 'Grammar' && state.rules) {
+      setRules(state.rules);
+    }
+  }, [layerId]);
+
+  const handleOk = () => {
+    if (!layerId) {
+      return;
+    }
+    const state: IGrammarSymbologyState = { renderType: 'Grammar', rules };
+    saveSymbology({
+      model,
+      layerId,
+      isStorySegmentOverride,
+      segmentId,
+      payload: {
+        symbologyState: state as any,
+        color: grammarToOLStyle(state),
+      },
+    });
+  };
+
+  useOkSignal(okSignalPromise, handleOk);
+
+  if (!layerId) {
+    return null;
+  }
+
+  if (isLoading) {
+    return <p>Loading layer properties…</p>;
+  }
+
+  return (
+    <div className="jp-gis-grammar-container">
+      <MappingTable
+        rules={rules}
+        featureProperties={featureProperties}
+        selectedRuleId={selectedRuleId}
+        onSelectRule={setSelectedRuleId}
+        onRulesChange={setRules}
+      />
+    </div>
+  );
+};
+
+export default Grammar;

--- a/packages/base/src/types.ts
+++ b/packages/base/src/types.ts
@@ -33,7 +33,8 @@ export type VectorRenderType =
   | 'Canonical'
   | 'Graduated'
   | 'Categorized'
-  | 'Heatmap';
+  | 'Heatmap'
+  | 'Grammar';
 
 /**
  * Add jupytergisMaps object to the global variables.

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -362,26 +362,33 @@ select option {
   border: none;
   border-bottom: 1px solid var(--jp-border-color2);
   border-radius: 0;
-  background: transparent;
+  background: var(--jp-layout-color1);
 }
 
 .jp-gis-mapping-row .jp-select-wrapper:hover {
   border-bottom-color: var(--jp-brand-color1);
-  background: transparent;
+}
+
+.jp-gis-mapping-row:hover .jp-select-wrapper {
+  background: var(--jp-layout-color2);
 }
 
 .jp-gis-mapping-row .jp-select-wrapper select.jp-mod-styled {
   border: none;
-  background: transparent;
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color0);
   box-shadow: none;
   height: auto;
   padding: 1px 20px 1px 2px;
   font-size: var(--jp-ui-font-size1);
 }
 
+.jp-gis-mapping-row:hover .jp-select-wrapper select.jp-mod-styled {
+  background: var(--jp-layout-color2);
+}
+
 .jp-gis-mapping-row .jp-select-wrapper select.jp-mod-styled:focus {
   outline: none;
-  background: transparent;
 }
 
 .jp-gis-mapping-verb {

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -272,3 +272,196 @@ select option {
   cursor: pointer;
   user-select: none;
 }
+
+/* ── Grammar Symbology ─────────────────────────────────────────────────── */
+
+.jp-gis-grammar-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.jp-gis-mapping-table {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.jp-gis-mapping-empty {
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color2);
+  margin: 4px 0;
+}
+
+.jp-gis-mapping-row-wrapper {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid transparent;
+  border-radius: var(--jp-border-radius);
+}
+
+.jp-gis-mapping-row-wrapper.jp-gis-mapping-row-expanded {
+  border-color: var(--jp-border-color2);
+}
+
+/* The triple: subject ── [verb] ──▶ object, all on one line */
+.jp-gis-mapping-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.jp-gis-mapping-row:hover {
+  background: var(--jp-layout-color2);
+}
+
+.jp-gis-mapping-row .jp-select-wrapper {
+  flex: 1 1 0;
+  margin-bottom: 0;
+  min-width: 0;
+}
+
+.jp-gis-mapping-verb {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2px;
+  flex: 1.5 1 0;
+  min-width: 0;
+}
+
+.jp-gis-mapping-verb .jp-select-wrapper {
+  flex: 1 1 0;
+  margin-bottom: 0;
+  min-width: 0;
+}
+
+.jp-gis-mapping-arrow {
+  white-space: nowrap;
+  font-size: var(--jp-ui-font-size1);
+  color: var(--jp-ui-font-color2);
+}
+
+.jp-gis-mapping-delete {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--jp-ui-font-color2);
+  font-size: 1rem;
+  padding: 0 4px;
+  flex-shrink: 0;
+}
+
+.jp-gis-mapping-delete:hover {
+  color: var(--jp-error-color1);
+}
+
+/* Inline method editor — shown below the triple row when expanded */
+.jp-gis-mapping-editor-inline {
+  padding: 8px;
+  border-top: 1px solid var(--jp-border-color2);
+}
+
+.jp-gis-mapping-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.jp-gis-mapping-add {
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
+.jp-gis-categorical-row {
+  justify-content: flex-start;
+  gap: 1rem;
+}
+
+.jp-gis-categorical-label {
+  font-size: var(--jp-ui-font-size1);
+  min-width: 8rem;
+}
+
+.jp-gis-scale-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* When-conditions row — sits below the triple row */
+.jp-gis-when-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px 4px 4px;
+  min-height: 24px;
+}
+
+.jp-gis-predicate-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1px 6px;
+  background: var(--jp-layout-color3);
+  border: 1px solid var(--jp-border-color2);
+  border-radius: 10px;
+  font-size: var(--jp-ui-font-size0);
+  white-space: nowrap;
+}
+
+.jp-gis-predicate-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--jp-ui-font-color2);
+  padding: 0 0 0 2px;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.jp-gis-predicate-remove:hover {
+  color: var(--jp-error-color1);
+}
+
+.jp-gis-predicate-add-btn {
+  background: none;
+  border: 1px dashed var(--jp-border-color2);
+  border-radius: 10px;
+  cursor: pointer;
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+  padding: 1px 8px;
+}
+
+.jp-gis-predicate-add-btn:hover {
+  border-color: var(--jp-brand-color1);
+  color: var(--jp-brand-color1);
+}
+
+.jp-gis-predicate-form {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 0;
+}
+
+.jp-gis-predicate-form .jp-select-wrapper {
+  flex: 0 0 auto;
+  margin-bottom: 0;
+}
+
+.jp-gis-predicate-add-ok,
+.jp-gis-predicate-add-cancel {
+  flex: 0 0 auto;
+  padding: 2px 8px;
+  font-size: var(--jp-ui-font-size0);
+}

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -33,6 +33,13 @@ select option {
   max-width: 50%;
 }
 
+/* Rows with two label+input pairs (e.g. Min/Max): each input gets ~25% */
+.jp-gis-symbology-row-pair > .jp-mod-styled {
+  flex: 1 1 0;
+  max-width: none;
+  min-width: 0;
+}
+
 .jp-gis-color-ramp-div {
   display: flex;
   flex: 1 1 50%;
@@ -281,6 +288,34 @@ select option {
   gap: 8px;
 }
 
+.jp-gis-grammar-fallback {
+  border-top: 1px solid var(--jp-border-color2);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.jp-gis-grammar-fallback-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  padding: 2px 0;
+  width: 100%;
+  text-align: left;
+}
+
+.jp-gis-grammar-fallback-toggle:hover {
+  color: var(--jp-brand-color1);
+}
+
+.jp-gis-grammar-fallback-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 0 2px 12px;
+}
+
 .jp-gis-mapping-table {
   display: flex;
   flex-direction: column;
@@ -323,6 +358,30 @@ select option {
   flex: 1 1 0;
   margin-bottom: 0;
   min-width: 0;
+  /* strip the box — underline only */
+  border: none;
+  border-bottom: 1px solid var(--jp-border-color2);
+  border-radius: 0;
+  background: transparent;
+}
+
+.jp-gis-mapping-row .jp-select-wrapper:hover {
+  border-bottom-color: var(--jp-brand-color1);
+  background: transparent;
+}
+
+.jp-gis-mapping-row .jp-select-wrapper select.jp-mod-styled {
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  height: auto;
+  padding: 1px 20px 1px 2px;
+  font-size: var(--jp-ui-font-size1);
+}
+
+.jp-gis-mapping-row .jp-select-wrapper select.jp-mod-styled:focus {
+  outline: none;
+  background: transparent;
 }
 
 .jp-gis-mapping-verb {
@@ -393,6 +452,12 @@ select option {
   gap: 8px;
 }
 
+/* Type mismatch: scheme output type doesn't match channel expected type */
+.jp-gis-scheme-mismatch select {
+  border-color: var(--jp-warn-color1, #f57c00) !important;
+  color: var(--jp-warn-color1, #f57c00);
+}
+
 /* When-conditions row — sits below the triple row */
 .jp-gis-when-row {
   display: flex;
@@ -401,7 +466,6 @@ select option {
   align-items: center;
   gap: 4px;
   padding: 2px 4px 4px 4px;
-  min-height: 24px;
 }
 
 .jp-gis-predicate-chip {
@@ -409,10 +473,11 @@ select option {
   align-items: center;
   gap: 2px;
   padding: 1px 6px;
-  background: var(--jp-layout-color3);
-  border: 1px solid var(--jp-border-color2);
+  background: transparent;
+  border: 1px solid var(--jp-border-color3, rgba(128, 128, 128, 0.3));
   border-radius: 10px;
   font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
   white-space: nowrap;
 }
 
@@ -464,4 +529,92 @@ select option {
   flex: 0 0 auto;
   padding: 2px 8px;
   font-size: var(--jp-ui-font-size0);
+}
+
+/* ── Scale preview (collapsed mapping row indicator) ───────────────────── */
+
+.jp-gis-scale-preview-container {
+  flex: 0 0 auto;
+  width: 120px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+/* Shared color swatch (constant color / categorical dot) */
+.jp-gis-scale-preview-swatch {
+  display: inline-block;
+  width: 13px;
+  height: 13px;
+  border-radius: 2px;
+  border: 1px solid rgba(128, 128, 128, 0.4);
+  flex-shrink: 0;
+}
+
+/* Color-ramp preview: gradient bar + label side by side */
+.jp-gis-scale-preview-ramp {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+}
+
+.jp-gis-scale-preview-ramp-bar {
+  flex: 0 0 40px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+.jp-gis-scale-preview-ramp-label {
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Categorical dots */
+.jp-gis-scale-preview-categorical {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 2px;
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.jp-gis-scale-preview-more {
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+  white-space: nowrap;
+}
+
+/* Generic small text (constant number, scalar) */
+.jp-gis-scale-preview-text {
+  font-size: var(--jp-ui-font-size0);
+  color: var(--jp-ui-font-color2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.jp-gis-scale-preview-scalar em {
+  font-style: normal;
+  color: var(--jp-ui-font-color3);
+}
+
+.jp-gis-scale-preview-ramp-label em {
+  font-style: normal;
+  color: var(--jp-ui-font-color3);
+}
+
+.jp-gis-scale-preview-arrow {
+  margin: 0 2px;
+  color: var(--jp-ui-font-color3);
 }

--- a/packages/schema/src/schema/project/layers/vectorLayer.json
+++ b/packages/schema/src/schema/project/layers/vectorLayer.json
@@ -29,8 +29,63 @@
       "properties": {
         "renderType": {
           "type": "string",
-          "enum": ["Single Symbol", "Graduated", "Categorized", "Canonical"],
+          "enum": ["Single Symbol", "Graduated", "Categorized", "Canonical", "Grammar"],
           "default": "Single Symbol"
+        },
+        "rules": {
+          "type": "array",
+          "description": "Encoding rules for Grammar render type. Each rule maps an input field to a visual channel via a scale.",
+          "items": {
+            "type": "object",
+            "required": ["id", "field", "channel", "scale"],
+            "properties": {
+              "id": { "type": "string" },
+              "field": { "type": "string" },
+              "channel": {
+                "type": "string",
+                "enum": [
+                  "fill-color",
+                  "stroke-color",
+                  "stroke-width",
+                  "circle-fill-color",
+                  "circle-stroke-color",
+                  "circle-stroke-width",
+                  "circle-radius"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": ["quantitative", "ordinal", "nominal"]
+              },
+              "when": {
+                "type": "array",
+                "description": "Guard predicates (AND-ed). Rule applies only when all pass.",
+                "items": {
+                  "type": "object",
+                  "required": ["type"],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": ["geometryType", "hasField", "fieldEquals"]
+                    },
+                    "value": {},
+                    "field": { "type": "string" }
+                  }
+                }
+              },
+              "scale": {
+                "type": "object",
+                "required": ["scheme"],
+                "properties": {
+                  "scheme": {
+                    "type": "string",
+                    "enum": ["colorRamp", "categorical", "scalar", "constant", "identity"]
+                  }
+                }
+              }
+            }
+          },
+          "default": []
         },
         "value": {
           "type": "string"

--- a/packages/schema/src/schema/project/layers/vectorLayer.json
+++ b/packages/schema/src/schema/project/layers/vectorLayer.json
@@ -137,6 +137,10 @@
           "type": "boolean",
           "description": "Whether the stroke color follows the fill color expression",
           "default": false
+        },
+        "fallback": {
+          "type": "object",
+          "description": "Per-channel fallback values for Grammar render type (the final else branch)"
         }
       },
       "additionalProperties": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15098,11 +15098,11 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>, typescript@patch:typescript@^5#~builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: a5a6dc399d3761ded54192031f11d3ad5df8001c7febe3fbbc8098efcb552cdf8f2f402b3618c56dafcd04fef63dee005f4900f608e185404caedc46480539ed
+  checksum: 8bb8d86819ac86a498eada254cad7fb69c5f74778506c700c2a712daeaff21d3a6f51fd0d534fe16903cb010d1b74f89437a3d02d4d0ff5ca2ba9a4660de8497
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a **Grammar of Graphics** inspired render type for vector layers alongside the existing Graduated / Categorized / Single Symbol modes.

## What's in here

- **Encoding rules**: `(field, scale, channel)` triples compiled to OpenLayers FlatStyle expressions
- **Scale types**: color ramp, categorical, scalar (numeric), constant, identity
- **Type safety**: color scales only map to color channels, scalar only to numeric; warning shown on mismatch
- **Multi-rule merging**: multiple rules targeting the same channel with different `when` filters collapse into a single OL `case` chain
- **Fallback style**: configurable per-channel fallback for the final `else` branch
- **Pre-fill**: switching to Grammar bootstraps rules from the current Graduated/Categorized/Single Symbol state, and switching away seeds the target type from Grammar rules
- **Compact triple view**: collapsed rows show a small scale preview (gradient bar, color swatches, value range); filter conditions shown as read-only labels when collapsed, editable when expanded

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1221.org.readthedocs.build/en/1221/
💡 JupyterLite preview: https://jupytergis--1221.org.readthedocs.build/en/1221/lite
💡 Specta preview: https://jupytergis--1221.org.readthedocs.build/en/1221/lite/specta

<!-- readthedocs-preview jupytergis end -->