### PR TITLE
Reduce redundant STAC search fetches on filter panel load

### DIFF
--- a/packages/base/src/stacBrowser/hooks/useStacFilterExtension.ts
+++ b/packages/base/src/stacBrowser/hooks/useStacFilterExtension.ts
@@ -1,6 +1,6 @@
 import { IJupyterGISModel } from '@jupytergis/schema';
 import { endOfToday, startOfToday } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import useIsFirstRender from '@/src/shared/hooks/useIsFirstRender';
 import { useStacResultsContext } from '@/src/stacBrowser/context/StacResultsContext';
@@ -59,6 +59,7 @@ export function useStacFilterExtension({
     currentBBox,
     useWorldBBox,
     setUseWorldBBox,
+    hasLoadedInitialSearchState,
   } = useStacSearch({
     model,
   });
@@ -70,37 +71,44 @@ export function useStacFilterExtension({
     Record<string, IQueryableFilter>
   >({});
   const [filterOperator, setFilterOperator] = useState<FilterOperator>('and');
+  const hasLoadedInitialFilterStateRef = useRef(false);
+  /** Last auto-search request; skips duplicate consecutive fetches (React churn). */
+  const lastAutoQueryKeyRef = useRef<string | null>(null);
 
   const stateDb = GlobalStateDbManager.getInstance().getStateDb();
 
   // On mount, load saved filter state from StateDB (if present)
   useEffect(() => {
     async function loadFilterExtensionStateFromDb() {
-      const savedFilterState = (await stateDb?.fetch(
-        STAC_FILTER_EXTENSION_STATE_KEY,
-      )) as IStacFilterExtensionStateDb | undefined;
+      hasLoadedInitialFilterStateRef.current = false;
+      try {
+        const savedFilterState = (await stateDb?.fetch(
+          STAC_FILTER_EXTENSION_STATE_KEY,
+        )) as IStacFilterExtensionStateDb | undefined;
 
-      if (savedFilterState) {
-        if (savedFilterState.selectedCollection) {
-          setSelectedCollection(savedFilterState.selectedCollection);
+        if (savedFilterState) {
+          if (savedFilterState.selectedCollection) {
+            setSelectedCollection(savedFilterState.selectedCollection);
+          }
+          if (savedFilterState.queryableFilters) {
+            const restoredFilters: Record<string, IQueryableFilter> = {};
+            Object.entries(savedFilterState.queryableFilters).forEach(
+              ([key, filter]) => {
+                restoredFilters[key] = {
+                  operator: filter.operator,
+                  inputValue:
+                    filter.inputValue === null ? undefined : filter.inputValue,
+                };
+              },
+            );
+            setSelectedQueryables(restoredFilters);
+          }
+          if (savedFilterState.filterOperator) {
+            setFilterOperator(savedFilterState.filterOperator);
+          }
         }
-        if (savedFilterState.queryableFilters) {
-          // Convert null back to undefined for inputValue
-          const restoredFilters: Record<string, IQueryableFilter> = {};
-          Object.entries(savedFilterState.queryableFilters).forEach(
-            ([key, filter]) => {
-              restoredFilters[key] = {
-                operator: filter.operator,
-                inputValue:
-                  filter.inputValue === null ? undefined : filter.inputValue,
-              };
-            },
-          );
-          setSelectedQueryables(restoredFilters);
-        }
-        if (savedFilterState.filterOperator) {
-          setFilterOperator(savedFilterState.filterOperator);
-        }
+      } finally {
+        hasLoadedInitialFilterStateRef.current = true;
       }
     }
 
@@ -137,6 +145,7 @@ export function useStacFilterExtension({
 
   // Reset all state when URL changes
   useEffect(() => {
+    lastAutoQueryKeyRef.current = null;
     setQueryableFields(undefined);
     setCollections([]);
     setSelectedCollection('');
@@ -222,8 +231,8 @@ export function useStacFilterExtension({
           const { [qKey]: _, ...rest } = prev;
           return rest;
         }
-        // If inputValue is undefined but filter exists, keep it (user might be entering value)
-        // Only remove if explicitly set to null
+        // If inputValue is undefined but filter exists, keep it (user might be
+        // entering value). Only remove if explicitly set to null.
         return {
           ...prev,
           [qKey]: filter,
@@ -278,7 +287,6 @@ export function useStacFilterExtension({
       limit,
       'filter-lang': 'cql2-json',
     };
-
     // Only add filter if there are any conditions
     if (filterConditions.length > 0) {
       body.filter = {
@@ -314,17 +322,35 @@ export function useStacFilterExtension({
     const searchUrl = baseUrl.endsWith('/')
       ? `${baseUrl}search`
       : `${baseUrl}/search`;
+    lastAutoQueryKeyRef.current = JSON.stringify({
+      searchUrl,
+      queryBody,
+    });
     await executeQuery(queryBody, searchUrl);
-  }, [model, executeQuery, buildQuery, baseUrl]);
+  }, [model, buildQuery, baseUrl]);
 
   // Handle search when filters change
   useEffect(() => {
-    if (model && !isFirstRender && selectedCollection !== '') {
+    const hasLoadedInitialFilterState = hasLoadedInitialFilterStateRef.current;
+    if (
+      model &&
+      !isFirstRender &&
+      selectedCollection !== '' &&
+      hasLoadedInitialFilterState &&
+      hasLoadedInitialSearchState
+    ) {
       const queryBody = buildQuery();
       const searchUrl = baseUrl.endsWith('/')
         ? `${baseUrl}search`
         : `${baseUrl}/search`;
-      executeQuery(queryBody, searchUrl);
+      const autoQueryKey = JSON.stringify({ searchUrl, queryBody });
+
+      if (lastAutoQueryKeyRef.current === autoQueryKey) {
+        return;
+      }
+
+      lastAutoQueryKeyRef.current = autoQueryKey;
+      void executeQuery(queryBody, searchUrl);
     }
   }, [
     model,
@@ -336,8 +362,8 @@ export function useStacFilterExtension({
     endTime,
     currentBBox,
     buildQuery,
-    executeQuery,
     baseUrl,
+    hasLoadedInitialSearchState,
   ]);
 
   return {

--- a/packages/base/src/stacBrowser/hooks/useStacSearch.ts
+++ b/packages/base/src/stacBrowser/hooks/useStacSearch.ts
@@ -16,6 +16,7 @@ interface IUseStacSearchReturn {
   setCurrentBBox: (bbox: [number, number, number, number]) => void;
   useWorldBBox: boolean;
   setUseWorldBBox: (val: boolean) => void;
+  hasLoadedInitialSearchState: boolean;
 }
 
 interface IStacSearchStateDb {
@@ -38,26 +39,33 @@ export function useStacSearch({
     [number, number, number, number]
   >([-180, -90, 180, 90]);
   const [useWorldBBox, setUseWorldBBox] = useState(false);
+  const [hasLoadedInitialSearchState, setHasLoadedInitialSearchState] =
+    useState(false);
 
   const stateDb = GlobalStateDbManager.getInstance().getStateDb();
 
   // Load saved state from StateDB on mount
   useEffect(() => {
     async function loadStacSearchStateFromDb() {
-      const savedState = (await stateDb?.fetch(STAC_SEARCH_STATE_KEY)) as
-        | IStacSearchStateDb
-        | undefined;
+      setHasLoadedInitialSearchState(false);
+      try {
+        const savedState = (await stateDb?.fetch(STAC_SEARCH_STATE_KEY)) as
+          | IStacSearchStateDb
+          | undefined;
 
-      if (savedState) {
-        if (savedState.startTime) {
-          setStartTime(new Date(savedState.startTime));
+        if (savedState) {
+          if (savedState.startTime) {
+            setStartTime(new Date(savedState.startTime));
+          }
+          if (savedState.endTime) {
+            setEndTime(new Date(savedState.endTime));
+          }
+          if (savedState.useWorldBBox !== undefined) {
+            setUseWorldBBox(savedState.useWorldBBox);
+          }
         }
-        if (savedState.endTime) {
-          setEndTime(new Date(savedState.endTime));
-        }
-        if (savedState.useWorldBBox !== undefined) {
-          setUseWorldBBox(savedState.useWorldBBox);
-        }
+      } finally {
+        setHasLoadedInitialSearchState(true);
       }
     }
 
@@ -106,5 +114,6 @@ export function useStacSearch({
     setCurrentBBox,
     useWorldBBox,
     setUseWorldBBox,
+    hasLoadedInitialSearchState,
   };
 }


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
The STAC Filter Extension panel could fire extra /search requests when StateDB state was still loading. This adds a flag to reduce that churn so the panel issues one intentional search per real change.
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself
