### PR TITLE
Fix CTRL+click not removing items from selection

### DIFF
--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -167,7 +167,7 @@ export const LayersBodyComponent: React.FC<IBodyProps> = props => {
           },
         };
       } else {
-        // If types are the same add the selection - multi-selection
+        // If types are the same modify the selection (either add or remove to multi-selection)
         if (item in selectedValue) {
           const { [item]: _, ...rest } = selectedValue;
           newSelection = rest;


### PR DESCRIPTION
## Description

Resolves #1168
CTRL+clicking an already-selected layer in the layers panel now deselects it

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself

## AI Disclosure

- [x] This PR contains AI-generated content.
- [x] I have tested any AI-generated content in my PR.
- [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1224.org.readthedocs.build/en/1224/
💡 JupyterLite preview: https://jupytergis--1224.org.readthedocs.build/en/1224/lite
💡 Specta preview: https://jupytergis--1224.org.readthedocs.build/en/1224/lite/specta

<!-- readthedocs-preview jupytergis end -->