### PR TITLE
Remove `NPM_TOKEN` secret from publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Finalize Release
         id: finalize-release
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Description

This should have no effect, as I believe the value of this secret was emptystring. If I'm wrong, and this breaks publishing, it will force us to switch to trusted publishing, which is a good thing anyway :)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1225.org.readthedocs.build/en/1225/
💡 JupyterLite preview: https://jupytergis--1225.org.readthedocs.build/en/1225/lite
💡 Specta preview: https://jupytergis--1225.org.readthedocs.build/en/1225/lite/specta

<!-- readthedocs-preview jupytergis end -->