### PR TITLE
Replace specta link with its new home

### DIFF
--- a/docs/user_guide/how-tos/story-maps.md
+++ b/docs/user_guide/how-tos/story-maps.md
@@ -113,7 +113,7 @@ If your story map or project references other files (e.g. GeoJSON, images, or ra
 
 **Step 5 (optional): Enable Specta**
 
-[Specta](https://github.com/trungleduc/specta) with JupyterGIS is a full-screen story map presentation mode (minimal UI, previous/next navigation, segment content). To enable it in your JupyterLite deployment, add `specta` to the **dependencies** in `.github/build-environment.yml`, alongside the existing JupyterLite packages. For example:
+[Specta](https://github.com/notebook-link/specta) with JupyterGIS is a full-screen story map presentation mode (minimal UI, previous/next navigation, segment content). To enable it in your JupyterLite deployment, add `specta` to the **dependencies** in `.github/build-environment.yml`, alongside the existing JupyterLite packages. For example:
 
 ```yaml
 # .github/build-environment.yml


### PR DESCRIPTION
## Description

This repo was migrated, and our check links job seems to not handle the redirect? :shrug: https://github.com/geojupyter/jupytergis/actions/runs/23797672879/job/69349147776?pr=1228

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1231.org.readthedocs.build/en/1231/
💡 JupyterLite preview: https://jupytergis--1231.org.readthedocs.build/en/1231/lite
💡 Specta preview: https://jupytergis--1231.org.readthedocs.build/en/1231/lite/specta

<!-- readthedocs-preview jupytergis end -->