### PR TITLE
Exclude Categorical Colormaps for Heatmap symbology

### DIFF
--- a/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampSelector.tsx
+++ b/packages/base/src/dialogs/symbology/components/color_ramp/ColorRampSelector.tsx
@@ -45,13 +45,17 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
 
   useColorMapList(setColorMaps);
 
-  const displayColorRamps = propColorMaps ?? colorMaps;
+  useEffect(() => {
+    if (propColorMaps) {
+      setColorMaps(propColorMaps);
+    }
+  }, [propColorMaps]);
 
   useEffect(() => {
-    if (displayColorRamps.length > 0) {
+    if (colorMaps.length > 0) {
       updateCanvas(selectedRamp);
     }
-  }, [selectedRamp, displayColorRamps, reverse]);
+  }, [selectedRamp, colorMaps, reverse]);
 
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
@@ -80,7 +84,7 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
     }
     canvas.style.visibility = 'hidden';
 
-    const ramp = displayColorRamps.find(c => c.name === rampName);
+    const ramp = colorMaps.find(c => c.name === rampName);
     if (!ramp) {
       return;
     }
@@ -124,7 +128,7 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
       <div
         className={`jp-gis-color-ramp-dropdown ${isOpen ? 'jp-gis-open' : ''}`}
       >
-        {displayColorRamps.map((item, index) => (
+        {colorMaps.map((item, index) => (
           <ColorRampSelectorEntry
             index={index}
             colorMap={item}

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Heatmap.tsx
@@ -56,6 +56,7 @@ const Heatmap: React.FC<ISymbologyDialogProps> = ({
   useColorMapList(setColorMaps);
 
   // Filter: only continuous colormaps with class requirement <= 9 nshades
+  // because heatmap does not support nshades > 9
   const continuousMaps = colorMaps.filter(m => {
     if (m.type !== 'continuous') {
       return false;


### PR DESCRIPTION
## Description

Exclude Categorical colormaps for Heatmap symbology and Include only Continuous colormaps with only 9 number of shades.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1242.org.readthedocs.build/en/1242/
💡 JupyterLite preview: https://jupytergis--1242.org.readthedocs.build/en/1242/lite
💡 Specta preview: https://jupytergis--1242.org.readthedocs.build/en/1242/lite/specta

<!-- readthedocs-preview jupytergis end -->