### PR TITLE
Wire notebook GIS widget to shared Y doc awareness

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -435,34 +435,43 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
       const view = this._Map.getView();
 
-      view.on('change:center', () => this._updateCenter());
+      const syncViewportThrottled = throttle(() => {
+        // Not syncing center if following someone else
+        if (this._model.localState?.remoteUser) {
+          return;
+        }
 
-      // TODO: Note for the future, will need to update listeners if view changes
-      view.on(
-        'change:center',
-        throttle(() => {
-          // Not syncing center if following someone else
-          if (this._model.localState?.remoteUser) {
-            return;
-          }
-          const view = this._Map.getView();
-          const center = view.getCenter();
-          const zoom = view.getZoom();
-          if (!center || !zoom) {
-            return;
-          }
-          this._model.syncViewport(
-            {
-              coordinates: {
-                x: center[0],
-                y: center[1],
-              },
-              zoom,
+        const view = this._Map.getView();
+        const center = view.getCenter();
+        const zoom = view.getZoom();
+
+        if (!center || !zoom) {
+          return;
+        }
+
+        const currentExtent = view.calculateExtent(this._Map.getSize());
+        this._model.syncViewport(
+          {
+            coordinates: {
+              x: center[0],
+              y: center[1],
             },
-            this._mainViewModel.id,
-          );
-        }),
-      );
+            zoom,
+            extent: [
+              currentExtent[0],
+              currentExtent[1],
+              currentExtent[2],
+              currentExtent[3],
+            ],
+          },
+          this._mainViewModel.id,
+        );
+      }, 200);
+
+      view.on('change:center', () => {
+        this._updateCenter();
+        syncViewportThrottled();
+      });
 
       this._Map.on('postrender', () => {
         if (this.state.annotations) {

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -68,6 +68,7 @@ export type JgisCoordinates = { x: number; y: number };
 export interface IViewPortState {
   coordinates: JgisCoordinates;
   zoom: number;
+  extent: [number, number, number, number];
 }
 
 export type Pointer = {

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -53,6 +53,12 @@ class GISDocument(CommWidget):
     Create a new GISDocument object.
 
     :param path: the path to the file that you would like to open. If not provided, a new ephemeral widget will be created.
+
+    Collaborative client state from the front end is mirrored into :mod:`ypywidgets`
+    ``Awareness`` on the kernel. Subscribe with ``on_awareness_change(callback)``
+    (returns a subscription id; use ``unobserve_awareness(id)`` to remove). The
+    current snapshot is available as ``awareness.states`` on the underlying
+    ``pycrdt.Awareness`` via the inherited ``awareness`` property.
     """
 
     def __init__(

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -50,6 +50,10 @@ export const CLASS_NAME = 'jupytergis-notebook-widget';
 
 export class YJupyterGISModel extends JupyterYModel {
   jupyterGISModel: JupyterGISModel;
+
+  get awareness() {
+    return this.jupyterGISModel?.sharedModel?.awareness;
+  }
 }
 
 export class YJupyterGISLuminoWidget extends Panel {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
This adds a getter for the newly exposed `awareness` so we can access it from a notebook, adds `extent` to the `viewportState`, and consolidates redundant `change:center` listeners.

<img width="732" height="380" alt="image" src="https://github.com/user-attachments/assets/434598b9-0296-4f29-81ca-26d0178c85d1" />

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1246.org.readthedocs.build/en/1246/
💡 JupyterLite preview: https://jupytergis--1246.org.readthedocs.build/en/1246/lite
💡 Specta preview: https://jupytergis--1246.org.readthedocs.build/en/1246/lite/specta

<!-- readthedocs-preview jupytergis end -->