### PR TITLE
fix(types): replace `any` types in FilterRow with proper types

### DIFF
--- a/packages/base/src/panelview/filter-panel/FilterRow.tsx
+++ b/packages/base/src/panelview/filter-panel/FilterRow.tsx
@@ -27,7 +27,7 @@ const FilterRow: React.FC<{
 
   useEffect(() => {
     const sortedKeys = Object.keys(features).sort();
-    const sortedResult: Record<string, (string | number)[]> = {};
+    const sortedResult: typeof sortedFeatures = {};
 
     for (const key of sortedKeys) {
       // Convert each Set to a sorted array


### PR DESCRIPTION
## Summary

Removes 4 explicit `any` types from `FilterRow.tsx`, replacing them with proper TypeScript types. This is a small step toward enabling the `no-explicit-any` ESLint rule (#1238).

## Why this matters

The `filterRows` and `setFilterRows` props were typed as `any`, losing type safety at the component boundary. The parent component (`Filter.tsx`) already uses `IJGISFilterItem[]` for this state, so the types were known but not enforced in the child.

## Changes

**`packages/base/src/panelview/filter-panel/FilterRow.tsx`**:
- `filterRows: any` -> `filterRows: IJGISFilterItem[]` (imported from `@jupytergis/schema`)
- `setFilterRows: any` -> `React.Dispatch<React.SetStateAction<IJGISFilterItem[]>>`
- `useState<{ [key: string]: any }>` -> `useState<Record<string, (string | number)[]>>`
- Local `sortedResult` variable: same type narrowing

## Testing

Type-only change with no runtime behavior difference. The types match what `Filter.tsx` already passes to this component.

Ref #1238

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1262.org.readthedocs.build/en/1262/
💡 JupyterLite preview: https://jupytergis--1262.org.readthedocs.build/en/1262/lite
💡 Specta preview: https://jupytergis--1262.org.readthedocs.build/en/1262/lite/specta

<!-- readthedocs-preview jupytergis end -->