### PR TITLE
`getColorMap` as an parent method

### DIFF
--- a/packages/base/src/dialogs/symbology/colorRampUtils.ts
+++ b/packages/base/src/dialogs/symbology/colorRampUtils.ts
@@ -181,6 +181,19 @@ export const useColorMapList = (setColorMaps: (maps: IColorMap[]) => void) => {
 };
 
 /**
+ * Get a color map by name.
+ * Caches the full list on first call for efficiency, since generating color ramps is expensive.
+ */
+let colorMapCache: IColorMap[] | null = null;
+
+export const getColorMap = (name: ColorRampName): IColorMap | undefined => {
+  if (!colorMapCache) {
+    colorMapCache = getColorMapList();
+  }
+  return colorMapCache.find(c => c.name === name);
+};
+
+/**
  * Ensure we always get a valid hex string from either an RGB(A) array or string.
  */
 export const ensureHexColorCode = (color: number[] | string): string => {

--- a/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
+++ b/packages/base/src/dialogs/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
@@ -25,7 +25,7 @@ import { LoadingOverlay } from '@/src/shared/components/loading';
 import { useLatest } from '@/src/shared/hooks/useLatest';
 import { GlobalStateDbManager } from '@/src/store';
 import { ClassificationMode } from '@/src/types';
-import { ColorRampName, getColorMapList } from '../../colorRampUtils';
+import { ColorRampName, getColorMap } from '../../colorRampUtils';
 import { useEffectiveSymbologyParams } from '../../hooks/useEffectiveSymbologyParams';
 
 export type InterpolationType = 'discrete' | 'linear' | 'exact';
@@ -355,7 +355,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
     }
     setIsLoading(false);
 
-    const colorRamp = getColorMapList().find(c => c.name === selectedRamp);
+    const colorRamp = getColorMap(selectedRamp);
     if (!colorRamp) {
       return;
     }

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Categorized.tsx
@@ -7,7 +7,7 @@ import {
   colorToRgba,
   DEFAULT_COLOR,
   DEFAULT_STROKE_WIDTH,
-  getColorMapList,
+  getColorMap,
   isColor,
   RgbaColor,
 } from '@/src/dialogs/symbology/colorRampUtils';
@@ -156,8 +156,8 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     const stops = Array.from(
       selectableAttributesAndValues[selectedAttribute],
     ).sort((a, b) => a - b);
-    const colorRamp = getColorMapList().find(c => c.name === selectedRamp);
 
+    const colorRamp = getColorMap(selectedRamp);
     if (!colorRamp) {
       return;
     }

--- a/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
+++ b/packages/base/src/dialogs/symbology/vector_layer/types/Graduated.tsx
@@ -8,7 +8,7 @@ import {
   colorToRgba,
   DEFAULT_COLOR,
   DEFAULT_STROKE_WIDTH,
-  getColorMapList,
+  getColorMap,
   isColor,
   RgbaColor,
 } from '@/src/dialogs/symbology/colorRampUtils';
@@ -366,7 +366,7 @@ const Graduated: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
       stops[stops.length - 1] = rangeMax;
     }
 
-    const colorRamp = getColorMapList().find(c => c.name === selectedRamp);
+    const colorRamp = getColorMap(selectedRamp);
     const getStopOutputPairs = (): IStopRow[] => {
       if (symbologyTab === 'radius') {
         return stops.map(v => ({ id: UUID.uuid4(), stop: v, output: v }));


### PR DESCRIPTION
## Description

`getColorMap` as an parent method which generated `colorMap` list and caches it without regenerating `colorMap` list every time.

- Closes #1254 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1267.org.readthedocs.build/en/1267/
💡 JupyterLite preview: https://jupytergis--1267.org.readthedocs.build/en/1267/lite
💡 Specta preview: https://jupytergis--1267.org.readthedocs.build/en/1267/lite/specta

<!-- readthedocs-preview jupytergis end -->