### PR TITLE
Fix Add Story Segment bug

### DIFF
--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -686,7 +686,7 @@ export class JupyterGISModel implements IJupyterGISModel {
    * @returns Object with storySegmentId and storyMapId, or null if no extent/zoom found
    */
   addStorySegment(viewState?: IViewState[string]): IStorySegmentRef | null {
-    const state = viewState ?? Object.values(this.getViewState())[0];
+    const state = viewState ?? this.getOptions();
 
     const extent = state?.extent;
     const zoom = state?.zoom;


### PR DESCRIPTION
## Description

Now we get current mapView by default if we not have zoom and extent.


https://github.com/user-attachments/assets/6aea7765-b474-46e6-a83e-9d36e9a171a9



- #1271 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1275.org.readthedocs.build/en/1275/
💡 JupyterLite preview: https://jupytergis--1275.org.readthedocs.build/en/1275/lite
💡 Specta preview: https://jupytergis--1275.org.readthedocs.build/en/1275/lite/specta

<!-- readthedocs-preview jupytergis end -->