### PR TITLE
refactor: useRightPanelOptions uses callbacks instead of owning curTab

### DIFF
--- a/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
+++ b/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
@@ -1,8 +1,4 @@
-import {
-  IJupyterGISClientState,
-  IJupyterGISModel,
-  IJupyterGISSettings,
-} from '@jupytergis/schema';
+import { IJupyterGISClientState, IJupyterGISModel } from '@jupytergis/schema';
 import * as React from 'react';
 
 interface IUseRightPanelOptionsResult {
@@ -10,45 +6,51 @@ interface IUseRightPanelOptionsResult {
   editorMode: boolean;
   showEditor: boolean;
   storyPanelTitle: string;
-  curTab: string;
-  setCurTab: React.Dispatch<React.SetStateAction<string>>;
   toggleEditor: () => void;
 }
 
+/**
+ * Tracks story map presentation mode and editor mode, and fires optional
+ * callbacks when the active tab should change. This keeps tab state in the
+ * caller (RightPanel, MergedPanel, …) rather than inside this hook, so the
+ * same hook can drive any panel layout.
+ *
+ * @param model - The JupyterGIS model to subscribe to.
+ * @param opts.onPresentationModeEnabled - Called when story presentation mode
+ *   is activated; the caller should switch to the story tab.
+ * @param opts.onIdentifyFeatures - Called when new features are identified on
+ *   the map; the caller should switch to the identify tab.
+ * @returns storyMapPresentationMode, editorMode, showEditor, storyPanelTitle,
+ *   toggleEditor.
+ */
 export function useRightPanelOptions(
   model: IJupyterGISModel,
-  settings: IJupyterGISSettings,
+  opts?: {
+    onPresentationModeEnabled?: () => void;
+    onIdentifyFeatures?: () => void;
+  },
 ): IUseRightPanelOptionsResult {
   const [editorMode, setEditorMode] = React.useState(true);
   const [storyMapPresentationMode, setStoryMapPresentationMode] =
     React.useState(model.getOptions().storyMapPresentationMode ?? false);
 
-  const [curTab, setCurTab] = React.useState<string>(() => {
-    const initialPresentationMode =
-      model.getOptions().storyMapPresentationMode ?? false;
-    if (initialPresentationMode) {
-      return 'storyPanel';
-    }
-    if (!settings.objectPropertiesDisabled) {
-      return 'objectProperties';
-    }
-    if (!settings.storyMapsDisabled) {
-      return 'storyPanel';
-    }
-    if (!settings.annotationsDisabled) {
-      return 'annotations';
-    }
-    if (!settings.identifyDisabled) {
-      return 'identifyPanel';
-    }
-    return '';
+  // Keep refs fresh to avoid stale closures in the effect below
+  const onPresentationModeEnabledRef = React.useRef(
+    opts?.onPresentationModeEnabled,
+  );
+  const onIdentifyFeaturesRef = React.useRef(opts?.onIdentifyFeatures);
+  React.useEffect(() => {
+    onPresentationModeEnabledRef.current = opts?.onPresentationModeEnabled;
+    onIdentifyFeaturesRef.current = opts?.onIdentifyFeatures;
   });
 
   React.useEffect(() => {
     const onOptionsChanged = () => {
       const { storyMapPresentationMode } = model.getOptions();
       setStoryMapPresentationMode(storyMapPresentationMode ?? false);
-      storyMapPresentationMode && setCurTab('storyPanel');
+      if (storyMapPresentationMode) {
+        onPresentationModeEnabledRef.current?.();
+      }
     };
     let currentlyIdentifiedFeatures: any = undefined;
     const onAwarenessChanged = (
@@ -64,7 +66,7 @@ export function useRightPanelOptions(
         localState.identifiedFeatures.value !== currentlyIdentifiedFeatures
       ) {
         currentlyIdentifiedFeatures = localState.identifiedFeatures.value;
-        setCurTab('identifyPanel');
+        onIdentifyFeaturesRef.current?.();
       }
     };
 
@@ -94,8 +96,6 @@ export function useRightPanelOptions(
     editorMode,
     showEditor,
     storyPanelTitle,
-    curTab,
-    setCurTab,
     toggleEditor,
   };
 }

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -86,15 +86,37 @@ interface IRightPanelProps {
 }
 
 export const RightPanel: React.FC<IRightPanelProps> = props => {
+  const [curTab, setCurTab] = React.useState<string>(() => {
+    const initialPresentationMode =
+      props.model.getOptions().storyMapPresentationMode ?? false;
+    if (initialPresentationMode) {
+      return 'storyPanel';
+    }
+    if (!props.settings.objectPropertiesDisabled) {
+      return 'objectProperties';
+    }
+    if (!props.settings.storyMapsDisabled) {
+      return 'storyPanel';
+    }
+    if (!props.settings.annotationsDisabled) {
+      return 'annotations';
+    }
+    if (!props.settings.identifyDisabled) {
+      return 'identifyPanel';
+    }
+    return '';
+  });
+
   const {
     storyMapPresentationMode,
     editorMode,
     showEditor,
     storyPanelTitle,
-    curTab,
-    setCurTab,
     toggleEditor,
-  } = useRightPanelOptions(props.model, props.settings);
+  } = useRightPanelOptions(props.model, {
+    onPresentationModeEnabled: () => setCurTab('storyPanel'),
+    onIdentifyFeatures: () => setCurTab('identifyPanel'),
+  });
 
   const [selectedObjectProperties, setSelectedObjectProperties] =
     React.useState(undefined);


### PR DESCRIPTION
## Summary

part of #892 .

- Removes `curTab` and `setCurTab` from `useRightPanelOptions` return value
- Hook now accepts optional `onPresentationModeEnabled` and `onIdentifyFeatures` callbacks instead of switching tabs directly
- `RightPanel` manages its own `curTab` state and passes callbacks to the hook
- Improves JSDoc to clarify the hook's purpose and inputs/outputs

This makes the hook reusable by any panel layout (e.g. a future `MergedPanel`) without coupling tab state to a specific panel structure.

step to implement #1216 .

## Test plan

- Open a JupyterGIS file and verify the right panel behaves as before
- Object properties tab shows by default
- Story panel switches to automatically when story presentation mode is enabled
- Identify panel switches to automatically when features are identified on the map
- Editor/preview toggle works inside the story panel

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1280.org.readthedocs.build/en/1280/
💡 JupyterLite preview: https://jupytergis--1280.org.readthedocs.build/en/1280/lite
💡 Specta preview: https://jupytergis--1280.org.readthedocs.build/en/1280/lite/specta

<!-- readthedocs-preview jupytergis end -->