### PR TITLE
feat: add togglePanel command and toolbar button

### DIFF
--- a/docs/contributor_guide/explanation/architecture.md
+++ b/docs/contributor_guide/explanation/architecture.md
@@ -96,6 +96,8 @@ It mediates changes with Conflict-free Replicated Data Types (CRDTs), which is h
 by `yjs`.
 It is the "magic sauce" that enables collaboration!
 
+For a full explanation of where different kinds of state live (document, Settings, StateDB, React state), see [State management](state-management.md).
+
 :::tip
 You can view the shared model in many contexts by writing
 `console.log(model.sharedModel)` in a TypeScript file!

--- a/docs/contributor_guide/explanation/state-management.md
+++ b/docs/contributor_guide/explanation/state-management.md
@@ -1,0 +1,33 @@
+# State management
+
+JupyterGIS stores state in four places. Choose based on who needs it and how long it should live.
+
+| Mechanism                            | Persisted              | Shared with collaborators |
+| ------------------------------------ | ---------------------- | ------------------------- |
+| Document (`uiState`, `viewState`, …) | In `.jgis` file        | Yes (Yjs CRDT)            |
+| JupyterLab Settings                  | Per-user JSON          | No                        |
+| StateDB                              | Browser `localStorage` | No                        |
+| React state                          | Memory only            | No                        |
+
+## Document state
+
+Written into the `.jgis` file and replicated via Yjs.
+
+- **`layers` / `sources` / `layerTree`** — map content. Always shared.
+- **`options`** — map view config (zoom, centre, projection). Always shared.
+- **`viewState`** — per-collaborator camera snapshots, keyed by collaborator ID.
+- **`uiState`** — panel open/closed state (`leftPanelOpen`, `rightPanelOpen`, `consoleOpen`, `temporalControllerOpen`). Whether changes are actually written to the shared document is controlled by the `syncUIState` setting (default: `true`). The `useUIState` hook abstracts this for React components.
+
+Use document state for anything that belongs to the file's presentation or that the author wants to hand off to collaborators.
+
+## JupyterLab Settings
+
+Deployment-level feature flags (e.g. `leftPanelDisabled`, `syncUIState`). Defined in `python/jupytergis_core/schema/`. Per-user, never shared. Use for _whether a feature exists_, not its current state.
+
+## StateDB
+
+JupyterLab's `IStateDB` (`localStorage`). Per-browser, never shared. Use for personal UI micro-state too fine-grained for the document (e.g. layer tree expand/collapse).
+
+## React state
+
+Plain `useState` — lost on unmount. Use for ephemeral, local-only UI state (hover, open dropdown, uncommitted form values).

--- a/packages/base/src/commands/BaseCommandIDs.ts
+++ b/packages/base/src/commands/BaseCommandIDs.ts
@@ -53,6 +53,7 @@ export const downloadGeoJSON = 'jupytergis:downloadGeoJSON';
 // Panel toggles
 export const toggleLeftPanel = 'jupytergis:toggleLeftPanel';
 export const toggleRightPanel = 'jupytergis:toggleRightPanel';
+export const togglePanel = 'jupytergis:togglePanel';
 
 // Left panel tabs
 export const showLayersTab = 'jupytergis:showLayersTab';

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1362,25 +1362,18 @@ export function addCommands(
     isEnabled: () => Boolean(tracker.currentWidget),
     isToggled: () => {
       const current = tracker.currentWidget;
-      return current ? !current.model.jgisSettings.leftPanelDisabled : false;
+      return current
+        ? (current.model.getUIState().leftPanelOpen ?? true)
+        : false;
     },
-    execute: async () => {
+    execute: () => {
       const current = tracker.currentWidget;
       if (!current) {
         return;
       }
-
-      try {
-        const settings = await current.model.getSettings();
-        const currentValue =
-          settings?.composite?.leftPanelDisabled ??
-          current.model.jgisSettings.leftPanelDisabled ??
-          false;
-        await settings?.set('leftPanelDisabled', !currentValue);
-        commands.notifyCommandChanged(CommandIDs.toggleLeftPanel);
-      } catch (err) {
-        console.error('Failed to toggle Left Panel:', err);
-      }
+      const currentValue = current.model.getUIState().leftPanelOpen ?? true;
+      current.model.setUIState({ leftPanelOpen: !currentValue });
+      commands.notifyCommandChanged(CommandIDs.toggleLeftPanel);
     },
   });
 
@@ -1396,25 +1389,18 @@ export function addCommands(
     isEnabled: () => Boolean(tracker.currentWidget),
     isToggled: () => {
       const current = tracker.currentWidget;
-      return current ? !current.model.jgisSettings.rightPanelDisabled : false;
+      return current
+        ? (current.model.getUIState().rightPanelOpen ?? true)
+        : false;
     },
-    execute: async () => {
+    execute: () => {
       const current = tracker.currentWidget;
       if (!current) {
         return;
       }
-
-      try {
-        const settings = await current.model.getSettings();
-        const currentValue =
-          settings?.composite?.rightPanelDisabled ??
-          current.model.jgisSettings.rightPanelDisabled ??
-          false;
-        await settings?.set('rightPanelDisabled', !currentValue);
-        commands.notifyCommandChanged(CommandIDs.toggleRightPanel);
-      } catch (err) {
-        console.error('Failed to toggle Right Panel:', err);
-      }
+      const currentValue = current.model.getUIState().rightPanelOpen ?? true;
+      current.model.setUIState({ rightPanelOpen: !currentValue });
+      commands.notifyCommandChanged(CommandIDs.toggleRightPanel);
     },
   });
 
@@ -1424,7 +1410,16 @@ export function addCommands(
     iconClass: 'fa fa-layer-group',
     isEnabled: () => Boolean(tracker.currentWidget),
     execute: () => {
-      window.dispatchEvent(new CustomEvent('jgis:togglePanel'));
+      const current = tracker.currentWidget;
+      if (!current) {
+        return;
+      }
+      const { leftPanelOpen = true, rightPanelOpen = true } =
+        current.model.getUIState();
+      // Show all if any panel is hidden; hide all if all are shown.
+      const show = !leftPanelOpen || !rightPanelOpen;
+      current.model.setUIState({ leftPanelOpen: show, rightPanelOpen: show });
+      commands.notifyCommandChanged(CommandIDs.togglePanel);
     },
   });
 

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1423,29 +1423,8 @@ export function addCommands(
     caption: 'Toggle the panel in the current JupyterGIS document.',
     iconClass: 'fa fa-layer-group',
     isEnabled: () => Boolean(tracker.currentWidget),
-    execute: async () => {
-      const current = tracker.currentWidget;
-      if (!current) {
-        return;
-      }
-      try {
-        const settings = await current.model.getSettings();
-        const leftDisabled =
-          settings?.composite?.leftPanelDisabled ??
-          current.model.jgisSettings.leftPanelDisabled ??
-          false;
-        const rightDisabled =
-          settings?.composite?.rightPanelDisabled ??
-          current.model.jgisSettings.rightPanelDisabled ??
-          false;
-        // If either panel is visible, hide both; if both are hidden, show both.
-        const hide = !leftDisabled || !rightDisabled;
-        await settings?.set('leftPanelDisabled', hide);
-        await settings?.set('rightPanelDisabled', hide);
-        commands.notifyCommandChanged(CommandIDs.togglePanel);
-      } catch (err) {
-        console.error('Failed to toggle panels:', err);
-      }
+    execute: () => {
+      window.dispatchEvent(new CustomEvent('jgis:togglePanel'));
     },
   });
 

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1423,8 +1423,29 @@ export function addCommands(
     caption: 'Toggle the panel in the current JupyterGIS document.',
     iconClass: 'fa fa-layer-group',
     isEnabled: () => Boolean(tracker.currentWidget),
-    execute: () => {
-      window.dispatchEvent(new CustomEvent('jgis:togglePanel'));
+    execute: async () => {
+      const current = tracker.currentWidget;
+      if (!current) {
+        return;
+      }
+      try {
+        const settings = await current.model.getSettings();
+        const leftDisabled =
+          settings?.composite?.leftPanelDisabled ??
+          current.model.jgisSettings.leftPanelDisabled ??
+          false;
+        const rightDisabled =
+          settings?.composite?.rightPanelDisabled ??
+          current.model.jgisSettings.rightPanelDisabled ??
+          false;
+        // If either panel is visible, hide both; if both are hidden, show both.
+        const hide = !leftDisabled || !rightDisabled;
+        await settings?.set('leftPanelDisabled', hide);
+        await settings?.set('rightPanelDisabled', hide);
+        commands.notifyCommandChanged(CommandIDs.togglePanel);
+      } catch (err) {
+        console.error('Failed to toggle panels:', err);
+      }
     },
   });
 

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1418,6 +1418,16 @@ export function addCommands(
     },
   });
 
+  commands.addCommand(CommandIDs.togglePanel, {
+    label: trans.__('Toggle Panel'),
+    caption: 'Toggle the panel in the current JupyterGIS document.',
+    iconClass: 'fa fa-layer-group',
+    isEnabled: () => Boolean(tracker.currentWidget),
+    execute: () => {
+      window.dispatchEvent(new CustomEvent('jgis:togglePanel'));
+    },
+  });
+
   // Left panel tabs
   commands.addCommand(CommandIDs.showLayersTab, {
     label: trans.__('Show Layers Tab'),

--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -65,6 +65,7 @@ const iconObject = {
   [CommandIDs.toggleStoryPresentationMode]: {
     iconClass: 'fa fa-book jgis-icon-adjust',
   },
+  [CommandIDs.togglePanel]: { iconClass: 'fa fa-layer-group' },
   [CommandIDs.renameSelected]: { iconClass: 'fa fa-pen' },
   [CommandIDs.removeSelected]: { iconClass: 'fa fa-trash' },
 };

--- a/packages/base/src/features/stac-browser/components/StacPanel.tsx
+++ b/packages/base/src/features/stac-browser/components/StacPanel.tsx
@@ -63,11 +63,8 @@ const StacPanelContent = ({ model }: IStacViewProps) => {
       style={{ boxShadow: 'none' }}
     >
       <TabsList className="jgis-stac-panel-tabs-list">
-        <TabsTrigger className="jGIS-layer-browser-category" value="filters">
-          Filters
-        </TabsTrigger>
+        <TabsTrigger value="filters">Filters</TabsTrigger>
         <TabsTrigger
-          className="jGIS-layer-browser-category"
           value="results"
           // Total results will always be the the same as the limit if the
           // provider doesn't support the context extension (where totalPages comes from)

--- a/packages/base/src/shared/components/Tabs.tsx
+++ b/packages/base/src/shared/components/Tabs.tsx
@@ -41,14 +41,73 @@ const TabsRoot: React.FC<IPanelTabProps> = ({
 
 const TabsList: React.FC<React.ComponentProps<typeof TabsPrimitive.List>> = ({
   className,
+  children,
   ...props
 }) => {
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = React.useState(false);
+  const [canScrollRight, setCanScrollRight] = React.useState(false);
+
+  const updateScrollButtons = React.useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
+  }, []);
+
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+    updateScrollButtons();
+    el.addEventListener('scroll', updateScrollButtons, { passive: true });
+    const ro = new ResizeObserver(updateScrollButtons);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener('scroll', updateScrollButtons);
+      ro.disconnect();
+    };
+  }, [updateScrollButtons]);
+
+  const scrollBy = (delta: number) => {
+    scrollRef.current?.scrollBy({ left: delta, behavior: 'smooth' });
+  };
+
   return (
-    <TabsPrimitive.List
-      data-slot="tabs-list"
-      className={cn('jgis-tabs-list', className)}
-      {...props}
-    />
+    <div className="jgis-tabs-list-wrapper">
+      <button
+        className="jgis-tabs-scroll-btn"
+        style={{ visibility: canScrollLeft ? 'visible' : 'hidden' }}
+        onMouseDown={e => e.stopPropagation()}
+        onClick={() => scrollBy(-80)}
+        tabIndex={-1}
+        aria-label="Scroll tabs left"
+      >
+        ‹
+      </button>
+      <div ref={scrollRef} className="jgis-tabs-list-scroll">
+        <TabsPrimitive.List
+          data-slot="tabs-list"
+          className={cn('jgis-tabs-list', className)}
+          {...props}
+        >
+          {children}
+        </TabsPrimitive.List>
+      </div>
+      <button
+        className="jgis-tabs-scroll-btn"
+        style={{ visibility: canScrollRight ? 'visible' : 'hidden' }}
+        onMouseDown={e => e.stopPropagation()}
+        onClick={() => scrollBy(80)}
+        tabIndex={-1}
+        aria-label="Scroll tabs right"
+      >
+        ›
+      </button>
+    </div>
   );
 };
 

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -190,6 +190,9 @@ export class JupyterGISPanel extends SplitPanel {
   }
 
   get consoleOpened(): boolean {
+    if (this._mainViewModel) {
+      return this._mainViewModel.jGISModel.getUIState().consoleOpen ?? false;
+    }
     return this._consoleOpened;
   }
 
@@ -204,6 +207,7 @@ export class JupyterGISPanel extends SplitPanel {
       this._consoleView.dispose();
       this._consoleView = undefined;
       this._consoleOpened = false;
+      this._setConsoleUIState(false);
       setTimeout(() => {
         window.dispatchEvent(new Event('resize'));
       }, 250);
@@ -241,6 +245,7 @@ export class JupyterGISPanel extends SplitPanel {
         this.addWidget(this._consoleView);
         this.setRelativeSizes([2, 1]);
         this._consoleOpened = true;
+        this._setConsoleUIState(true);
         await consolePanel.console.inject(
           `from jupytergis import GISDocument\ndoc = GISDocument("${jgisPath}")`,
         );
@@ -253,15 +258,26 @@ export class JupyterGISPanel extends SplitPanel {
     } else {
       if (this._consoleOpened) {
         this._consoleOpened = false;
+        this._setConsoleUIState(false);
         this.setRelativeSizes([1, 0]);
       } else {
         this._consoleOpened = true;
+        this._setConsoleUIState(true);
         this.setRelativeSizes([2, 1]);
       }
     }
     setTimeout(() => {
       window.dispatchEvent(new Event('resize'));
     }, 250);
+  }
+
+  private _setConsoleUIState(open: boolean): void {
+    if (
+      this._mainViewModel &&
+      (this._mainViewModel.jGISModel.jgisSettings.syncUIState ?? true)
+    ) {
+      this._mainViewModel.jGISModel.setUIState({ consoleOpen: open });
+    }
   }
 
   private _state: IStateDB | undefined;

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -272,10 +272,7 @@ export class JupyterGISPanel extends SplitPanel {
   }
 
   private _setConsoleUIState(open: boolean): void {
-    if (
-      this._mainViewModel &&
-      (this._mainViewModel.jGISModel.jgisSettings.syncUIState ?? true)
-    ) {
+    if (this._mainViewModel) {
       this._mainViewModel.jGISModel.setUIState({ consoleOpen: open });
     }
   }

--- a/packages/base/src/workspace/panels/components/TabbedPanel.tsx
+++ b/packages/base/src/workspace/panels/components/TabbedPanel.tsx
@@ -18,23 +18,28 @@ export interface ITabConfig {
 
 interface ITabbedPanelProps {
   tabs: ITabConfig[];
-  containerClassName: string;
   curTab: string;
   onTabClick: (name: string) => void;
-  style?: React.CSSProperties;
+  onMinimize?: () => void;
 }
 
 export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
   tabs,
-  containerClassName,
   curTab,
   onTabClick,
-  style,
+  onMinimize,
 }) => {
   const enabledTabs = tabs.filter(tab => tab.enabled);
 
   return (
-    <div className={containerClassName} style={style}>
+    <>
+      {onMinimize && (
+        <button
+          className="jgis-panel-minimize-btn"
+          onClick={onMinimize}
+          title="Minimize panel"
+        />
+      )}
       <TabsRoot className="jgis-panel-tabs" curTab={curTab}>
         <TabsList>
           {enabledTabs.map(tab => (
@@ -58,6 +63,6 @@ export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
           </TabsContent>
         ))}
       </TabsRoot>
-    </div>
+    </>
   );
 };

--- a/packages/base/src/workspace/panels/components/TabbedPanel.tsx
+++ b/packages/base/src/workspace/panels/components/TabbedPanel.tsx
@@ -44,7 +44,6 @@ export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
         <TabsList>
           {enabledTabs.map(tab => (
             <TabsTrigger
-              className="jGIS-layer-browser-category"
               key={tab.name}
               value={tab.name}
               onClick={() => onTabClick(tab.name)}

--- a/packages/base/src/workspace/panels/hooks/useUIState.ts
+++ b/packages/base/src/workspace/panels/hooks/useUIState.ts
@@ -1,0 +1,46 @@
+import { IJGISUIState, IJupyterGISModel } from '@jupytergis/schema';
+import * as React from 'react';
+
+/**
+ * Read and write a single uiState field.
+ *
+ * When syncUIState is true the value is backed by the shared document model:
+ * remote changes are applied and local changes are written back.
+ *
+ * When syncUIState is false the value is local React state only, initialised
+ * from the document on mount. Changes stay in memory and are lost on reload.
+ */
+export function useUIState<K extends keyof IJGISUIState>(
+  key: K,
+  model: IJupyterGISModel,
+  syncUIState: boolean,
+): [IJGISUIState[K], (value: IJGISUIState[K]) => void] {
+  const [value, setValue] = React.useState<IJGISUIState[K]>(
+    () => model.getUIState()[key],
+  );
+
+  React.useEffect(() => {
+    if (!syncUIState) {
+      return;
+    }
+    const handler = (_: IJupyterGISModel, state: IJGISUIState) => {
+      setValue(state[key]);
+    };
+    model.uiStateChanged.connect(handler);
+    return () => {
+      model.uiStateChanged.disconnect(handler);
+    };
+  }, [model, key, syncUIState]);
+
+  const setUIStateValue = React.useCallback(
+    (newValue: IJGISUIState[K]) => {
+      setValue(newValue);
+      if (syncUIState) {
+        model.setUIState({ [key]: newValue } as Partial<IJGISUIState>);
+      }
+    },
+    [model, key, syncUIState],
+  );
+
+  return [value, setUIStateValue];
+}

--- a/packages/base/src/workspace/panels/hooks/useUIState.ts
+++ b/packages/base/src/workspace/panels/hooks/useUIState.ts
@@ -2,27 +2,21 @@ import { IJGISUIState, IJupyterGISModel } from '@jupytergis/schema';
 import * as React from 'react';
 
 /**
- * Read and write a single uiState field.
+ * Read and write a single uiState field, backed by the model.
  *
- * When syncUIState is true the value is backed by the shared document model:
- * remote changes are applied and local changes are written back.
- *
- * When syncUIState is false the value is local React state only, initialised
- * from the document on mount. Changes stay in memory and are lost on reload.
+ * The model handles syncUIState routing: when sync is disabled it stores
+ * changes locally (in-memory) and emits the signal without touching the
+ * shared document, so remote peers are unaffected.
  */
 export function useUIState<K extends keyof IJGISUIState>(
   key: K,
   model: IJupyterGISModel,
-  syncUIState: boolean,
 ): [IJGISUIState[K], (value: IJGISUIState[K]) => void] {
   const [value, setValue] = React.useState<IJGISUIState[K]>(
     () => model.getUIState()[key],
   );
 
   React.useEffect(() => {
-    if (!syncUIState) {
-      return;
-    }
     const handler = (_: IJupyterGISModel, state: IJGISUIState) => {
       setValue(state[key]);
     };
@@ -30,16 +24,14 @@ export function useUIState<K extends keyof IJGISUIState>(
     return () => {
       model.uiStateChanged.disconnect(handler);
     };
-  }, [model, key, syncUIState]);
+  }, [model, key]);
 
   const setUIStateValue = React.useCallback(
     (newValue: IJGISUIState[K]) => {
       setValue(newValue);
-      if (syncUIState) {
-        model.setUIState({ [key]: newValue } as Partial<IJGISUIState>);
-      }
+      model.setUIState({ [key]: newValue } as Partial<IJGISUIState>);
     },
-    [model, key, syncUIState],
+    [model, key],
   );
 
   return [value, setUIStateValue];

--- a/packages/base/src/workspace/panels/leftpanel.tsx
+++ b/packages/base/src/workspace/panels/leftpanel.tsx
@@ -30,14 +30,6 @@ interface ILeftPanelProps {
 export const LeftPanel: React.FC<ILeftPanelProps> = props => {
   const [options, setOptions] = React.useState(props.model.getOptions());
   const storyMapPresentationMode = options.storyMapPresentationMode ?? false;
-  const [visible, setVisible] = React.useState(true);
-
-  React.useEffect(() => {
-    const handler = () => setVisible(v => !v);
-    window.addEventListener('jgis:togglePanel', handler);
-    return () => window.removeEventListener('jgis:togglePanel', handler);
-  }, []);
-
   const [curTab, setCurTab] = React.useState<string>(() => {
     if (!props.settings.layersDisabled) {
       return 'layers';
@@ -116,7 +108,12 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
         containerClassName="jgis-left-panel-container"
         curTab={curTab}
         onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
-        style={{ display: allLeftTabsDisabled || !visible ? 'none' : 'block' }}
+        style={{
+          display:
+            allLeftTabsDisabled || props.settings.leftPanelDisabled
+              ? 'none'
+              : 'block',
+        }}
       />
     </Draggable>
   );

--- a/packages/base/src/workspace/panels/leftpanel.tsx
+++ b/packages/base/src/workspace/panels/leftpanel.tsx
@@ -30,6 +30,14 @@ interface ILeftPanelProps {
 export const LeftPanel: React.FC<ILeftPanelProps> = props => {
   const [options, setOptions] = React.useState(props.model.getOptions());
   const storyMapPresentationMode = options.storyMapPresentationMode ?? false;
+  const [visible, setVisible] = React.useState(true);
+
+  React.useEffect(() => {
+    const handler = () => setVisible(v => !v);
+    window.addEventListener('jgis:togglePanel', handler);
+    return () => window.removeEventListener('jgis:togglePanel', handler);
+  }, []);
+
   const [curTab, setCurTab] = React.useState<string>(() => {
     if (!props.settings.layersDisabled) {
       return 'layers';
@@ -108,12 +116,7 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
         containerClassName="jgis-left-panel-container"
         curTab={curTab}
         onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
-        style={{
-          display:
-            allLeftTabsDisabled || props.settings.leftPanelDisabled
-              ? 'none'
-              : 'block',
-        }}
+        style={{ display: allLeftTabsDisabled || !visible ? 'none' : 'block' }}
       />
     </Draggable>
   );

--- a/packages/base/src/workspace/panels/leftpanel.tsx
+++ b/packages/base/src/workspace/panels/leftpanel.tsx
@@ -12,6 +12,7 @@ import Draggable from 'react-draggable';
 import { ITabConfig, TabbedPanel } from './components/TabbedPanel';
 import { LayersBodyComponent } from './components/layers';
 import { useLayerTree } from './hooks/useLayerTree';
+import { useUIState } from './hooks/useUIState';
 import StacPanel from '../../features/stac-browser/components/StacPanel';
 
 export interface ILeftPanelClickHandlerParams {
@@ -30,13 +31,11 @@ interface ILeftPanelProps {
 export const LeftPanel: React.FC<ILeftPanelProps> = props => {
   const [options, setOptions] = React.useState(props.model.getOptions());
   const storyMapPresentationMode = options.storyMapPresentationMode ?? false;
-  const [visible, setVisible] = React.useState(true);
-
-  React.useEffect(() => {
-    const handler = () => setVisible(v => !v);
-    window.addEventListener('jgis:togglePanel', handler);
-    return () => window.removeEventListener('jgis:togglePanel', handler);
-  }, []);
+  const [leftPanelOpen, setLeftPanelOpen] = useUIState(
+    'leftPanelOpen',
+    props.model,
+    props.settings.syncUIState ?? true,
+  );
 
   const [curTab, setCurTab] = React.useState<string>(() => {
     if (!props.settings.layersDisabled) {
@@ -105,19 +104,34 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
     },
   ];
 
+  const nodeRef = React.useRef<HTMLDivElement>(null);
+
   return (
     <Draggable
+      nodeRef={nodeRef}
       handle=".jgis-tabs-list"
-      cancel=".jgis-tabs-trigger"
+      cancel=".jgis-panel-tab-content"
       bounds=".jGIS-Mainview-Container"
     >
-      <TabbedPanel
-        tabs={tabs}
-        containerClassName="jgis-left-panel-container"
-        curTab={curTab}
-        onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
-        style={{ display: allLeftTabsDisabled || !visible ? 'none' : 'block' }}
-      />
+      <div
+        ref={nodeRef}
+        className="jgis-left-panel-container"
+        style={{
+          display:
+            allLeftTabsDisabled ||
+            props.settings.leftPanelDisabled ||
+            !leftPanelOpen
+              ? 'none'
+              : 'block',
+        }}
+      >
+        <TabbedPanel
+          tabs={tabs}
+          curTab={curTab}
+          onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
+          onMinimize={() => setLeftPanelOpen(false)}
+        />
+      </div>
     </Draggable>
   );
 };

--- a/packages/base/src/workspace/panels/leftpanel.tsx
+++ b/packages/base/src/workspace/panels/leftpanel.tsx
@@ -115,8 +115,9 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
     >
       <div
         ref={nodeRef}
-        className="jgis-left-panel-container"
+        className="jgis-panel-container"
         style={{
+          left: 0,
           display:
             allLeftTabsDisabled ||
             props.settings.leftPanelDisabled ||

--- a/packages/base/src/workspace/panels/leftpanel.tsx
+++ b/packages/base/src/workspace/panels/leftpanel.tsx
@@ -34,7 +34,6 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
   const [leftPanelOpen, setLeftPanelOpen] = useUIState(
     'leftPanelOpen',
     props.model,
-    props.settings.syncUIState ?? true,
   );
 
   const [curTab, setCurTab] = React.useState<string>(() => {
@@ -109,8 +108,8 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
   return (
     <Draggable
       nodeRef={nodeRef}
-      handle=".jgis-tabs-list"
-      cancel=".jgis-panel-tab-content"
+      handle=".jgis-tabs-list-wrapper"
+      cancel=".jgis-panel-tab-content, .jgis-tabs-scroll-btn"
       bounds=".jGIS-Mainview-Container"
     >
       <div

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import Draggable from 'react-draggable';
 
 import { useRightPanelOptions } from './hooks/useRightPanelOptions';
+import { useUIState } from './hooks/useUIState';
 import { AnnotationsPanel } from '../../features/annotations';
 import { IdentifyPanelComponent } from '../../features/identify/IdentifyPanel';
 import { ObjectPropertiesReact } from '../../features/objectproperties';
@@ -86,13 +87,11 @@ interface IRightPanelProps {
 }
 
 export const RightPanel: React.FC<IRightPanelProps> = props => {
-  const [visible, setVisible] = React.useState(true);
-
-  React.useEffect(() => {
-    const handler = () => setVisible(v => !v);
-    window.addEventListener('jgis:togglePanel', handler);
-    return () => window.removeEventListener('jgis:togglePanel', handler);
-  }, []);
+  const [rightPanelOpen, setRightPanelOpen] = useUIState(
+    'rightPanelOpen',
+    props.model,
+    props.settings.syncUIState ?? true,
+  );
 
   const [curTab, setCurTab] = React.useState<string>(() => {
     const initialPresentationMode =
@@ -150,18 +149,29 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
     props.settings.identifyDisabled;
 
   const rightPanelVisible =
-    visible && !props.settings.rightPanelDisabled && !allRightTabsDisabled;
+    rightPanelOpen &&
+    !props.settings.rightPanelDisabled &&
+    !allRightTabsDisabled;
+
+  const nodeRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <Draggable
+      nodeRef={nodeRef}
       handle=".jgis-tabs-list"
-      cancel=".jgis-tabs-trigger"
+      cancel=".jgis-panel-tab-content"
       bounds=".jGIS-Mainview-Container"
     >
       <div
+        ref={nodeRef}
         className="jgis-right-panel-container"
         style={{ display: rightPanelVisible ? 'block' : 'none' }}
       >
+        <button
+          className="jgis-panel-minimize-btn"
+          onClick={() => setRightPanelOpen(false)}
+          title="Minimize panel"
+        />
         <TabsRoot className="jgis-panel-tabs" curTab={curTab}>
           <TabsList>
             {tabInfo.map(tab => (

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -86,6 +86,14 @@ interface IRightPanelProps {
 }
 
 export const RightPanel: React.FC<IRightPanelProps> = props => {
+  const [visible, setVisible] = React.useState(true);
+
+  React.useEffect(() => {
+    const handler = () => setVisible(v => !v);
+    window.addEventListener('jgis:togglePanel', handler);
+    return () => window.removeEventListener('jgis:togglePanel', handler);
+  }, []);
+
   const [curTab, setCurTab] = React.useState<string>(() => {
     const initialPresentationMode =
       props.model.getOptions().storyMapPresentationMode ?? false;
@@ -142,7 +150,7 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
     props.settings.identifyDisabled;
 
   const rightPanelVisible =
-    !props.settings.rightPanelDisabled && !allRightTabsDisabled;
+    visible && !props.settings.rightPanelDisabled && !allRightTabsDisabled;
 
   return (
     <Draggable

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -86,14 +86,6 @@ interface IRightPanelProps {
 }
 
 export const RightPanel: React.FC<IRightPanelProps> = props => {
-  const [visible, setVisible] = React.useState(true);
-
-  React.useEffect(() => {
-    const handler = () => setVisible(v => !v);
-    window.addEventListener('jgis:togglePanel', handler);
-    return () => window.removeEventListener('jgis:togglePanel', handler);
-  }, []);
-
   const [curTab, setCurTab] = React.useState<string>(() => {
     const initialPresentationMode =
       props.model.getOptions().storyMapPresentationMode ?? false;
@@ -150,7 +142,7 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
     props.settings.identifyDisabled;
 
   const rightPanelVisible =
-    visible && !props.settings.rightPanelDisabled && !allRightTabsDisabled;
+    !props.settings.rightPanelDisabled && !allRightTabsDisabled;
 
   return (
     <Draggable

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -164,8 +164,8 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
     >
       <div
         ref={nodeRef}
-        className="jgis-right-panel-container"
-        style={{ display: rightPanelVisible ? 'block' : 'none' }}
+        className="jgis-panel-container"
+        style={{ right: 0, display: rightPanelVisible ? 'block' : 'none' }}
       >
         <button
           className="jgis-panel-minimize-btn"
@@ -176,7 +176,6 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
           <TabsList>
             {tabInfo.map(tab => (
               <TabsTrigger
-                className="jGIS-layer-browser-category"
                 key={`${tab.name}-${tab.title}`}
                 value={tab.name}
                 onClick={() => {

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -90,7 +90,6 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
   const [rightPanelOpen, setRightPanelOpen] = useUIState(
     'rightPanelOpen',
     props.model,
-    props.settings.syncUIState ?? true,
   );
 
   const [curTab, setCurTab] = React.useState<string>(() => {
@@ -158,8 +157,8 @@ export const RightPanel: React.FC<IRightPanelProps> = props => {
   return (
     <Draggable
       nodeRef={nodeRef}
-      handle=".jgis-tabs-list"
-      cancel=".jgis-panel-tab-content"
+      handle=".jgis-tabs-list-wrapper"
+      cancel=".jgis-panel-tab-content, .jgis-tabs-scroll-btn"
       bounds=".jGIS-Mainview-Container"
     >
       <div

--- a/packages/base/src/workspace/toolbar/widget.tsx
+++ b/packages/base/src/workspace/toolbar/widget.tsx
@@ -176,6 +176,15 @@ export class ToolbarWidget extends ReactiveToolbar {
       );
       identifyButton.node.dataset.testid = 'toggleStoryPresentationMode-button';
 
+      const togglePanelButton = new CommandToolbarButton({
+        id: CommandIDs.togglePanel,
+        label: '',
+        commands: options.commands,
+      });
+
+      this.addItem('togglePanel', togglePanelButton);
+      togglePanelButton.node.dataset.testid = 'toggle-panel-button';
+
       this.addItem('separator2', new Separator());
 
       const toggleConsoleButton = new CommandToolbarButton({

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -130,6 +130,40 @@ button.jp-mod-styled.jp-mod-reject {
   left: 0;
 }
 
+.jgis-panel-minimize-btn {
+  width: 100%;
+  height: 8px;
+  padding: 0;
+  border: none;
+  border-radius: 8px 8px 0 0;
+  background: transparent;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.jgis-panel-minimize-btn::before {
+  content: '';
+  display: block;
+  width: 24px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 1px;
+}
+
+.jgis-right-panel-container:hover .jgis-panel-minimize-btn,
+.jgis-left-panel-container:hover .jgis-panel-minimize-btn {
+  opacity: 0.3;
+}
+
+.jgis-panel-minimize-btn:hover {
+  opacity: 0.7 !important;
+  background: rgba(128, 128, 128, 0.15);
+}
+
 .jgis-icon-adjust {
   padding-top: 5px;
 }

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -107,9 +107,9 @@ button.jp-mod-styled.jp-mod-reject {
 }
 
 /* Height constrained to 0.5rem less than .jGIS-Mainview-Container */
-.jgis-right-panel-container,
-.jgis-left-panel-container {
+.jgis-panel-container {
   position: absolute;
+  width: 330px;
   margin: 0.25rem;
   z-index: 40;
   max-height: calc(100% - 0.5rem);
@@ -118,16 +118,6 @@ button.jp-mod-styled.jp-mod-reject {
   box-shadow:
     0 4px 8px 0 rgba(0, 0, 0, 0.2),
     0 6px 20px 0 rgba(0, 0, 0, 0.19);
-}
-
-.jgis-right-panel-container {
-  width: 330px;
-  right: 0;
-}
-
-.jgis-left-panel-container {
-  width: 250px;
-  left: 0;
 }
 
 .jgis-panel-minimize-btn {
@@ -154,8 +144,7 @@ button.jp-mod-styled.jp-mod-reject {
   border-radius: 1px;
 }
 
-.jgis-right-panel-container:hover .jgis-panel-minimize-btn,
-.jgis-left-panel-container:hover .jgis-panel-minimize-btn {
+.jgis-panel-container:hover .jgis-panel-minimize-btn {
   opacity: 0.3;
 }
 
@@ -209,8 +198,7 @@ button.jp-mod-styled.jp-mod-reject {
     width: 60%;
   }
 
-  .jgis-left-panel-container,
-  .jgis-right-panel-container {
+  .jgis-panel-container {
     position: relative;
     margin: 0;
   }

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -126,10 +126,8 @@ button.jp-mod-styled.jp-mod-reject {
   padding: 0;
   border: none;
   border-radius: 8px 8px 0 0;
-  background: transparent;
+  background: var(--jp-layout-color2);
   cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.15s;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -142,15 +140,16 @@ button.jp-mod-styled.jp-mod-reject {
   height: 2px;
   background: currentColor;
   border-radius: 1px;
+  opacity: 0;
+  transition: opacity 0.15s;
 }
 
-.jgis-panel-container:hover .jgis-panel-minimize-btn {
+.jgis-panel-container:hover .jgis-panel-minimize-btn::before {
   opacity: 0.3;
 }
 
-.jgis-panel-minimize-btn:hover {
+.jgis-panel-minimize-btn:hover::before {
   opacity: 0.7 !important;
-  background: rgba(128, 128, 128, 0.15);
 }
 
 .jgis-icon-adjust {

--- a/packages/base/style/shared/tabs.css
+++ b/packages/base/style/shared/tabs.css
@@ -18,6 +18,7 @@
   width: 100%;
   font-size: 9px;
   overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 .jgis-tabs-list:active {

--- a/packages/base/style/shared/tabs.css
+++ b/packages/base/style/shared/tabs.css
@@ -8,17 +8,19 @@
 
 .jgis-tabs-list {
   display: inline-flex;
-  height: 2.5rem;
+  height: 1.5rem;
   align-items: center;
   justify-content: space-evenly;
   background-color: var(--jp-layout-color2);
   color: var(--jp-ui-font-color0);
   cursor: grab;
-  gap: 1rem;
+  gap: 0.5rem;
   width: 100%;
   font-size: 9px;
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, currentColor 20%, transparent) transparent;
 }
 
 .jgis-tabs-list:active {
@@ -31,9 +33,9 @@
   justify-content: center;
   white-space: nowrap;
   border-radius: 0.25rem;
-  padding: 0.25rem 0.5rem;
+  padding: 0.125rem 0.375rem;
   font-size: var(--jp-ui-font-size2);
-  font-weight: 500;
+  font-weight: 400;
   outline: none;
   transition: all 0.3s ease;
   border: 1px solid transparent;
@@ -52,10 +54,7 @@
 }
 
 .jgis-tabs-trigger[data-state='active'] {
-  background-color: var(--jp-layout-color2);
-  color: var(--jp-ui-font-color0);
-  box-shadow: 0 1px 2px
-    color-mix(in srgb, var(--jp-layout-color0), transparent 90%);
+  font-weight: 600;
 }
 
 .jgis-tabs-content {

--- a/packages/base/style/shared/tabs.css
+++ b/packages/base/style/shared/tabs.css
@@ -6,25 +6,58 @@
   background-color: var(--jp-layout-color0);
 }
 
+.jgis-tabs-list-wrapper {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 1.5rem;
+  background-color: var(--jp-layout-color2);
+  color: var(--jp-ui-font-color0);
+}
+
+.jgis-tabs-list-scroll {
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  min-width: 0;
+}
+
 .jgis-tabs-list {
-  display: inline-flex;
+  display: flex;
   height: 1.5rem;
   align-items: center;
   justify-content: space-evenly;
-  background-color: var(--jp-layout-color2);
-  color: var(--jp-ui-font-color0);
   cursor: grab;
   gap: 0.5rem;
-  width: 100%;
+  min-width: 100%;
+  width: max-content;
   font-size: 9px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, currentColor 20%, transparent) transparent;
 }
 
 .jgis-tabs-list:active {
   cursor: grabbing;
+}
+
+.jgis-tabs-scroll-btn {
+  flex-shrink: 0;
+  width: 1rem;
+  height: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: currentColor;
+  font-size: 14px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.5;
+}
+
+.jgis-tabs-scroll-btn:hover {
+  opacity: 1;
+  background: rgba(128, 128, 128, 0.15);
 }
 
 .jgis-tabs-trigger {

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -12,6 +12,7 @@ import {
   IJGISSource,
   IJGISSources,
   IJGISStoryMap,
+  IJGISUIState,
 } from './_interface/project/jgis';
 import { SCHEMA_VERSION } from './_interface/version';
 import {
@@ -27,6 +28,14 @@ import {
 
 export const DEFAULT_PROJECTION = 'EPSG:3857';
 
+/** Default uiState written into every document (new and on first open). */
+const DEFAULT_UI_STATE: IJGISUIState = {
+  leftPanelOpen: true,
+  rightPanelOpen: true,
+  consoleOpen: false,
+  temporalControllerOpen: false,
+};
+
 /** Default JSON content for a new JupyterGIS document. */
 export const DEFAULT_JGIS_DOCUMENT_CONTENT = `{
 	"schemaVersion": "${SCHEMA_VERSION}",
@@ -34,6 +43,7 @@ export const DEFAULT_JGIS_DOCUMENT_CONTENT = `{
 	"sources": {},
   "stories": {},
   "viewState": {},
+  "uiState": ${JSON.stringify(DEFAULT_UI_STATE)},
 	"options": {"latitude": 0, "longitude": 0, "zoom": 0, "bearing": 0, "pitch": 0, "projection": "${DEFAULT_PROJECTION}", "storyMapPresentationMode": false},
 	"layerTree": [],
 	"metadata": {}
@@ -52,6 +62,7 @@ export class JupyterGISDoc
     this._sources = this.ydoc.getMap<Y.Map<any>>('sources');
     this._stories = this.ydoc.getMap<Y.Map<any>>('stories');
     this._viewState = this.ydoc.getMap<Y.Map<any>>('viewState');
+    this._uiState = this.ydoc.getMap<any>('uiState');
     this._metadata = this.ydoc.getMap<string>('metadata');
 
     this.undoManager.addToScope(this._layers);
@@ -68,6 +79,7 @@ export class JupyterGISDoc
     this._sources.observeDeep(this._sourcesObserver.bind(this));
     this._stories.observeDeep(this._storyMapsObserver.bind(this));
     this._viewState.observe(this._viewStateObserver.bind(this));
+    this._uiState.observe(this._uiStateObserver.bind(this));
     this._options.observe(this._optionsObserver.bind(this));
     this._metadata.observe(this._metaObserver.bind(this));
   }
@@ -91,6 +103,7 @@ export class JupyterGISDoc
     const sources = this._sources.toJSON();
     const stories = this._stories.toJSON();
     const viewState = this._viewState.toJSON();
+    const uiState = this._uiState.toJSON();
     const metadata = this._metadata.toJSON();
 
     return {
@@ -99,6 +112,7 @@ export class JupyterGISDoc
       sources,
       stories,
       viewState,
+      uiState,
       options,
       metadata,
     };
@@ -142,6 +156,14 @@ export class JupyterGISDoc
       const viewState = value['viewState'] ?? {};
       Object.entries(viewState).forEach(([key, val]) =>
         this._viewState.set(key, val),
+      );
+
+      const uiState = {
+        ...DEFAULT_UI_STATE,
+        ...((value['uiState'] as Record<string, unknown>) ?? {}),
+      };
+      Object.entries(uiState).forEach(([key, val]) =>
+        this._uiState.set(key, val),
       );
 
       const metadata = value['metadata'] ?? {};
@@ -258,6 +280,28 @@ export class JupyterGISDoc
 
   get options(): IJGISOptions {
     return JSONExt.deepCopy(this._options.toJSON()) as IJGISOptions;
+  }
+
+  set uiState(uiState: Partial<IJGISUIState>) {
+    this.transact(() => {
+      for (const [key, value] of Object.entries(uiState)) {
+        this._uiState.set(key, value);
+      }
+    });
+  }
+
+  get uiState(): IJGISUIState {
+    return {
+      leftPanelOpen: true,
+      rightPanelOpen: true,
+      consoleOpen: false,
+      temporalControllerOpen: false,
+      ...JSONExt.deepCopy(this._uiState.toJSON()),
+    };
+  }
+
+  get uiStateChanged(): ISignal<IJupyterGISDoc, MapChange> {
+    return this._uiStateChanged;
   }
 
   get layersChanged(): ISignal<IJupyterGISDoc, IJGISLayerDocChange> {
@@ -560,6 +604,18 @@ export class JupyterGISDoc
     this._viewStateChanged.emit(changes);
   };
 
+  private _uiStateObserver = (event: Y.YMapEvent<any>): void => {
+    const changes = new Map();
+    event.changes.keys.forEach((change, key) => {
+      changes.set(key, {
+        action: change.action,
+        oldValue: change.oldValue,
+        newValue: this._uiState.get(key),
+      });
+    });
+    this._uiStateChanged.emit(changes);
+  };
+
   private _optionsObserver = (event: Y.YMapEvent<Y.Map<string>>): void => {
     const changes = new Map();
     event.changes.keys.forEach((event, key) => {
@@ -590,6 +646,7 @@ export class JupyterGISDoc
   private _sources: Y.Map<any>;
   private _stories: Y.Map<any>;
   private _viewState: Y.Map<any>;
+  private _uiState: Y.Map<any>;
   private _options: Y.Map<any>;
   private _metadata: Y.Map<string>;
 
@@ -609,6 +666,7 @@ export class JupyterGISDoc
     IJGISStoryMapDocChange
   >(this);
   private _viewStateChanged = new Signal<IJupyterGISDoc, MapChange>(this);
+  private _uiStateChanged = new Signal<IJupyterGISDoc, MapChange>(this);
   private _metadataChanged = new Signal<IJupyterGISDoc, MapChange>(this);
 
   private _initialSyncReadyPromise: Promise<void>;

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -27,6 +27,7 @@ import {
   IJGISSource,
   IJGISSources,
   IJGISStoryMap,
+  IJGISUIState,
   LayerType,
   SourceType,
 } from './_interface/project/jgis';
@@ -123,6 +124,7 @@ export interface IJupyterGISClientState {
 
 export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
   options: IJGISOptions;
+  uiState: IJGISUIState;
   layers: IJGISLayers;
   sources: IJGISSources;
   stories: IJGISStoryMaps;
@@ -177,6 +179,7 @@ export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
   removeMetadata(key: string): void;
 
   optionsChanged: ISignal<IJupyterGISDoc, MapChange>;
+  uiStateChanged: ISignal<IJupyterGISDoc, MapChange>;
   layersChanged: ISignal<IJupyterGISDoc, IJGISLayerDocChange>;
   sourcesChanged: ISignal<IJupyterGISDoc, IJGISSourceDocChange>;
   storyMapsChanged: ISignal<IJupyterGISDoc, IJGISStoryMapDocChange>;
@@ -286,6 +289,9 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   removeSource(id: string): void;
   getOptions(): IJGISOptions;
   setOptions(value: IJGISOptions): void;
+  getUIState(): IJGISUIState;
+  setUIState(value: Partial<IJGISUIState>): void;
+  uiStateChanged: ISignal<IJupyterGISModel, IJGISUIState>;
 
   removeLayerGroup(groupName: string): void;
   renameLayerGroup(groupName: string, newName: string): void;
@@ -503,4 +509,7 @@ export interface IJupyterGISSettings {
 
   // Map controls
   zoomButtonsEnabled?: boolean;
+
+  // Collaboration
+  syncUIState?: boolean;
 }

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -19,6 +19,7 @@ import {
   IJGISSource,
   IJGISSources,
   IJGISStoryMap,
+  IJGISUIState,
 } from './_interface/project/jgis';
 import {
   IStorySegmentLayer,
@@ -59,6 +60,7 @@ const DEFAULT_SETTINGS: IJupyterGISSettings = {
   identifyDisabled: false,
   storyMapsDisabled: false,
   zoomButtonsEnabled: false,
+  syncUIState: true,
 };
 
 export class JupyterGISModel implements IJupyterGISModel {
@@ -76,6 +78,7 @@ export class JupyterGISModel implements IJupyterGISModel {
       this._metadataChangedHandler,
       this,
     );
+    this._sharedModel.uiStateChanged.connect(this._uiStateChangedHandler, this);
     this.annotationModel = annotationModel;
     this.settingRegistry = settingRegistry;
     this._pathChanged = new Signal<JupyterGISModel, string>(this);
@@ -284,11 +287,11 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   set isTemporalControllerActive(isActive: boolean) {
-    this._isTemporalControllerActive = isActive;
+    this.setUIState({ temporalControllerOpen: isActive });
   }
 
   get isTemporalControllerActive(): boolean {
-    return this._isTemporalControllerActive;
+    return this._sharedModel.uiState.temporalControllerOpen ?? false;
   }
 
   centerOnPosition(id: string) {
@@ -297,6 +300,10 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   private _metadataChangedHandler(_: IJupyterGISDoc, args: MapChange) {
     this._sharedMetadataChanged.emit(args);
+  }
+
+  private _uiStateChangedHandler(_: IJupyterGISDoc, __: MapChange) {
+    this._uiStateChanged.emit(this._sharedModel.uiState);
   }
 
   addMetadata(key: string, value: string): void {
@@ -562,6 +569,18 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   getOptions(): IJGISOptions {
     return this._sharedModel.options;
+  }
+
+  setUIState(value: Partial<IJGISUIState>): void {
+    this._sharedModel.uiState = value;
+  }
+
+  getUIState(): IJGISUIState {
+    return this._sharedModel.uiState;
+  }
+
+  get uiStateChanged(): ISignal<IJupyterGISModel, IJGISUIState> {
+    return this._uiStateChanged;
   }
 
   syncViewport(viewport?: IViewPortState, emitter?: string): void {
@@ -1015,12 +1034,8 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   toggleTemporalController() {
-    this._isTemporalControllerActive = !this._isTemporalControllerActive;
-
-    this.sharedModel.awareness.setLocalStateField(
-      'isTemporalControllerActive',
-      this._isTemporalControllerActive,
-    );
+    const current = this._sharedModel.uiState.temporalControllerOpen ?? false;
+    this.setUIState({ temporalControllerOpen: !current });
   }
 
   private _getLayerTreeInfo(groupName: string):
@@ -1141,7 +1156,7 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   private _updateLayerSignal = new Signal<this, string>(this);
 
-  private _isTemporalControllerActive = false;
+  private _uiStateChanged = new Signal<this, IJGISUIState>(this);
 
   private _editing: { type: SelectionType; itemId: string } | null = null;
   private _editingChanged = new Signal<

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -291,7 +291,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   get isTemporalControllerActive(): boolean {
-    return this._sharedModel.uiState.temporalControllerOpen ?? false;
+    return this.getUIState().temporalControllerOpen ?? false;
   }
 
   centerOnPosition(id: string) {
@@ -303,7 +303,9 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   private _uiStateChangedHandler(_: IJupyterGISDoc, __: MapChange) {
-    this._uiStateChanged.emit(this._sharedModel.uiState);
+    if (this._jgisSettings.syncUIState ?? true) {
+      this._uiStateChanged.emit(this._sharedModel.uiState);
+    }
   }
 
   addMetadata(key: string, value: string): void {
@@ -572,11 +574,19 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   setUIState(value: Partial<IJGISUIState>): void {
-    this._sharedModel.uiState = value;
+    if (this._jgisSettings.syncUIState ?? true) {
+      this._sharedModel.uiState = value;
+    } else {
+      this._localUIState = { ...this._localUIState, ...value };
+      this._uiStateChanged.emit(this.getUIState());
+    }
   }
 
   getUIState(): IJGISUIState {
-    return this._sharedModel.uiState;
+    if (this._jgisSettings.syncUIState ?? true) {
+      return this._sharedModel.uiState;
+    }
+    return { ...this._sharedModel.uiState, ...this._localUIState };
   }
 
   get uiStateChanged(): ISignal<IJupyterGISModel, IJGISUIState> {
@@ -1156,6 +1166,7 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   private _updateLayerSignal = new Signal<this, string>(this);
 
+  private _localUIState: Partial<IJGISUIState> = {};
   private _uiStateChanged = new Signal<this, IJGISUIState>(this);
 
   private _editing: { type: SelectionType; itemId: string } | null = null;

--- a/packages/schema/src/schema/project/jgis.json
+++ b/packages/schema/src/schema/project/jgis.json
@@ -26,6 +26,9 @@
     "viewState": {
       "$ref": "#/definitions/jGISViewState"
     },
+    "uiState": {
+      "$ref": "#/definitions/jGISUIState"
+    },
     "metadata": {
       "type": "object",
       "patternProperties": {
@@ -210,6 +213,30 @@
       "default": [],
       "items": {
         "$ref": "#/definitions/jGISLayerItem"
+      }
+    },
+    "jGISUIState": {
+      "title": "IJGISUIState",
+      "type": "object",
+      "default": {},
+      "additionalProperties": false,
+      "properties": {
+        "leftPanelOpen": {
+          "type": "boolean",
+          "default": true
+        },
+        "rightPanelOpen": {
+          "type": "boolean",
+          "default": true
+        },
+        "consoleOpen": {
+          "type": "boolean",
+          "default": false
+        },
+        "temporalControllerOpen": {
+          "type": "boolean",
+          "default": false
+        }
       }
     },
     "jGISViewState": {

--- a/python/jupytergis_core/schema/jupytergis-settings.json
+++ b/python/jupytergis_core/schema/jupytergis-settings.json
@@ -63,6 +63,12 @@
       "title": "Enable Zoom Buttons",
       "description": "Enable + / − zoom buttons on the map.",
       "default": false
+    },
+    "syncUIState": {
+      "type": "boolean",
+      "title": "Sync UI State",
+      "description": "When enabled, panel visibility and workspace layout changes are written to the document and shared with collaborators. When disabled, layout changes stay local and are lost on reload.",
+      "default": true
     }
   }
 }


### PR DESCRIPTION
## Summary

Part of #892 (does not fix, advances). Closes #1283.

- Adds `jupytergis:togglePanel` toolbar button and command — shows all panels if any are hidden, hides all if all are shown
- Adds a minimize button to each panel (thin strip at top, appears on hover)
- Introduces `uiState` in the `.jgis` document model tracking `leftPanelOpen`, `rightPanelOpen`, `consoleOpen`, and `temporalControllerOpen`; panel and console visibility are driven by this state instead of DOM events or settings
- Adds a `syncUIState` JupyterLab setting (default: `true`) controlling whether layout changes are written to the shared document (visible to collaborators) or kept local
- Fixes panel dragging (was broken due to missing `nodeRef` with React 18 + react-draggable)
- Harmonizes left/right panel CSS into a single `.jgis-panel-container` class; removes the animated underline tab indicator in favour of `font-weight: 600` on the active tab; reduces tab list height and padding
- Adds a [state management explanation](docs/contributor_guide/explanation/state-management.md) to the contributor guide documenting when to use document state vs Settings vs StateDB vs React state

⚠️ Depends on #1280 — wait until that merges. See also the original PoC in #1216.

## Test plan

- Open a JupyterGIS file
- Click the toggle button in the toolbar — both panels should hide/show together; click again to restore
- Hover over a panel and click the minimize strip at the top — panel should collapse
- Reopen the file — panel state should be restored (both open by default)
- Toggle the console and reload — console state should be restored
- Set `syncUIState: false` in settings and verify layout changes are not shared with a second collaborator

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1281.org.readthedocs.build/en/1281/
💡 JupyterLite preview: https://jupytergis--1281.org.readthedocs.build/en/1281/lite
💡 Specta preview: https://jupytergis--1281.org.readthedocs.build/en/1281/lite/specta

<!-- readthedocs-preview jupytergis end -->