### PR TITLE
feat: mobile bottom sheet with MergedPanel

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,10 @@ htmlhelp_basename = "jupytergisdoc"
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
+nitpick_ignore = [
+    ("py:mod", "ypywidgets"),
+]
+
 jupyterlite_ignore_contents = [
     r".*\.qgz$",
     r"99-Explore_data_in_a_map\.ipynb$",

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -137,7 +137,7 @@ import TemporalSlider from './TemporalSlider';
 import { MainViewModel } from './mainviewmodel';
 import { SpectaPanel } from '../features/story/SpectaPanel';
 import type { IStoryViewerPanelHandle } from '../features/story/StoryViewerPanel';
-import { LeftPanel, RightPanel } from '../workspace/panels';
+import { LeftPanel, MergedPanel, RightPanel } from '../workspace/panels';
 
 type OlLayerTypes =
   | TileLayer
@@ -3308,24 +3308,42 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
               <div className="jgis-panels-wrapper">
                 {!this.state.isSpectaPresentation ? (
                   <>
-                    {this._state && (
-                      <LeftPanel
+                    {this.props.isMobile &&
+                    this._state &&
+                    this._formSchemaRegistry &&
+                    this._annotationModel ? (
+                      <MergedPanel
                         model={this._model}
                         commands={this._mainViewModel.commands}
                         state={this._state}
                         settings={this.state.jgisSettings}
-                      />
-                    )}
-                    {this._formSchemaRegistry && this._annotationModel && (
-                      <RightPanel
-                        model={this._model}
-                        commands={this._mainViewModel.commands}
                         formSchemaRegistry={this._formSchemaRegistry}
                         annotationModel={this._annotationModel}
                         addLayer={this.addLayer.bind(this)}
                         removeLayer={this.removeLayer.bind(this)}
-                        settings={this.state.jgisSettings}
                       />
+                    ) : (
+                      <>
+                        {this._state && (
+                          <LeftPanel
+                            model={this._model}
+                            commands={this._mainViewModel.commands}
+                            state={this._state}
+                            settings={this.state.jgisSettings}
+                          />
+                        )}
+                        {this._formSchemaRegistry && this._annotationModel && (
+                          <RightPanel
+                            model={this._model}
+                            commands={this._mainViewModel.commands}
+                            formSchemaRegistry={this._formSchemaRegistry}
+                            annotationModel={this._annotationModel}
+                            addLayer={this.addLayer.bind(this)}
+                            removeLayer={this.removeLayer.bind(this)}
+                            settings={this.state.jgisSettings}
+                          />
+                        )}
+                      </>
                     )}
                   </>
                 ) : (

--- a/packages/base/src/shared/components/Tabs.tsx
+++ b/packages/base/src/shared/components/Tabs.tsx
@@ -39,18 +39,19 @@ const TabsRoot: React.FC<IPanelTabProps> = ({
   );
 };
 
-const TabsList: React.FC<React.ComponentProps<typeof TabsPrimitive.List>> = ({
-  className,
-  ...props
-}) => {
+const TabsList = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.List>,
+  React.ComponentProps<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => {
   return (
     <TabsPrimitive.List
+      ref={ref}
       data-slot="tabs-list"
       className={cn('jgis-tabs-list', className)}
       {...props}
     />
   );
-};
+});
 
 const TabsTrigger: React.FC<
   React.ComponentProps<typeof TabsPrimitive.Trigger>

--- a/packages/base/src/workspace/panels/components/TabbedPanel.tsx
+++ b/packages/base/src/workspace/panels/components/TabbedPanel.tsx
@@ -28,10 +28,21 @@ export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
   onTabClick,
 }) => {
   const enabledTabs = tabs.filter(tab => tab.enabled);
+  const tabsListRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const list = tabsListRef.current;
+    const active = list?.querySelector<HTMLElement>('[data-state="active"]');
+    if (list && active) {
+      const listCenter = list.offsetWidth / 2;
+      const triggerCenter = active.offsetLeft + active.offsetWidth / 2;
+      list.scrollLeft = triggerCenter - listCenter;
+    }
+  }, [curTab]);
 
   return (
     <TabsRoot className="jgis-panel-tabs" curTab={curTab}>
-      <TabsList>
+      <TabsList ref={tabsListRef}>
         {enabledTabs.map(tab => (
           <TabsTrigger
             className="jGIS-layer-browser-category"

--- a/packages/base/src/workspace/panels/components/TabbedPanel.tsx
+++ b/packages/base/src/workspace/panels/components/TabbedPanel.tsx
@@ -20,12 +20,16 @@ interface ITabbedPanelProps {
   tabs: ITabConfig[];
   curTab: string;
   onTabClick: (name: string) => void;
+  onTabListMouseDown?: React.MouseEventHandler<HTMLDivElement>;
+  onTabListTouchStart?: React.TouchEventHandler<HTMLDivElement>;
 }
 
 export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
   tabs,
   curTab,
   onTabClick,
+  onTabListMouseDown,
+  onTabListTouchStart,
 }) => {
   const enabledTabs = tabs.filter(tab => tab.enabled);
   const tabsListRef = React.useRef<HTMLDivElement>(null);
@@ -42,7 +46,11 @@ export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
 
   return (
     <TabsRoot className="jgis-panel-tabs" curTab={curTab}>
-      <TabsList ref={tabsListRef}>
+      <TabsList
+        ref={tabsListRef}
+        onMouseDown={onTabListMouseDown}
+        onTouchStart={onTabListTouchStart}
+      >
         {enabledTabs.map(tab => (
           <TabsTrigger
             className="jGIS-layer-browser-category"

--- a/packages/base/src/workspace/panels/index.ts
+++ b/packages/base/src/workspace/panels/index.ts
@@ -1,3 +1,4 @@
 export * from './header';
 export * from './leftpanel';
+export * from './mergedpanel';
 export * from './rightpanel';

--- a/packages/base/src/workspace/panels/mergedpanel.tsx
+++ b/packages/base/src/workspace/panels/mergedpanel.tsx
@@ -37,6 +37,24 @@ export const MergedPanel: React.FC<IMergedPanelProps> = props => {
   const [leftPanelOpen] = useUIState('leftPanelOpen', props.model);
   const [rightPanelOpen] = useUIState('rightPanelOpen', props.model);
 
+  const [panelHeight, setPanelHeight] = React.useState<number | null>(null);
+
+  const onResizePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const onResizePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) {
+      return;
+    }
+    const newHeight = window.innerHeight - e.clientY;
+    setPanelHeight(Math.max(60, Math.min(newHeight, window.innerHeight * 0.9)));
+  };
+
+  const onResizePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.releasePointerCapture(e.pointerId);
+  };
+
   const [curTab, setCurTab] = React.useState<string>(() => {
     const { leftPanelDisabled, rightPanelDisabled } = props.settings;
     if (!leftPanelDisabled && !props.settings.layersDisabled) {
@@ -179,9 +197,16 @@ export const MergedPanel: React.FC<IMergedPanelProps> = props => {
           (leftPanelDisabled || leftPanelOpen === false) &&
           (rightPanelDisabled || rightPanelOpen === false)
             ? 'none'
-            : 'block',
+            : undefined,
+        ...(panelHeight !== null ? { height: `${panelHeight}px` } : {}),
       }}
     >
+      <div
+        className="jgis-resize-handle"
+        onPointerDown={onResizePointerDown}
+        onPointerMove={onResizePointerMove}
+        onPointerUp={onResizePointerUp}
+      />
       <TabbedPanel
         tabs={tabs}
         curTab={effectiveCurTab}

--- a/packages/base/src/workspace/panels/mergedpanel.tsx
+++ b/packages/base/src/workspace/panels/mergedpanel.tsx
@@ -38,21 +38,74 @@ export const MergedPanel: React.FC<IMergedPanelProps> = props => {
   const [rightPanelOpen] = useUIState('rightPanelOpen', props.model);
 
   const [panelHeight, setPanelHeight] = React.useState<number | null>(null);
+  const panelHeightRef = React.useRef<number | null>(null);
+  const isDraggingRef = React.useRef(false);
 
-  const onResizePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    e.currentTarget.setPointerCapture(e.pointerId);
+  const startTabListInteract = (startX: number, startY: number) => {
+    const startHeight = panelHeightRef.current ?? window.innerHeight * 0.3;
+    let gesture: 'undecided' | 'vertical' | 'horizontal' = 'undecided';
+
+    const classify = (dx: number, dy: number) => {
+      if (Math.hypot(dx, dy) > 6) {
+        gesture = Math.abs(dy) >= Math.abs(dx) ? 'vertical' : 'horizontal';
+      }
+    };
+
+    const applyResize = (clientY: number) => {
+      const clamped = Math.max(
+        60,
+        Math.min(startHeight + (startY - clientY), window.innerHeight * 0.9),
+      );
+      panelHeightRef.current = clamped;
+      setPanelHeight(clamped);
+    };
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (gesture === 'undecided') {
+        classify(ev.clientX - startX, ev.clientY - startY);
+      }
+      if (gesture === 'vertical') {
+        isDraggingRef.current = true;
+        applyResize(ev.clientY);
+      }
+    };
+
+    const onTouchMove = (ev: TouchEvent) => {
+      const t = ev.touches[0];
+      if (gesture === 'undecided') {
+        classify(t.clientX - startX, t.clientY - startY);
+      }
+      if (gesture === 'vertical') {
+        ev.preventDefault();
+        isDraggingRef.current = true;
+        applyResize(t.clientY);
+      }
+    };
+
+    const cleanup = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', cleanup);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', cleanup);
+      // Reset after click fires (click follows mouseup synchronously)
+      setTimeout(() => {
+        isDraggingRef.current = false;
+      }, 0);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', cleanup);
+    document.addEventListener('touchmove', onTouchMove, { passive: false });
+    document.addEventListener('touchend', cleanup);
   };
 
-  const onResizePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!e.currentTarget.hasPointerCapture(e.pointerId)) {
-      return;
-    }
-    const newHeight = window.innerHeight - e.clientY;
-    setPanelHeight(Math.max(60, Math.min(newHeight, window.innerHeight * 0.9)));
+  const onTabListMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    startTabListInteract(e.clientX, e.clientY);
   };
 
-  const onResizePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-    e.currentTarget.releasePointerCapture(e.pointerId);
+  const onTabListTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    const t = e.touches[0];
+    startTabListInteract(t.clientX, t.clientY);
   };
 
   const [curTab, setCurTab] = React.useState<string>(() => {
@@ -201,16 +254,18 @@ export const MergedPanel: React.FC<IMergedPanelProps> = props => {
         ...(panelHeight !== null ? { height: `${panelHeight}px` } : {}),
       }}
     >
-      <div
-        className="jgis-resize-handle"
-        onPointerDown={onResizePointerDown}
-        onPointerMove={onResizePointerMove}
-        onPointerUp={onResizePointerUp}
-      />
+      <div className="jgis-resize-handle" />
       <TabbedPanel
         tabs={tabs}
         curTab={effectiveCurTab}
-        onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
+        onTabClick={name => {
+          if (isDraggingRef.current) {
+            return;
+          }
+          setCurTab(prev => (prev === name ? '' : name));
+        }}
+        onTabListMouseDown={onTabListMouseDown}
+        onTabListTouchStart={onTabListTouchStart}
       />
     </div>
   );

--- a/packages/base/src/workspace/panels/mergedpanel.tsx
+++ b/packages/base/src/workspace/panels/mergedpanel.tsx
@@ -1,0 +1,192 @@
+import {
+  IAnnotationModel,
+  IJGISFormSchemaRegistry,
+  IJGISLayer,
+  IJupyterGISModel,
+  IJupyterGISSettings,
+} from '@jupytergis/schema';
+import { IStateDB } from '@jupyterlab/statedb';
+import { CommandRegistry } from '@lumino/commands';
+import * as React from 'react';
+
+import { ITabConfig, TabbedPanel } from './components/TabbedPanel';
+import { LayersBodyComponent } from './components/layers';
+import { useLayerTree } from './hooks/useLayerTree';
+import { useRightPanelOptions } from './hooks/useRightPanelOptions';
+import { useUIState } from './hooks/useUIState';
+import { RightPanelStoryViewer } from './rightpanel';
+import { AnnotationsPanel } from '../../features/annotations';
+import { IdentifyPanelComponent } from '../../features/identify/IdentifyPanel';
+import { ObjectPropertiesReact } from '../../features/objectproperties';
+import StacPanel from '../../features/stac-browser/components/StacPanel';
+import StoryEditorPanel from '../../features/story/StoryEditorPanel';
+import { PreviewModeSwitch } from '../../features/story/components/PreviewModeSwitch';
+
+export interface IMergedPanelProps {
+  model: IJupyterGISModel;
+  state: IStateDB;
+  commands: CommandRegistry;
+  settings: IJupyterGISSettings;
+  formSchemaRegistry: IJGISFormSchemaRegistry;
+  annotationModel: IAnnotationModel;
+  addLayer?: (id: string, layer: IJGISLayer, index: number) => Promise<void>;
+  removeLayer?: (id: string) => void;
+}
+
+export const MergedPanel: React.FC<IMergedPanelProps> = props => {
+  const [leftPanelOpen] = useUIState('leftPanelOpen', props.model);
+  const [rightPanelOpen] = useUIState('rightPanelOpen', props.model);
+
+  const [curTab, setCurTab] = React.useState<string>(() => {
+    const { leftPanelDisabled, rightPanelDisabled } = props.settings;
+    if (!leftPanelDisabled && !props.settings.layersDisabled) {
+      return 'layers';
+    }
+    if (!rightPanelDisabled && !props.settings.objectPropertiesDisabled) {
+      return 'objectProperties';
+    }
+    return '';
+  });
+
+  const [selectedObjectProperties, setSelectedObjectProperties] =
+    React.useState(undefined);
+
+  const { layerTree, segmentTree } = useLayerTree(props.model, props.commands, {
+    onSegmentAdded: () => setCurTab('segments'),
+  });
+
+  const {
+    storyMapPresentationMode,
+    editorMode,
+    showEditor,
+    storyPanelTitle,
+    toggleEditor,
+  } = useRightPanelOptions(props.model, {
+    onPresentationModeEnabled: () => setCurTab('storyPanel'),
+    onIdentifyFeatures: () => setCurTab('identifyPanel'),
+  });
+
+  const { leftPanelDisabled, rightPanelDisabled } = props.settings;
+
+  const tabs: ITabConfig[] = [
+    {
+      name: 'layers',
+      title: 'Layers',
+      enabled:
+        !leftPanelDisabled &&
+        !props.settings.layersDisabled &&
+        !storyMapPresentationMode,
+      content: (
+        <LayersBodyComponent
+          model={props.model}
+          commands={props.commands}
+          state={props.state}
+          layerTree={layerTree}
+        />
+      ),
+    },
+    {
+      name: 'stac',
+      title: 'Stac Browser',
+      enabled:
+        !leftPanelDisabled &&
+        !props.settings.stacBrowserDisabled &&
+        !storyMapPresentationMode,
+      content: <StacPanel model={props.model} />,
+    },
+    {
+      name: 'segments',
+      title: 'Segments',
+      enabled: !leftPanelDisabled && !props.settings.storyMapsDisabled,
+      content: (
+        <LayersBodyComponent
+          model={props.model}
+          commands={props.commands}
+          state={props.state}
+          layerTree={segmentTree}
+        />
+      ),
+    },
+    {
+      name: 'objectProperties',
+      title: 'Object Properties',
+      enabled:
+        !rightPanelDisabled &&
+        !props.settings.objectPropertiesDisabled &&
+        !storyMapPresentationMode,
+      content: (
+        <ObjectPropertiesReact
+          setSelectedObject={setSelectedObjectProperties}
+          selectedObject={selectedObjectProperties}
+          formSchemaRegistry={props.formSchemaRegistry}
+          model={props.model}
+        />
+      ),
+    },
+    {
+      name: 'storyPanel',
+      title: storyPanelTitle,
+      enabled: !rightPanelDisabled && !props.settings.storyMapsDisabled,
+      content: (
+        <>
+          {!storyMapPresentationMode && (
+            <PreviewModeSwitch
+              checked={!editorMode}
+              onCheckedChange={toggleEditor}
+            />
+          )}
+          {showEditor ? (
+            <StoryEditorPanel model={props.model} commands={props.commands} />
+          ) : curTab === 'storyPanel' ? (
+            <RightPanelStoryViewer
+              model={props.model}
+              addLayer={props.addLayer}
+              removeLayer={props.removeLayer}
+            />
+          ) : null}
+        </>
+      ),
+    },
+    {
+      name: 'annotations',
+      title: 'Annotations',
+      enabled: !rightPanelDisabled && !props.settings.annotationsDisabled,
+      content: (
+        <AnnotationsPanel
+          annotationModel={props.annotationModel}
+          jgisModel={props.model}
+        />
+      ),
+    },
+    {
+      name: 'identifyPanel',
+      title: 'Identified Features',
+      enabled: !rightPanelDisabled && !props.settings.identifyDisabled,
+      content: <IdentifyPanelComponent model={props.model} />,
+    },
+  ];
+
+  const enabledTabNames = tabs.filter(t => t.enabled).map(t => t.name);
+  const effectiveCurTab = enabledTabNames.includes(curTab)
+    ? curTab
+    : (enabledTabNames[0] ?? '');
+
+  return (
+    <div
+      className="jgis-merged-panel-container"
+      style={{
+        display:
+          (leftPanelDisabled || leftPanelOpen === false) &&
+          (rightPanelDisabled || rightPanelOpen === false)
+            ? 'none'
+            : 'block',
+      }}
+    >
+      <TabbedPanel
+        tabs={tabs}
+        curTab={effectiveCurTab}
+        onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
+      />
+    </div>
+  );
+};

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -31,7 +31,7 @@ import {
 /** Story viewer + useStoryMap hook
  * only mounted when story tab is active to avoid the hook causing re-renders when tab is hidden.
  **/
-function RightPanelStoryViewer({
+export function RightPanelStoryViewer({
   model,
   addLayer,
   removeLayer,

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -140,11 +140,69 @@ button.jp-mod-styled.jp-mod-reject {
     z-index: 1000;
     border-radius: 8px 8px 0 0;
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.2);
+    display: flex;
+    flex-direction: column;
+    height: 30vh;
+  }
+
+  /* Drag-to-resize handle */
+  .jgis-resize-handle {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 18px;
+    flex-shrink: 0;
+    cursor: ns-resize;
+    touch-action: none;
+  }
+
+  .jgis-resize-handle::before {
+    content: '';
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    background-color: var(--jp-border-color1);
+  }
+
+  /* Panel tabs fill the remaining height */
+  .jgis-merged-panel-container .jgis-panel-tabs {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
   }
 
   .jgis-merged-panel-container .jgis-tabs-content[data-state='active'] {
-    height: 30vh;
+    flex: 1;
+    min-height: 0;
+    height: unset;
     overflow-y: auto;
+  }
+
+  /* Tab list: natural-width tabs, horizontal scroll, thin scrollbar */
+  .jgis-merged-panel-container .jgis-tabs-list {
+    cursor: default;
+    justify-content: flex-start;
+    scrollbar-width: thin;
+    scrollbar-color: var(--jp-border-color1) transparent;
+  }
+
+  .jgis-merged-panel-container .jgis-tabs-list:active {
+    cursor: default;
+  }
+
+  .jgis-merged-panel-container .jgis-tabs-list::-webkit-scrollbar {
+    height: 3px;
+  }
+
+  .jgis-merged-panel-container .jgis-tabs-list::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .jgis-merged-panel-container .jgis-tabs-list::-webkit-scrollbar-thumb {
+    background-color: var(--jp-border-color1);
+    border-radius: 2px;
   }
 }
 

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -130,6 +130,24 @@ button.jp-mod-styled.jp-mod-reject {
   left: 0;
 }
 
+/* Mobile bottom sheet — merged panel only */
+@media (max-width: 768px) {
+  .jgis-merged-panel-container {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    border-radius: 8px 8px 0 0;
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .jgis-merged-panel-container .jgis-tabs-content[data-state='active'] {
+    height: 30vh;
+    overflow-y: auto;
+  }
+}
+
 .jgis-icon-adjust {
   padding-top: 5px;
 }

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -145,15 +145,14 @@ button.jp-mod-styled.jp-mod-reject {
     height: 30vh;
   }
 
-  /* Drag-to-resize handle */
+  /* Drag-to-resize handle — visual pill only */
   .jgis-resize-handle {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 18px;
+    height: 14px;
     flex-shrink: 0;
-    cursor: ns-resize;
-    touch-action: none;
+    pointer-events: none;
   }
 
   .jgis-resize-handle::before {
@@ -182,14 +181,15 @@ button.jp-mod-styled.jp-mod-reject {
 
   /* Tab list: natural-width tabs, horizontal scroll, thin scrollbar */
   .jgis-merged-panel-container .jgis-tabs-list {
-    cursor: default;
+    cursor: ns-resize;
     justify-content: flex-start;
+    touch-action: pan-x;
     scrollbar-width: thin;
     scrollbar-color: var(--jp-border-color1) transparent;
   }
 
   .jgis-merged-panel-container .jgis-tabs-list:active {
-    cursor: default;
+    cursor: ns-resize;
   }
 
   .jgis-merged-panel-container .jgis-tabs-list::-webkit-scrollbar {

--- a/ui-tests/tests/mobile-panel.spec.ts
+++ b/ui-tests/tests/mobile-panel.spec.ts
@@ -1,0 +1,120 @@
+import { galata, test } from '@jupyterlab/galata';
+import { expect } from '@playwright/test';
+import path from 'path';
+
+const FILENAME = 'panel-test.jGIS';
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
+
+test.describe('#mobilePanel', () => {
+  test.beforeAll(async ({ request }) => {
+    const content = galata.newContentsHelper(request);
+    await content.deleteDirectory('/testDir');
+    await content.uploadDirectory(
+      path.resolve(__dirname, './gis-files'),
+      '/testDir',
+    );
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.activity.closeAll();
+  });
+
+  test('merged panel is visible on mobile viewport', async ({ page }) => {
+    page.setViewportSize(MOBILE_VIEWPORT);
+    await page.filebrowser.open(`testDir/${FILENAME}`);
+    await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+
+    const mergedPanel = page.locator('.jgis-merged-panel-container');
+    await expect(mergedPanel).toBeVisible();
+  });
+
+  test('separate left/right panels are not shown on mobile', async ({
+    page,
+  }) => {
+    page.setViewportSize(MOBILE_VIEWPORT);
+    await page.filebrowser.open(`testDir/${FILENAME}`);
+    await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+
+    // On mobile the merged panel is used; the desktop panel containers
+    // should not be present as standalone positioned elements
+    await expect(page.locator('.jgis-merged-panel-container')).toBeVisible();
+    await expect(page.locator('.jgis-left-panel-container')).not.toBeVisible();
+    await expect(page.locator('.jgis-right-panel-container')).not.toBeVisible();
+  });
+
+  test('merged panel is not shown on desktop viewport', async ({ page }) => {
+    page.setViewportSize(DESKTOP_VIEWPORT);
+    await page.filebrowser.open(`testDir/${FILENAME}`);
+    await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+
+    await expect(
+      page.locator('.jgis-merged-panel-container'),
+    ).not.toBeVisible();
+    await expect(page.locator('.jgis-left-panel-container')).toBeVisible();
+  });
+
+  test('pill indicator is visible on mobile', async ({ page }) => {
+    page.setViewportSize(MOBILE_VIEWPORT);
+    await page.filebrowser.open(`testDir/${FILENAME}`);
+    await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+
+    await expect(page.locator('.jgis-resize-handle')).toBeVisible();
+  });
+
+  test('clicking a tab switches the active tab', async ({ page }) => {
+    page.setViewportSize(MOBILE_VIEWPORT);
+    await page.filebrowser.open(`testDir/${FILENAME}`);
+    await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+
+    const panel = page.locator('.jgis-merged-panel-container');
+    const triggers = panel.locator('.jgis-tabs-trigger');
+
+    // Click the second enabled tab
+    const secondTab = triggers.nth(1);
+    const secondTabName = await secondTab.textContent();
+    await secondTab.click();
+
+    // That tab should now be active
+    await expect(secondTab).toHaveAttribute('data-state', 'active');
+
+    // Click back to the first tab
+    await triggers.nth(0).click();
+    await expect(triggers.nth(0)).toHaveAttribute('data-state', 'active');
+    await expect(secondTab).toHaveAttribute('data-state', 'inactive');
+
+    console.log(`Tab switching verified for: ${secondTabName}`);
+  });
+
+  test('dragging tab list vertically resizes the panel', async ({ page }) => {
+    page.setViewportSize(MOBILE_VIEWPORT);
+    await page.filebrowser.open(`testDir/${FILENAME}`);
+    await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+
+    const panel = page.locator('.jgis-merged-panel-container');
+    const tabList = panel.locator('.jgis-tabs-list');
+
+    const initialBox = await panel.boundingBox();
+    expect(initialBox).not.toBeNull();
+
+    // Drag the tab list upward to expand the panel
+    const tabBox = await tabList.boundingBox();
+    expect(tabBox).not.toBeNull();
+
+    const startX = tabBox!.x + tabBox!.width / 2;
+    const startY = tabBox!.y + tabBox!.height / 2;
+    const dragDistance = 100;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    // Move slowly to trigger direction detection
+    for (let i = 1; i <= 10; i++) {
+      await page.mouse.move(startX, startY - (dragDistance * i) / 10);
+    }
+    await page.mouse.up();
+
+    const resizedBox = await panel.boundingBox();
+    expect(resizedBox).not.toBeNull();
+    expect(resizedBox!.height).toBeGreaterThan(initialBox!.height + 50);
+  });
+});


### PR DESCRIPTION
## Summary

Part of #892 (does not fix, advances). See also the original PoC in #1216.

Adds a `MergedPanel` component that replaces the separate `LeftPanel` and
`RightPanel` on mobile screens (≤768px) with a single bottom sheet combining
all tabs.

## Test plan

- Open a JupyterGIS file on a mobile-sized screen (≤768px)
- Verify a single bottom sheet panel appears with all tabs
- Toggle button in toolbar shows/hides the panel
- On desktop (>768px) the existing left and right panels are unchanged

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1282.org.readthedocs.build/en/1282/
💡 JupyterLite preview: https://jupytergis--1282.org.readthedocs.build/en/1282/lite
💡 Specta preview: https://jupytergis--1282.org.readthedocs.build/en/1282/lite/specta

<!-- readthedocs-preview jupytergis end -->