### PR TITLE
Disable pre-commit autofixes on PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,7 @@
 ci:
   # pre-commit.ci will open PRs updating our hooks once a month
   autoupdate_schedule: quarterly
-  # skip any check that needs internet access
-  autofix_prs: true
+  autofix_prs: false
 
 exclude: '.*\.jgis$'
 repos:


### PR DESCRIPTION
## Description

This behavior can be annoying. I'm not adamant about this, I just don't like it. If someone on the team likes this behavior we can keep it on. I'd much prefer to manually trigger autofixes with a `pre-commit.ci autofix` comment, which works even after this change.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1289.org.readthedocs.build/en/1289/
💡 JupyterLite preview: https://jupytergis--1289.org.readthedocs.build/en/1289/lite
💡 Specta preview: https://jupytergis--1289.org.readthedocs.build/en/1289/lite/specta

<!-- readthedocs-preview jupytergis end -->