### PR TITLE
fix: make left panel draggable; align structure with right panel

### DIFF
--- a/packages/base/src/workspace/panels/components/TabbedPanel.tsx
+++ b/packages/base/src/workspace/panels/components/TabbedPanel.tsx
@@ -18,46 +18,40 @@ export interface ITabConfig {
 
 interface ITabbedPanelProps {
   tabs: ITabConfig[];
-  containerClassName: string;
   curTab: string;
   onTabClick: (name: string) => void;
-  style?: React.CSSProperties;
 }
 
 export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
   tabs,
-  containerClassName,
   curTab,
   onTabClick,
-  style,
 }) => {
   const enabledTabs = tabs.filter(tab => tab.enabled);
 
   return (
-    <div className={containerClassName} style={style}>
-      <TabsRoot className="jgis-panel-tabs" curTab={curTab}>
-        <TabsList>
-          {enabledTabs.map(tab => (
-            <TabsTrigger
-              className="jGIS-layer-browser-category"
-              key={tab.name}
-              value={tab.name}
-              onClick={() => onTabClick(tab.name)}
-            >
-              {tab.title}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+    <TabsRoot className="jgis-panel-tabs" curTab={curTab}>
+      <TabsList>
         {enabledTabs.map(tab => (
-          <TabsContent
+          <TabsTrigger
+            className="jGIS-layer-browser-category"
             key={tab.name}
             value={tab.name}
-            className={cn('jgis-panel-tab-content', tab.contentClassName)}
+            onClick={() => onTabClick(tab.name)}
           >
-            {tab.content}
-          </TabsContent>
+            {tab.title}
+          </TabsTrigger>
         ))}
-      </TabsRoot>
-    </div>
+      </TabsList>
+      {enabledTabs.map(tab => (
+        <TabsContent
+          key={tab.name}
+          value={tab.name}
+          className={cn('jgis-panel-tab-content', tab.contentClassName)}
+        >
+          {tab.content}
+        </TabsContent>
+      ))}
+    </TabsRoot>
   );
 };

--- a/packages/base/src/workspace/panels/leftpanel.tsx
+++ b/packages/base/src/workspace/panels/leftpanel.tsx
@@ -29,6 +29,7 @@ interface ILeftPanelProps {
 }
 
 export const LeftPanel: React.FC<ILeftPanelProps> = props => {
+  const nodeRef = React.useRef<HTMLDivElement>(null);
   const [options, setOptions] = React.useState(props.model.getOptions());
   const storyMapPresentationMode = options.storyMapPresentationMode ?? false;
   const [leftPanelOpen] = useUIState('leftPanelOpen', props.model);
@@ -102,15 +103,14 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
 
   return (
     <Draggable
+      nodeRef={nodeRef}
       handle=".jgis-tabs-list"
       cancel=".jgis-tabs-trigger"
       bounds=".jGIS-Mainview-Container"
     >
-      <TabbedPanel
-        tabs={tabs}
-        containerClassName="jgis-left-panel-container"
-        curTab={curTab}
-        onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
+      <div
+        ref={nodeRef}
+        className="jgis-left-panel-container"
         style={{
           display:
             props.settings.leftPanelDisabled ||
@@ -119,7 +119,13 @@ export const LeftPanel: React.FC<ILeftPanelProps> = props => {
               ? 'none'
               : 'block',
         }}
-      />
+      >
+        <TabbedPanel
+          tabs={tabs}
+          curTab={curTab}
+          onTabClick={name => setCurTab(prev => (prev === name ? '' : name))}
+        />
+      </div>
     </Draggable>
   );
 };


### PR DESCRIPTION
## Summary

- Fixes left panel not being draggable by adding `nodeRef` to `Draggable` (required for React 18 since `findDOMNode` is removed)
- Removes the extra wrapper div from `TabbedPanel` so left and right panel have the same DOM structure: container div → `TabsRoot` → content

## Test plan

- [ ] Left panel is draggable
- [ ] Right panel still draggable
- [ ] Left panel layout matches right panel

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1301.org.readthedocs.build/en/1301/
💡 JupyterLite preview: https://jupytergis--1301.org.readthedocs.build/en/1301/lite
💡 Specta preview: https://jupytergis--1301.org.readthedocs.build/en/1301/lite/specta

<!-- readthedocs-preview jupytergis end -->