### PR TITLE
fix: temporal controller visibility based on layer selection

### DIFF
--- a/examples/data/temporal-test.geojson
+++ b/examples/data/temporal-test.geojson
@@ -1,0 +1,15 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [2.35, 48.85] },
+      "properties": { "name": "Paris", "time": "2024-01-01" }
+    },
+    {
+      "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [13.40, 52.52] },
+      "properties": { "name": "Berlin", "time": "2024-06-01" }
+    }
+  ]
+}

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -352,19 +352,11 @@ export function addCommands(
       }
 
       // Selection should only be one vector or heatmap layer
-      const isSelectionValid =
+      return (
         Object.keys(selectedLayers).length === 1 &&
         !model.getSource(layerId) &&
-        ['VectorLayer', 'HeatmapLayer'].includes(layerType);
-
-      if (!isSelectionValid && model.isTemporalControllerActive) {
-        model.toggleTemporalController();
-        commands.notifyCommandChanged(CommandIDs.temporalController);
-
-        return false;
-      }
-
-      return true;
+        ['VectorLayer', 'HeatmapLayer'].includes(layerType)
+      );
     },
 
     execute: (args?: { filePath?: string }) => {

--- a/packages/base/src/mainview/TemporalSlider.tsx
+++ b/packages/base/src/mainview/TemporalSlider.tsx
@@ -25,6 +25,7 @@ import { useGetProperties } from '@/src/features/layers/symbology/hooks/useGetPr
 interface ITemporalSliderProps {
   model: IJupyterGISModel;
   filterStates: IDict<IJGISFilterItem | undefined>;
+  style?: React.CSSProperties;
 }
 
 // List of common date formats to try
@@ -56,6 +57,7 @@ const stepMap = {
 const TemporalSlider: React.FC<ITemporalSliderProps> = ({
   model,
   filterStates,
+  style,
 }) => {
   const [layerId, setLayerId] = useState('');
   const [selectedFeature, setSelectedFeature] = useState('');
@@ -354,7 +356,7 @@ const TemporalSlider: React.FC<ITemporalSliderProps> = ({
   };
 
   return (
-    <div className="jp-gis-temporal-slider-container">
+    <div className="jp-gis-temporal-slider-container" style={style}>
       <div className="jp-gis-temporal-slider-row">
         {/* Feature select */}
         <div>

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -3119,6 +3119,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const olLayer = this.getLayer(layerId);
     const source = olLayer.getSource() as VectorSource;
 
+    if (typeof source.forEachFeature !== 'function') {
+      return;
+    }
+
     source.forEachFeature(feature => {
       const time = feature.get(selectedFeature);
       const parsedTime = typeof time === 'string' ? Date.parse(time) : time;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2267,16 +2267,25 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this.setState(old => ({ ...old, clientPointers }));
     });
 
-    // Temporal controller bit
-    // ? There's probably a better way to get changes in the model to trigger react rerenders
-    const isTemporalControllerActive = localState.isTemporalControllerActive;
+    // Compute displayTemporalController: active AND current selection is valid
+    const isTemporalControllerActive = !!localState.isTemporalControllerActive;
+    const selectedLayers = localState.selected?.value;
+    const selectedLayerId = selectedLayers
+      ? (Object.keys(selectedLayers)[0] ?? null)
+      : null;
+    const layerType = selectedLayerId
+      ? this._model.getLayer(selectedLayerId)?.type
+      : null;
+    const isSelectionValid =
+      !!selectedLayers &&
+      Object.keys(selectedLayers).length === 1 &&
+      !this._model.getSource(selectedLayerId!) &&
+      ['VectorLayer', 'HeatmapLayer'].includes(layerType ?? '');
+    const displayTemporalController =
+      isTemporalControllerActive && isSelectionValid;
 
-    if (isTemporalControllerActive !== this.state.displayTemporalController) {
-      this.setState(old => ({
-        ...old,
-        displayTemporalController: isTemporalControllerActive,
-      }));
-
+    if (displayTemporalController !== this.state.displayTemporalController) {
+      this.setState(old => ({ ...old, displayTemporalController }));
       this._mainViewModel.commands.notifyCommandChanged(
         CommandIDs.temporalController,
       );
@@ -3216,12 +3225,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         })}
 
         <div className="jGIS-Mainview-Container">
-          {this.state.displayTemporalController && (
-            <TemporalSlider
-              model={this._model}
-              filterStates={this.state.filterStates}
-            />
-          )}
+          <TemporalSlider
+            model={this._model}
+            filterStates={this.state.filterStates}
+            style={{
+              display: this.state.displayTemporalController ? 'block' : 'none',
+            }}
+          />
           <div
             ref={this.mainViewRef}
             className="jGIS-Mainview data-jgis-keybinding"


### PR DESCRIPTION
## Summary

- Fixes a crash (`forEachFeature is not a function`) when the temporal controller was active on a non-vector source layer
- Removes a side effect in `isEnabled` that was causing the temporal slider to close unexpectedly on pointer moves
- Reintroduces the layer-validity check from upstream: the slider hides when the selected layer is not a `VectorLayer` or `HeatmapLayer`, but the controller stays active — switching back to a valid layer shows the slider again without needing to re-enable it manually
- Adds a minimal GeoJSON test dataset (`examples/data/temporal-test.geojson`), closing #1304

## Test plan

- [ ] Open `temporal-test.geojson` as a vector layer, enable the temporal controller — slider should appear
- [ ] Select a non-vector layer (e.g. raster) — slider should hide, controller stays toggled on
- [ ] Switch back to the vector layer — slider should reappear automatically
- [ ] Verify no console errors when switching between layer types

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1305.org.readthedocs.build/en/1305/
💡 JupyterLite preview: https://jupytergis--1305.org.readthedocs.build/en/1305/lite
💡 Specta preview: https://jupytergis--1305.org.readthedocs.build/en/1305/lite/specta

<!-- readthedocs-preview jupytergis end -->