### PR TITLE
fix macrostrat raster url

### DIFF
--- a/packages/base/layer_gallery_generator.py
+++ b/packages/base/layer_gallery_generator.py
@@ -188,7 +188,7 @@ custom_providers = providers.copy()
 custom_providers["MacroStrat"] = {
     "CartoRaster": TileProvider(
         name="MacroStrat.CartoRaster",
-        url="https://tiles.macrostrat.org/carto-slim/{z}/{x}/{y}.png",
+        url="https://tiles.macrostrat.org/carto/{z}/{x}/{y}.png",
         attribution="© Geologic data © <a href=https://macrostrat.org>Macrostrat raster layer</a> (CC‑BY 4.0)",
         max_zoom=18,
     ),


### PR DESCRIPTION
## Description

The macrostrat raster url was accidentally changed together with the vector url. This PR reverts it to the correct one.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1306.org.readthedocs.build/en/1306/
💡 JupyterLite preview: https://jupytergis--1306.org.readthedocs.build/en/1306/lite
💡 Specta preview: https://jupytergis--1306.org.readthedocs.build/en/1306/lite/specta

<!-- readthedocs-preview jupytergis end -->