### PR TITLE
refactor: move icons to shared.

### DIFF
--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -18,6 +18,7 @@ import { ReadonlyPartialJSONObject, UUID } from '@lumino/coreutils';
 import { Coordinate } from 'ol/coordinate';
 import { fromLonLat } from 'ol/proj';
 
+import { targetWithCenterIcon } from '@/src/shared/icons';
 import { addLayerCreationCommands } from './operationCommands';
 import { CommandIDs, icons } from '../constants';
 import { LayerCreationFormDialog } from '../dialogs/layerCreationFormDialog';
@@ -26,7 +27,6 @@ import { SymbologyWidget } from '../features/layers/symbology/symbologyDialog';
 import { ProcessingFormDialog } from '../features/processing/ProcessingFormDialog';
 import { getSingleSelectedLayer } from '../features/processing/index';
 import { addProcessingCommands } from '../features/processing/processingCommands';
-import { targetWithCenterIcon } from '../icons';
 import keybindings from '../keybindings.json';
 import { getGeoJSONDataFromLayerSource, downloadFile } from '../tools';
 import { JupyterGISTracker, SYMBOLOGY_VALID_LAYER_TYPES } from '../types';

--- a/packages/base/src/constants.ts
+++ b/packages/base/src/constants.ts
@@ -12,7 +12,7 @@ import {
   rasterIcon,
   vectorSquareIcon,
   markerIcon,
-} from './icons';
+} from './shared/icons';
 
 /**
  * The command IDs.

--- a/packages/base/src/formbuilder/objectform/components/StorySegmentReset.tsx
+++ b/packages/base/src/formbuilder/objectform/components/StorySegmentReset.tsx
@@ -2,8 +2,8 @@ import { IJupyterGISModel } from '@jupytergis/schema';
 import { LabIcon } from '@jupyterlab/ui-components';
 import React from 'react';
 
-import { targetWithCenterIcon } from '@/src/icons';
 import { Button } from '@/src/shared/components/Button';
+import { targetWithCenterIcon } from '@/src/shared/icons';
 
 interface IStorySegmentResetProps {
   model?: IJupyterGISModel;

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -2,7 +2,7 @@ export * from './features/annotations';
 export * from './commands/index';
 export * from './constants';
 export * from './dialogs/layerCreationFormDialog';
-export * from './icons';
+export * from './shared/icons';
 export * from './mainview';
 export * from './menus';
 export * from './workspace/panels';

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -120,6 +120,7 @@ import { CommandIDs } from '@/src/constants';
 import AnnotationFloater from '@/src/features/annotations/components/AnnotationFloater';
 import { LoadingOverlay } from '@/src/shared/components/loading';
 import useMediaQuery from '@/src/shared/hooks/useMediaQuery';
+import { markerIcon } from '@/src/shared/icons';
 import {
   debounce,
   INTERNAL_PROXY_BASE,
@@ -135,7 +136,6 @@ import TemporalSlider from './TemporalSlider';
 import { MainViewModel } from './mainviewmodel';
 import { SpectaPanel } from '../features/story/SpectaPanel';
 import type { IStoryViewerPanelHandle } from '../features/story/StoryViewerPanel';
-import { markerIcon } from '../icons';
 import { LeftPanel, RightPanel } from '../workspace/panels';
 
 type OlLayerTypes =

--- a/packages/base/src/menus.ts
+++ b/packages/base/src/menus.ts
@@ -2,7 +2,7 @@ import { CommandRegistry } from '@lumino/commands';
 import { Menu } from '@lumino/widgets';
 
 import { CommandIDs } from './constants';
-import { rasterIcon } from './icons';
+import { rasterIcon } from './shared/icons';
 
 export const vectorSubMenu = (commands: CommandRegistry) => {
   const subMenu = new Menu({ commands });

--- a/packages/base/src/shared/icons.ts
+++ b/packages/base/src/shared/icons.ts
@@ -7,25 +7,25 @@
 
 import { LabIcon } from '@jupyterlab/ui-components';
 
-import bookOpenSvgStr from '../style/icons/book_open.svg';
-import clockSvgStr from '../style/icons/clock-solid.svg';
-import geoJsonSvgStr from '../style/icons/geojson.svg';
-import geolocationSvgStr from '../style/icons/geolocation.svg';
-import geoPackageSvgStr from '../style/icons/geopackage.svg';
-import infoSvgStr from '../style/icons/info-solid.svg';
-import logoSvgStr from '../style/icons/logo.svg';
-import logoMiniSvgStr from '../style/icons/logo_mini.svg';
-import logoMiniAlternativeSvgStr from '../style/icons/logo_mini_alternative.svg';
-import logoMiniQGZ from '../style/icons/logo_mini_qgz.svg';
-import markerSvgStr from '../style/icons/marker.svg';
-import moundSvgStr from '../style/icons/mound.svg';
-import nonVisibilitySvgStr from '../style/icons/nonvisibility.svg';
-import rasterSvgStr from '../style/icons/raster.svg';
-import targetWithCenterSvgStr from '../style/icons/target_with_center.svg';
-import targetWithoutCenterSvgStr from '../style/icons/target_without_center.svg';
-import terminalToolbarSvgStr from '../style/icons/terminal_toolbar.svg';
-import vectorSquareSvgStr from '../style/icons/vector_square.svg';
-import visibilitySvgStr from '../style/icons/visibility.svg';
+import bookOpenSvgStr from '../../style/icons/book_open.svg';
+import clockSvgStr from '../../style/icons/clock-solid.svg';
+import geoJsonSvgStr from '../../style/icons/geojson.svg';
+import geolocationSvgStr from '../../style/icons/geolocation.svg';
+import geoPackageSvgStr from '../../style/icons/geopackage.svg';
+import infoSvgStr from '../../style/icons/info-solid.svg';
+import logoSvgStr from '../../style/icons/logo.svg';
+import logoMiniSvgStr from '../../style/icons/logo_mini.svg';
+import logoMiniAlternativeSvgStr from '../../style/icons/logo_mini_alternative.svg';
+import logoMiniQGZ from '../../style/icons/logo_mini_qgz.svg';
+import markerSvgStr from '../../style/icons/marker.svg';
+import moundSvgStr from '../../style/icons/mound.svg';
+import nonVisibilitySvgStr from '../../style/icons/nonvisibility.svg';
+import rasterSvgStr from '../../style/icons/raster.svg';
+import targetWithCenterSvgStr from '../../style/icons/target_with_center.svg';
+import targetWithoutCenterSvgStr from '../../style/icons/target_without_center.svg';
+import terminalToolbarSvgStr from '../../style/icons/terminal_toolbar.svg';
+import vectorSquareSvgStr from '../../style/icons/vector_square.svg';
+import visibilitySvgStr from '../../style/icons/visibility.svg';
 
 export const logoIcon = new LabIcon({
   name: 'jupytergis::logo',

--- a/packages/base/src/workspace/panels/components/layers.tsx
+++ b/packages/base/src/workspace/panels/components/layers.tsx
@@ -28,7 +28,7 @@ import {
   nonVisibilityIcon,
   targetWithCenterIcon,
   visibilityIcon,
-} from '@/src/icons';
+} from '@/src/shared/icons';
 import { ILeftPanelClickHandlerParams } from '@/src/workspace/panels/leftpanel';
 import { LegendItem } from './legendItem';
 

--- a/packages/base/src/workspace/toolbar/widget.tsx
+++ b/packages/base/src/workspace/toolbar/widget.tsx
@@ -18,8 +18,8 @@ import { Widget } from '@lumino/widgets';
 import * as React from 'react';
 
 import { CommandIDs } from '@/src/constants';
-import { terminalToolbarIcon } from '@/src/icons';
 import { rasterSubMenu, vectorSubMenu } from '@/src/menus';
+import { terminalToolbarIcon } from '@/src/shared/icons';
 
 export const TOOLBAR_SEPARATOR_CLASS = 'jGIS-Toolbar-Separator';
 export const TOOLBAR_GROUPNAME_CLASS = 'jGIS-Toolbar-GroupName';


### PR DESCRIPTION
Part of #1235.

## Changes so far

- `icons.ts` → `shared/icons.ts` (fixes relative SVG paths)

More commits to follow on this branch.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1310.org.readthedocs.build/en/1310/
💡 JupyterLite preview: https://jupytergis--1310.org.readthedocs.build/en/1310/lite
💡 Specta preview: https://jupytergis--1310.org.readthedocs.build/en/1310/lite/specta

<!-- readthedocs-preview jupytergis end -->