### PR TITLE
fix: update VectorTile proxy loader for OpenLayers 10.9.0

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -829,28 +829,33 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
               vtSourceOptions.tileLoadFunction = (tile, tileUrl) => {
                 const vtTile = tile as VectorTile<RenderFeature>;
                 const proxyUrl = `${proxyBase}?url=${encodeURIComponent(tileUrl)}${headersParam}`;
-                vtTile.setLoader(async (extent, _resolution, projection) => {
-                  try {
-                    const response = await fetch(proxyUrl);
-                    if (!response.ok) {
-                      throw new Error(
-                        `Tile proxy request failed: ${response.status} ${response.statusText}`,
+                vtTile.setLoader((extent, _resolution, projection) => {
+                  return fetch(proxyUrl)
+                    .then(response => {
+                      if (!response.ok) {
+                        throw new Error(
+                          `Tile proxy request failed: ${response.status} ${response.statusText}`,
+                        );
+                      }
+                      return response.arrayBuffer();
+                    })
+                    .then(data => {
+                      const features = vtTile.getFormat().readFeatures(data, {
+                        extent,
+                        featureProjection: projection,
+                      });
+                      vtTile.setFeatures(features);
+                      this._log('debug', `Proxy tile loaded: ${tileUrl}`);
+                      return features;
+                    })
+                    .catch((err: any) => {
+                      this._log(
+                        'error',
+                        `Proxy tile error for ${tileUrl}: ${err.message}`,
                       );
-                    }
-                    const data = await response.arrayBuffer();
-                    const features = vtTile.getFormat().readFeatures(data, {
-                      extent,
-                      featureProjection: projection,
+                      tile.setState(TileState.ERROR);
+                      return [];
                     });
-                    vtTile.setFeatures(features);
-                    this._log('debug', `Proxy tile loaded: ${tileUrl}`);
-                  } catch (err: any) {
-                    this._log(
-                      'error',
-                      `Proxy tile error for ${tileUrl}: ${err.message}`,
-                    );
-                    tile.setState(TileState.ERROR);
-                  }
                 });
               };
             }


### PR DESCRIPTION
## Summary

OpenLayers [10.9.0](https://github.com/openlayers/openlayers/releases/tag/v10.9.0) introduced promise-based vector loaders in [PR #17403](https://github.com/openlayers/openlayers/pull/17403) ("Promise based vector loader; fix failure handling"). This changed the `FeatureLoader<T>` return type from `void` to `void | Promise<T[]>`.

The existing proxy tile loader used `async/await`, which implicitly returns `Promise<void>`. Since `Promise<void>` is not assignable to `Promise<RenderFeature[]>`, this caused a TypeScript error in the CI "build without lockfile" job, which resolves `^10.1.0` to the latest 10.x (10.9.0):

```
error TS2345: Argument of type '(extent: Extent, _resolution: number, projection: Projection) => Promise<void>'
is not assignable to parameter of type 'FeatureLoader<RenderFeature>'.
  Type 'Promise<void>' is not assignable to type 'void | Promise<RenderFeature[]>'.
```

## Fix

Convert the `async/await` loader to an explicit `.then()/.catch()` chain that returns `Promise<RenderFeature[]>`, satisfying the new type constraint. Runtime behaviour is identical.

## Testing

To manually test the proxy tile loader, add a Vector Tile layer with the following URL and enable the **Use Proxy** checkbox:

```
https://api.hubocean.earth/api/table/v2/tile?table_id=23db622e-b657-42fb-9de4-23b4603a0b5a&z={z}&x={x}&y={y}
```

## Test plan

- [ ] TypeScript build passes (`jlpm tsc --noEmit` in `packages/base`)
- [ ] "build without lockfile" CI job passes
- [ ] Vector Tile layer loads correctly via the proxy

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1317.org.readthedocs.build/en/1317/
💡 JupyterLite preview: https://jupytergis--1317.org.readthedocs.build/en/1317/lite
💡 Specta preview: https://jupytergis--1317.org.readthedocs.build/en/1317/lite/specta

<!-- readthedocs-preview jupytergis end -->