### PR TITLE
Use direct link to contributer guide

### DIFF
--- a/python/jupytergis/README.md
+++ b/python/jupytergis/README.md
@@ -102,7 +102,7 @@ We welcome contributions from the community! To contribute:
 - Make your changes
 - Submit a pull request
 
-For more details, check out our [CONTRIBUTING.md](https://github.com/geojupyter/jupytergis/blob/main/CONTRIBUTING.md).
+For more details, check out our [Contributer Guide](https://jupytergis.readthedocs.io/en/latest/contributor_guide/index.html).
 
 ## License
 


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Use the actual contributor guide link in the readme.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1318.org.readthedocs.build/en/1318/
💡 JupyterLite preview: https://jupytergis--1318.org.readthedocs.build/en/1318/lite
💡 Specta preview: https://jupytergis--1318.org.readthedocs.build/en/1318/lite/specta

<!-- readthedocs-preview jupytergis end -->