### PR TITLE
Security: Unbounded awareness event listeners can accumulate (client-side DoS risk)

### DIFF
--- a/packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts
+++ b/packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts
@@ -70,12 +70,16 @@ export const useGetSymbology = ({
     // initial load
     fetchSymbology();
 
-    model.sharedModel.awareness.on('change', () => {
+    const awareness = model.sharedModel.awareness;
+    const awarenessChangeHandler = () => {
       fetchSymbology();
-    });
+    };
+
+    awareness.on('change', awarenessChangeHandler);
 
     return () => {
       disposed = true;
+      awareness.off('change', awarenessChangeHandler);
     };
   }, [layerId, model]);
 


### PR DESCRIPTION
## Summary

Security: Unbounded awareness event listeners can accumulate (client-side DoS risk)

## Problem

**Severity**: `Medium` | **File**: `packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts:L74`

The hook subscribes to `model.sharedModel.awareness.on('change', ...)` but never unsubscribes in the cleanup function. Re-mounts or dependency changes can register multiple listeners, causing repeated `fetchSymbology()` execution and increasing CPU/memory usage over time. In collaborative scenarios, frequent awareness updates could amplify this into an availability issue.

## Solution

Store the listener function in a stable variable and remove it in the effect cleanup (e.g., `awareness.off('change', handler)`). Also consider debouncing/throttling updates if awareness events are frequent.

## Changes

- `packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts` (modified)

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1323.org.readthedocs.build/en/1323/
💡 JupyterLite preview: https://jupytergis--1323.org.readthedocs.build/en/1323/lite
💡 Specta preview: https://jupytergis--1323.org.readthedocs.build/en/1323/lite/specta

<!-- readthedocs-preview jupytergis end -->