### PR TITLE
Bugfix: `symbologyState` incorrectly initialized as `undefined`

### DIFF
--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampControls.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampControls.tsx
@@ -64,7 +64,7 @@ const ColorRampControls: React.FC<IColorRampControlsProps> = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [reverseRamp, setReverseRamp] = useState<boolean>(false);
   const [warning, setWarning] = useState<string | null>(null);
-  const symbologyState = layerParams.symbologyState;
+  const symbologyState = layerParams.symbologyState ?? {};
 
   useEffect(() => {
     if (symbologyState) {


### PR DESCRIPTION
## Description

Fix `symbologyState` get's `undefined` for new added layers.


https://github.com/user-attachments/assets/3cda92e4-9d6e-4b4d-85b9-bfc488929c0e

- Closes #1321 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1326.org.readthedocs.build/en/1326/
💡 JupyterLite preview: https://jupytergis--1326.org.readthedocs.build/en/1326/lite
💡 Specta preview: https://jupytergis--1326.org.readthedocs.build/en/1326/lite/specta

<!-- readthedocs-preview jupytergis end -->