### PR TITLE
refactor: move processing forms to features/processing/forms/

### DIFF
--- a/packages/base/src/features/processing/ProcessingFormDialog.tsx
+++ b/packages/base/src/features/processing/ProcessingFormDialog.tsx
@@ -4,9 +4,9 @@ import { PromiseDelegate } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import * as React from 'react';
 
-import { DissolveForm } from '@/src/formbuilder/objectform/process';
-import { DefaultProcessingForm } from '@/src/formbuilder/objectform/processingForm';
 import type { IBaseFormProps } from '@/src/types';
+import { DissolveForm } from './forms/dissolveProcessForm';
+import { DefaultProcessingForm } from './forms/processingForm';
 
 export interface IProcessingFormDialogOptions extends IBaseFormProps {
   formContext: 'update' | 'create';

--- a/packages/base/src/features/processing/forms/dissolveProcessForm.tsx
+++ b/packages/base/src/features/processing/forms/dissolveProcessForm.tsx
@@ -4,11 +4,14 @@ import { Signal } from '@lumino/signaling';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
+import { SchemaForm } from '@/src/formbuilder/objectform/SchemaForm';
+import {
+  processBaseSchema,
+  removeFormEntry,
+} from '@/src/formbuilder/objectform/schemaUtils';
+import { useSchemaFormState } from '@/src/formbuilder/objectform/useSchemaFormState';
 import { deepCopy, loadFile } from '@/src/tools';
 import type { IBaseFormProps } from '@/src/types';
-import { SchemaForm } from '../SchemaForm';
-import { processBaseSchema, removeFormEntry } from '../schemaUtils';
-import { useSchemaFormState } from '../useSchemaFormState';
 
 export interface IDissolveFormProps extends IBaseFormProps {
   ok?: Signal<Dialog<any>, number>;

--- a/packages/base/src/features/processing/forms/processingForm.tsx
+++ b/packages/base/src/features/processing/forms/processingForm.tsx
@@ -6,11 +6,14 @@ import { Signal } from '@lumino/signaling';
 import { UiSchema } from '@rjsf/utils';
 import React, { useEffect, useMemo, useRef } from 'react';
 
+import { SchemaForm } from '@/src/formbuilder/objectform/SchemaForm';
+import {
+  processBaseSchema,
+  removeFormEntry,
+} from '@/src/formbuilder/objectform/schemaUtils';
+import { useSchemaFormState } from '@/src/formbuilder/objectform/useSchemaFormState';
 import { deepCopy } from '@/src/tools';
 import type { IBaseFormProps } from '@/src/types';
-import { SchemaForm } from './SchemaForm';
-import { processBaseSchema, removeFormEntry } from './schemaUtils';
-import { useSchemaFormState } from './useSchemaFormState';
 
 export interface IProcessingFormWrapperProps extends IBaseFormProps {
   /** Signal emitted by the dialog when OK is clicked; form submits when this fires. */

--- a/packages/base/src/formbuilder/objectform/process/index.ts
+++ b/packages/base/src/formbuilder/objectform/process/index.ts
@@ -1,1 +1,0 @@
-export * from './dissolveProcessForm';


### PR DESCRIPTION
Part of #1235.

Moves `formbuilder/objectform/processingForm.tsx` and `formbuilder/objectform/process/dissolveProcessForm.tsx` to `features/processing/forms/`, co-locating them with the rest of the processing feature.

Imports to the shared form infrastructure (`SchemaForm`, `schemaUtils`, `useSchemaFormState`) are updated to use `@/src/formbuilder/objectform/` paths for now — those will move to `shared/schema-form/` in a follow-up step.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1335.org.readthedocs.build/en/1335/
💡 JupyterLite preview: https://jupytergis--1335.org.readthedocs.build/en/1335/lite
💡 Specta preview: https://jupytergis--1335.org.readthedocs.build/en/1335/lite/specta

<!-- readthedocs-preview jupytergis end -->