### PR TITLE
ci: speed up workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2
         with:
+          cache-environment: true
           environment-name: gis
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,9 +173,20 @@ jobs:
       - name: Install
         shell: bash -l {0}
         working-directory: ui-tests
-        run: |
-          jlpm install
-          jlpm playwright install chromium
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: jlpm install
+
+      - name: Set up browser cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ${{ github.workspace }}/pw-browsers
+          key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
+
+      - name: Install browser
+        shell: bash -l {0}
+        working-directory: ui-tests
+        run: npx playwright install chromium
 
       - name: Execute integration tests
         shell: bash -l {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Install browser
         shell: bash -l {0}
         working-directory: ui-tests
-        run: npx playwright install chromium
+        run: jlpm playwright install chromium
 
       - name: Execute integration tests
         shell: bash -l {0}
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install browser
         shell: bash -l {0}
-        run: npx playwright install chromium
+        run: jlpm playwright install chromium
         working-directory: ui-tests
 
       - name: Execute integration tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:
+          cache-environment: true
           environment-name: gis
           create-args: >-
             python=${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,9 +174,20 @@ jobs:
       - name: Install
         shell: bash -l {0}
         working-directory: ui-tests
-        run: |
-          jlpm install
-          jlpm playwright install chromium
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: jlpm install
+
+      - name: Set up browser cache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
+        with:
+          path: ${{ github.workspace }}/pw-browsers
+          key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
+
+      - name: Install browser
+        shell: bash -l {0}
+        working-directory: ui-tests
+        run: npx playwright install chromium
 
       - name: Execute integration tests
         shell: bash -l {0}

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -7,8 +7,15 @@ on:
     branches: '*'
     paths:
       - 'packages/**'
+      - 'docs/**'
       - 'package.json'
       - 'yarn.lock'
+      - '.eslintrc.js'
+      - '.eslintignore'
+      - '.prettierrc'
+      - '.prettierignore'
+      - 'tsconfigbase.json'
+      - 'tsconfig.eslint.json'
       - '.github/workflows/lint-js.yml'
 
 permissions: {}

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -5,18 +5,6 @@ on:
     branches: main
   pull_request:
     branches: '*'
-    paths:
-      - 'packages/**'
-      - 'docs/**'
-      - 'package.json'
-      - 'yarn.lock'
-      - '.eslintrc.js'
-      - '.eslintignore'
-      - '.prettierrc'
-      - '.prettierignore'
-      - 'tsconfigbase.json'
-      - 'tsconfig.eslint.json'
-      - '.github/workflows/lint-js.yml'
 
 permissions: {}
 

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -5,6 +5,11 @@ on:
     branches: main
   pull_request:
     branches: '*'
+    paths:
+      - 'packages/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/lint-js.yml'
 
 permissions: {}
 

--- a/.github/workflows/unit-test-js.yml
+++ b/.github/workflows/unit-test-js.yml
@@ -5,6 +5,11 @@ on:
     branches: main
   pull_request:
     branches: '*'
+    paths:
+      - 'packages/**'
+      - 'package.json'
+      - 'yarn.lock'
+      - '.github/workflows/unit-test-js.yml'
 
 permissions: {}
 

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'python/**'
       - 'scripts/**'
+      - 'pyproject.toml'
       - '.github/workflows/unit-test-python.yml'
 
 permissions: {}

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -5,6 +5,10 @@ on:
     branches: main
   pull_request:
     branches: '*'
+    paths:
+      - 'python/**'
+      - 'scripts/**'
+      - '.github/workflows/unit-test-python.yml'
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Add path filters to `lint-js`, `unit-test-js`, and `unit-test-python` so they only run when relevant files change (JS-only PRs skip Python tests and vice versa; snapshot-only PRs skip both)
- Cache Playwright browsers in the main integration tests job (already done for the lite job)
- Cache micromamba environment in the main build workflow

Note: path filters cause skipped checks to appear as "skipped" rather than "passed" — worth checking if branch protection rules require these checks to pass.

Part of ongoing CI maintenance.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1340.org.readthedocs.build/en/1340/
💡 JupyterLite preview: https://jupytergis--1340.org.readthedocs.build/en/1340/lite
💡 Specta preview: https://jupytergis--1340.org.readthedocs.build/en/1340/lite/specta

<!-- readthedocs-preview jupytergis end -->