### PR TITLE
Split awareness updates into field-specific model signals

### DIFF
--- a/.github/workflows/unit-test-js.yml
+++ b/.github/workflows/unit-test-js.yml
@@ -57,4 +57,4 @@ jobs:
 
       - name: Run unit tests
         shell: bash -l {0}
-        run: jlpm lerna run test --scope @jupytergis/base
+        run: jlpm run test

--- a/packages/base/src/features/filter/Filter.tsx
+++ b/packages/base/src/features/filter/Filter.tsx
@@ -40,7 +40,7 @@ const FilterComponent: React.FC<IFilterComponentProps> = ({
   }, []);
 
   useEffect(() => {
-    const handleClientStateChanged = () => {
+    const syncSelectedLayer = () => {
       if (!model?.localState?.selected?.value) {
         return;
       }
@@ -63,14 +63,14 @@ const FilterComponent: React.FC<IFilterComponentProps> = ({
       }
     };
 
-    model?.clientStateChanged.connect(handleClientStateChanged);
+    model?.selectedChanged.connect(syncSelectedLayer);
 
     // Want to rebuild filter object when zoom changes to get values for that zoom level
     // This is because the filtering inputs may depend on the currently visible features
     model?.sharedOptionsChanged.connect(handleSharedOptionsChanged);
 
     return () => {
-      model?.clientStateChanged.disconnect(handleClientStateChanged);
+      model?.selectedChanged.disconnect(syncSelectedLayer);
       model?.sharedOptionsChanged.disconnect(handleSharedOptionsChanged);
     };
   }, [model]);

--- a/packages/base/src/features/filter/Filter.tsx
+++ b/packages/base/src/features/filter/Filter.tsx
@@ -40,7 +40,7 @@ const FilterComponent: React.FC<IFilterComponentProps> = ({
   }, []);
 
   useEffect(() => {
-    const syncSelectedLayer = () => {
+    const handleSelectedChanged = () => {
       if (!model?.localState?.selected?.value) {
         return;
       }
@@ -63,14 +63,14 @@ const FilterComponent: React.FC<IFilterComponentProps> = ({
       }
     };
 
-    model?.selectedChanged.connect(syncSelectedLayer);
+    model?.selectedChanged.connect(handleSelectedChanged);
 
     // Want to rebuild filter object when zoom changes to get values for that zoom level
     // This is because the filtering inputs may depend on the currently visible features
     model?.sharedOptionsChanged.connect(handleSharedOptionsChanged);
 
     return () => {
-      model?.selectedChanged.disconnect(syncSelectedLayer);
+      model?.selectedChanged.disconnect(handleSelectedChanged);
       model?.sharedOptionsChanged.disconnect(handleSharedOptionsChanged);
     };
   }, [model]);

--- a/packages/base/src/features/identify/IdentifyPanel.tsx
+++ b/packages/base/src/features/identify/IdentifyPanel.tsx
@@ -27,8 +27,7 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
   }, [features]);
 
   useEffect(() => {
-    const handleIdentifyStateChanged = () => {
-      console.log('ident panel handleIdentifyStateChanged');
+    const handleIdentifyFeaturesChanged = () => {
       const clients = model.sharedModel.awareness.getStates();
       const remoteUserId = model?.localState?.remoteUser;
 
@@ -61,13 +60,18 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
       }
     };
 
-    model?.identifiedFeaturesChanged.connect(handleIdentifyStateChanged);
-    model?.remoteUserChanged.connect(handleIdentifyStateChanged);
-    handleIdentifyStateChanged();
+    const signals = [
+      model?.identifiedFeaturesChanged,
+      model?.remoteUserChanged,
+    ];
+
+    signals.forEach(signal => signal.connect(handleIdentifyFeaturesChanged));
+    handleIdentifyFeaturesChanged();
 
     return () => {
-      model?.identifiedFeaturesChanged.disconnect(handleIdentifyStateChanged);
-      model?.remoteUserChanged.disconnect(handleIdentifyStateChanged);
+      signals.forEach(signal =>
+        signal.disconnect(handleIdentifyFeaturesChanged),
+      );
     };
   }, [model, remoteUser]);
 

--- a/packages/base/src/features/identify/IdentifyPanel.tsx
+++ b/packages/base/src/features/identify/IdentifyPanel.tsx
@@ -1,10 +1,6 @@
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  IDict,
-  IJupyterGISClientState,
-  IJupyterGISModel,
-} from '@jupytergis/schema';
+import { IDict, IJupyterGISModel } from '@jupytergis/schema';
 import { User } from '@jupyterlab/services';
 import { LabIcon, caretDownIcon } from '@jupyterlab/ui-components';
 import React, { useEffect, useRef, useState } from 'react';
@@ -31,10 +27,9 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
   }, [features]);
 
   useEffect(() => {
-    const handleClientStateChanged = (
-      sender: IJupyterGISModel,
-      clients: Map<number, IJupyterGISClientState>,
-    ) => {
+    const handleIdentifyStateChanged = () => {
+      console.log('ident panel handleIdentifyStateChanged');
+      const clients = model.sharedModel.awareness.getStates();
       const remoteUserId = model?.localState?.remoteUser;
 
       // If following a collaborator
@@ -66,12 +61,15 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
       }
     };
 
-    model?.clientStateChanged.connect(handleClientStateChanged);
+    model?.identifiedFeaturesChanged.connect(handleIdentifyStateChanged);
+    model?.remoteUserChanged.connect(handleIdentifyStateChanged);
+    handleIdentifyStateChanged();
 
     return () => {
-      model?.clientStateChanged.disconnect(handleClientStateChanged);
+      model?.identifiedFeaturesChanged.disconnect(handleIdentifyStateChanged);
+      model?.remoteUserChanged.disconnect(handleIdentifyStateChanged);
     };
-  }, [model]);
+  }, [model, remoteUser]);
 
   const highlightFeatureOnMap = (feature: any) => {
     model?.highlightFeatureSignal?.emit(feature);

--- a/packages/base/src/features/identify/IdentifyPanel.tsx
+++ b/packages/base/src/features/identify/IdentifyPanel.tsx
@@ -35,14 +35,18 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
       if (remoteUserId) {
         const remoteState = clients.get(remoteUserId);
         if (remoteState) {
-          if (remoteState.user?.username !== remoteUser?.username) {
-            setRemoteUser(remoteState.user);
-          }
+          setRemoteUser(previousUser =>
+            previousUser?.username === remoteState.user?.username
+              ? previousUser
+              : remoteState.user,
+          );
 
           setFeatures(remoteState.identifiedFeatures?.value ?? {});
         }
         return;
       }
+
+      setRemoteUser(previousUser => (previousUser ? null : previousUser));
 
       // If not following a collaborator
       const identifiedFeatures = model?.localState?.identifiedFeatures?.value;
@@ -73,7 +77,7 @@ export const IdentifyPanelComponent: React.FC<IIdentifyComponentProps> = ({
         signal.disconnect(handleIdentifyFeaturesChanged),
       );
     };
-  }, [model, remoteUser]);
+  }, [model]);
 
   const highlightFeatureOnMap = (feature: any) => {
     model?.highlightFeatureSignal?.emit(feature);

--- a/packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts
+++ b/packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts
@@ -70,12 +70,14 @@ export const useGetSymbology = ({
     // initial load
     fetchSymbology();
 
-    model.sharedModel.awareness.on('change', () => {
+    const handleSelectedChanged = () => {
       fetchSymbology();
-    });
+    };
+    model.selectedChanged.connect(handleSelectedChanged);
 
     return () => {
       disposed = true;
+      model.selectedChanged.disconnect(handleSelectedChanged);
     };
   }, [layerId, model]);
 

--- a/packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts
+++ b/packages/base/src/features/layers/symbology/hooks/useGetSymbology.ts
@@ -70,14 +70,15 @@ export const useGetSymbology = ({
     // initial load
     fetchSymbology();
 
-    const handleSelectedChanged = () => {
+    const handleLayersChanged = () => {
       fetchSymbology();
     };
-    model.selectedChanged.connect(handleSelectedChanged);
+
+    model.sharedLayersChanged.connect(handleLayersChanged);
 
     return () => {
       disposed = true;
-      model.selectedChanged.disconnect(handleSelectedChanged);
+      model.sharedLayersChanged.disconnect(handleLayersChanged);
     };
   }, [layerId, model]);
 

--- a/packages/base/src/features/layers/symbology/symbologyDialog.tsx
+++ b/packages/base/src/features/layers/symbology/symbologyDialog.tsx
@@ -54,7 +54,7 @@ const SymbologyDialog: React.FC<ISymbologyDialogProps> = ({
   let LayerSymbology: React.JSX.Element;
 
   useEffect(() => {
-    const syncSelectedLayer = () => {
+    const handleSelectedChanged = () => {
       if (!model.localState?.selected?.value) {
         return;
       }
@@ -65,12 +65,12 @@ const SymbologyDialog: React.FC<ISymbologyDialogProps> = ({
     };
 
     // Initial state
-    syncSelectedLayer();
+    handleSelectedChanged();
 
-    model.selectedChanged.connect(syncSelectedLayer);
+    model.selectedChanged.connect(handleSelectedChanged);
 
     return () => {
-      model.selectedChanged.disconnect(syncSelectedLayer);
+      model.selectedChanged.disconnect(handleSelectedChanged);
     };
   }, []);
 

--- a/packages/base/src/features/layers/symbology/symbologyDialog.tsx
+++ b/packages/base/src/features/layers/symbology/symbologyDialog.tsx
@@ -54,7 +54,7 @@ const SymbologyDialog: React.FC<ISymbologyDialogProps> = ({
   let LayerSymbology: React.JSX.Element;
 
   useEffect(() => {
-    const handleClientStateChanged = () => {
+    const syncSelectedLayer = () => {
       if (!model.localState?.selected?.value) {
         return;
       }
@@ -65,12 +65,12 @@ const SymbologyDialog: React.FC<ISymbologyDialogProps> = ({
     };
 
     // Initial state
-    handleClientStateChanged();
+    syncSelectedLayer();
 
-    model.clientStateChanged.connect(handleClientStateChanged);
+    model.selectedChanged.connect(syncSelectedLayer);
 
     return () => {
-      model.clientStateChanged.disconnect(handleClientStateChanged);
+      model.selectedChanged.disconnect(syncSelectedLayer);
     };
   }, []);
 

--- a/packages/base/src/features/objectproperties/index.tsx
+++ b/packages/base/src/features/objectproperties/index.tsx
@@ -1,8 +1,4 @@
-import {
-  IJGISFormSchemaRegistry,
-  IJupyterGISClientState,
-  IJupyterGISModel,
-} from '@jupytergis/schema';
+import { IJGISFormSchemaRegistry, IJupyterGISModel } from '@jupytergis/schema';
 import { UUID } from '@lumino/coreutils';
 import * as React from 'react';
 
@@ -34,9 +30,7 @@ export class ObjectPropertiesReact extends React.Component<IProps, IStates> {
       setSelectedObject: props.setSelectedObject,
     };
 
-    this.props.model.clientStateChanged.connect(
-      this._onClientSharedStateChanged,
-    );
+    this.props.model.selectedChanged.connect(this._onSelectedChanged);
 
     this.props.model?.sharedLayersChanged.connect(this._sharedJGISModelChanged);
     this.props.model?.sharedSourcesChanged.connect(
@@ -48,24 +42,15 @@ export class ObjectPropertiesReact extends React.Component<IProps, IStates> {
     this.forceUpdate();
   };
 
-  private _onClientSharedStateChanged = (
-    sender: IJupyterGISModel,
-    clients: Map<number, IJupyterGISClientState>,
-  ): void => {
-    let newState: IJupyterGISClientState | undefined;
-    const clientId = this.state.clientId;
-
-    const localState = clientId ? clients.get(clientId) : null;
+  private _onSelectedChanged = (): void => {
+    const localState = this.props.model.localState;
     if (
       localState &&
       localState.selected?.emitter &&
       localState.selected.emitter !== this.state.id &&
       localState.selected?.value
     ) {
-      newState = localState;
-    }
-    if (newState) {
-      const selection = newState.selected.value;
+      const selection = localState.selected.value;
       const selectedObjectIds = Object.keys(selection || {});
       // Only show object properties if ONE object is selected
       if (selection === undefined || selectedObjectIds.length !== 1) {

--- a/packages/base/src/features/story/StoryViewerPanel.tsx
+++ b/packages/base/src/features/story/StoryViewerPanel.tsx
@@ -128,7 +128,7 @@ function StoryViewerPanel({
   // Listen for layer selection changes in unguided mode
   useEffect(() => {
     // ! TODO this logic (getting a single selected layer) is also in the processing index.ts, move to tools
-    const handleSelectedStorySegmentChange = () => {
+    const handleSelectedStorySegmentChanged = () => {
       // This is just to update the displayed content
       // So bail early if we don't need to do that
       if (!storyData || storyData.storyType !== 'unguided') {
@@ -162,11 +162,11 @@ function StoryViewerPanel({
     };
 
     // ! TODO really only want to connect this un unguided mode
-    model.selectedChanged.connect(handleSelectedStorySegmentChange);
-    handleSelectedStorySegmentChange();
+    model.selectedChanged.connect(handleSelectedStorySegmentChanged);
+    handleSelectedStorySegmentChanged();
 
     return () => {
-      model.selectedChanged.disconnect(handleSelectedStorySegmentChange);
+      model.selectedChanged.disconnect(handleSelectedStorySegmentChanged);
     };
   }, [model, storyData, setIndex]);
 

--- a/packages/base/src/features/story/StoryViewerPanel.tsx
+++ b/packages/base/src/features/story/StoryViewerPanel.tsx
@@ -135,12 +135,12 @@ function StoryViewerPanel({
         return;
       }
 
-      const localState = model.sharedModel.awareness.getLocalState();
-      if (!localState || !localState['selected']?.value) {
+      const selected = model.localState?.selected?.value;
+      if (!selected) {
         return;
       }
 
-      const selectedLayers = Object.keys(localState['selected'].value);
+      const selectedLayers = Object.keys(selected);
 
       // Ensure only one layer is selected
       if (selectedLayers.length !== 1) {
@@ -162,13 +162,11 @@ function StoryViewerPanel({
     };
 
     // ! TODO really only want to connect this un unguided mode
-    model.sharedModel.awareness.on('change', handleSelectedStorySegmentChange);
+    model.selectedChanged.connect(handleSelectedStorySegmentChange);
+    handleSelectedStorySegmentChange();
 
     return () => {
-      model.sharedModel.awareness.off(
-        'change',
-        handleSelectedStorySegmentChange,
-      );
+      model.selectedChanged.disconnect(handleSelectedStorySegmentChange);
     };
   }, [model, storyData, setIndex]);
 

--- a/packages/base/src/mainview/TemporalSlider.tsx
+++ b/packages/base/src/mainview/TemporalSlider.tsx
@@ -75,7 +75,7 @@ const TemporalSlider: React.FC<ITemporalSliderProps> = ({
 
   useEffect(() => {
     // This is for when the selected layer changes
-    const handleClientStateChanged = () => {
+    const syncSelectedLayer = () => {
       if (!model.localState?.selected?.value) {
         return;
       }
@@ -119,13 +119,13 @@ const TemporalSlider: React.FC<ITemporalSliderProps> = ({
     };
 
     // Initial state
-    handleClientStateChanged();
+    syncSelectedLayer();
 
-    model.clientStateChanged.connect(handleClientStateChanged);
+    model.selectedChanged.connect(syncSelectedLayer);
     model.sharedLayersChanged.connect(handleLayerChange);
 
     return () => {
-      model.clientStateChanged.disconnect(handleClientStateChanged);
+      model.selectedChanged.disconnect(syncSelectedLayer);
       model.sharedLayersChanged.disconnect(handleLayerChange);
       removeFilter();
       if (intervalRef.current) {

--- a/packages/base/src/mainview/TemporalSlider.tsx
+++ b/packages/base/src/mainview/TemporalSlider.tsx
@@ -75,7 +75,7 @@ const TemporalSlider: React.FC<ITemporalSliderProps> = ({
 
   useEffect(() => {
     // This is for when the selected layer changes
-    const syncSelectedLayer = () => {
+    const handleSelectedChanged = () => {
       if (!model.localState?.selected?.value) {
         return;
       }
@@ -91,7 +91,7 @@ const TemporalSlider: React.FC<ITemporalSliderProps> = ({
     };
 
     // this is for when the layer itself changes
-    const handleLayerChange = (
+    const handleSharedLayersChanged = (
       _: IJupyterGISDoc,
       change: IJGISLayerDocChange,
     ) => {
@@ -119,14 +119,14 @@ const TemporalSlider: React.FC<ITemporalSliderProps> = ({
     };
 
     // Initial state
-    syncSelectedLayer();
+    handleSelectedChanged();
 
-    model.selectedChanged.connect(syncSelectedLayer);
-    model.sharedLayersChanged.connect(handleLayerChange);
+    model.selectedChanged.connect(handleSelectedChanged);
+    model.sharedLayersChanged.connect(handleSharedLayersChanged);
 
     return () => {
-      model.selectedChanged.disconnect(syncSelectedLayer);
-      model.sharedLayersChanged.disconnect(handleLayerChange);
+      model.selectedChanged.disconnect(handleSelectedChanged);
+      model.sharedLayersChanged.disconnect(handleSharedLayersChanged);
       removeFilter();
       if (intervalRef.current) {
         clearInterval(intervalRef.current);

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -295,12 +295,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._syncSettingsFromRegistry();
     });
 
-    // Watch isIdentifying and clear the highlight when Identify Tool is turned off
-    this._model.sharedModel.awareness.on('change', () => {
-      if (this._model.currentMode !== 'identifying' && this._highlightLayer) {
-        this._highlightLayer.getSource()?.clear();
-      }
-    });
+    // Watch identify-related awareness changes and clear highlight when
+    // Identify tool is turned off.
+    this._model.identifiedFeaturesChanged.connect(
+      this._clearHighlightWhenIdentifyDisabled,
+      this,
+    );
 
     this.state = {
       id: this._mainViewModel.id,
@@ -382,6 +382,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     this._model.clientStateChanged.disconnect(
       this._onClientSharedStateChanged,
+      this,
+    );
+    this._model.identifiedFeaturesChanged.disconnect(
+      this._clearHighlightWhenIdentifyDisabled,
       this,
     );
 
@@ -2620,6 +2624,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       }
     }
   };
+
+  private _clearHighlightWhenIdentifyDisabled(): void {
+    if (this._model.currentMode !== 'identifying' && this._highlightLayer) {
+      this._highlightLayer.getSource()?.clear();
+    }
+  }
 
   /**
    * Handler for when story maps change in the model.

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -422,11 +422,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     // Clean up story scroll listener
     this._cleanupStoryScrollListener();
 
-    this._model.sharedModel.awareness.off(
-      'change',
-      this._onSelectedLayerChange,
-    );
-
     this._mainViewModel.dispose();
   }
 
@@ -631,13 +626,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           units: (getProjection(projection) ?? view.getProjection()).getUnits(),
         },
       }));
-
-      // Track changes of selected layers and rebind edit interactions when
-      // the user switches the currently selected draw-vector layer.
-      this._model.sharedModel.awareness.on(
-        'change',
-        this._onSelectedLayerChange,
-      );
     }
   }
 
@@ -2238,21 +2226,63 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return;
     }
 
-    const selectedLayerID = Object.keys(selectedLayers)[0];
-    const JGISLayer = this._model.getLayer(selectedLayerID);
-    this._handleDrawVectorLayerSelectionChanged(JGISLayer);
+    const selectedLayerId = Object.keys(selectedLayers)[0];
+    const JGISLayer = this._model.getLayer(selectedLayerId);
+    if (!JGISLayer) {
+      return;
+    }
+
+    this._syncVectorDrawingFromSelection(JGISLayer, selectedLayerId);
   };
 
-  /* check if the currently selected layer is a drawVector layer
-  and update isDrawVectorLayer to remove the display of the 
-  geometry selection overlay if required */
-  private _handleDrawVectorLayerSelectionChanged(
-    layer: IJGISLayer | undefined,
-  ): void {
-    if (layer && !this._model.checkIfIsADrawVectorLayer(layer)) {
+  private _syncVectorDrawingFromSelection = (
+    layer: IJGISLayer,
+    selectedLayerId: string,
+  ): void => {
+    const decision = this._getVectorDrawingSelectionDecision(
+      layer,
+      selectedLayerId,
+    );
+    if (decision.disableEditing) {
       this._model.editingVectorLayer = false;
       this._updateEditingVectorLayer();
+      return;
     }
+    if (!decision.shouldRebind) {
+      return;
+    }
+
+    this._previousDrawLayerID = selectedLayerId;
+    this._currentDrawLayerID = selectedLayerId;
+    this._editVectorLayer();
+  };
+
+  /**
+   * Decide how selection changes should affect vector drawing state.
+   *
+   * This helper only computes whether
+   * draw mode must be disabled (non-draw layer selected) and whether draw
+   * interactions should be rebound (draw mode enabled and selected draw layer
+   * changed).
+   */
+  private _getVectorDrawingSelectionDecision(
+    layer: IJGISLayer,
+    selectedLayerId: string,
+  ): { disableEditing: boolean; shouldRebind: boolean } {
+    const isDrawVectorLayer = this._model.checkIfIsADrawVectorLayer(layer);
+    if (!isDrawVectorLayer) {
+      return { disableEditing: true, shouldRebind: false };
+    }
+
+    if (!this._model.editingVectorLayer) {
+      return { disableEditing: false, shouldRebind: false };
+    }
+
+    if (selectedLayerId === this._previousDrawLayerID) {
+      return { disableEditing: false, shouldRebind: false };
+    }
+
+    return { disableEditing: false, shouldRebind: true };
   }
 
   private _handleTemporalControllerActiveChanged(): void {
@@ -2283,20 +2313,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._mainViewModel.commands.notifyCommandChanged(
         CommandIDs.temporalController,
       );
-    }
-
-    /* check if the currently selected layer is a drawVector layer
-    and update isDrawVectorLayer to remove the display of the geometry selection overlay if required*/
-    // const selectedLayers = localState?.selected?.value;
-    if (!selectedLayers) {
-      return;
-    }
-
-    const selectedLayerID = Object.keys(selectedLayers)[0];
-    const JGISLayer = this._model.getLayer(selectedLayerID);
-    if (JGISLayer && !this._model.checkIfIsADrawVectorLayer(JGISLayer)) {
-      this._model.editingVectorLayer = false;
-      this._updateEditingVectorLayer();
     }
   }
 
@@ -3348,8 +3364,14 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _updateEditingVectorLayer() {
     const editingVectorLayer: boolean = this._model.editingVectorLayer;
     this.setState(old => ({ ...old, editingVectorLayer }));
+
+    if (editingVectorLayer === true) {
+      this._editVectorLayer();
+    }
+
     if (editingVectorLayer === false && this._draw) {
       this._removeDrawInteraction();
+      this._currentDrawLayerID = undefined;
     }
   }
 
@@ -3525,33 +3547,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _removeModifyInteraction = () => {
     this._modify.setActive(false);
     this._Map.removeInteraction(this._modify);
-  };
-
-  private _onSelectedLayerChange = () => {
-    const selectedLayers =
-      this._model.sharedModel.awareness.getLocalState()?.selected?.value;
-
-    const selectedLayerId = selectedLayers
-      ? Object.keys(selectedLayers)[0]
-      : undefined;
-
-    if (!selectedLayerId || selectedLayerId === this._previousDrawLayerID) {
-      return;
-    }
-
-    const selectedLayer = this._model.getLayer(selectedLayerId);
-
-    if (!selectedLayer) {
-      return;
-    }
-
-    if (!this._model.checkIfIsADrawVectorLayer(selectedLayer)) {
-      return;
-    }
-
-    this._previousDrawLayerID = selectedLayerId;
-    this._currentDrawLayerID = selectedLayerId;
-    this._editVectorLayer();
   };
 
   render(): JSX.Element {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -266,6 +266,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._syncTemporalControllerVisibility,
       this,
     );
+    this._model.pointerChanged.connect(this._syncClientPointers, this);
     this._model.selectedChanged.connect(
       this._syncTemporalControllerVisibility,
       this,
@@ -354,6 +355,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const zoom = options.zoom !== undefined ? options.zoom : 1;
 
     await this.generateMap(center, zoom, projection);
+    this._syncClientPointers();
     this._syncTemporalControllerVisibility();
     this._mainViewModel.initSignal();
     if (window.jupytergisMaps !== undefined && this._documentPath) {
@@ -397,6 +399,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._syncTemporalControllerVisibility,
       this,
     );
+    this._model.pointerChanged.disconnect(this._syncClientPointers, this);
     this._model.selectedChanged.disconnect(
       this._syncTemporalControllerVisibility,
       this,
@@ -2261,66 +2264,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       }
     }
 
-    // cursors
-    clients.forEach((client, clientId) => {
-      if (!client?.user) {
-        return;
-      }
-
-      const pointer = client.pointer?.value;
-
-      // We already display our own cursor on mouse move
-      if (this._model.getClientId() === clientId) {
-        return;
-      }
-
-      const clientPointers = { ...this.state.clientPointers };
-      let currentClientPointer = clientPointers[clientId];
-
-      if (pointer) {
-        const pixel = this._Map.getPixelFromCoordinate([
-          pointer.coordinates.x,
-          pointer.coordinates.y,
-        ]);
-
-        const lonLat = toLonLat([pointer.coordinates.x, pointer.coordinates.y]);
-
-        if (!currentClientPointer) {
-          currentClientPointer = {
-            username: client.user.username,
-            displayName: client.user.display_name,
-            color: client.user.color,
-            coordinates: {
-              x: pixel[0],
-              y: pixel[1],
-            },
-            lonLat: {
-              longitude: lonLat[0],
-              latitude: lonLat[1],
-            },
-          };
-        } else {
-          currentClientPointer = {
-            ...currentClientPointer,
-            coordinates: {
-              x: pixel[0],
-              y: pixel[1],
-            },
-            lonLat: {
-              longitude: lonLat[0],
-              latitude: lonLat[1],
-            },
-          };
-        }
-
-        clientPointers[clientId] = currentClientPointer;
-      } else {
-        delete clientPointers[clientId];
-      }
-
-      this.setState(old => ({ ...old, clientPointers }));
-    });
-
     /* check if the currently selected layer is a drawVector layer
     and update isDrawVectorLayer to remove the display of the geometry selection overlay if required*/
     const selectedLayers = localState.selected?.value;
@@ -2379,6 +2322,65 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._model.editingVectorLayer = false;
       this._updateEditingVectorLayer();
     }
+  }
+
+  private _syncClientPointers(): void {
+    const clients = this._model.sharedModel.awareness.getStates() as Map<
+      number,
+      IJupyterGISClientState
+    >;
+    const clientPointers = { ...this.state.clientPointers };
+
+    clients.forEach((client, clientId) => {
+      if (!client?.user || this._model.getClientId() === clientId) {
+        return;
+      }
+
+      const pointer = client.pointer?.value;
+      let currentClientPointer = clientPointers[clientId];
+
+      if (pointer) {
+        const pixel = this._Map.getPixelFromCoordinate([
+          pointer.coordinates.x,
+          pointer.coordinates.y,
+        ]);
+        const lonLat = toLonLat([pointer.coordinates.x, pointer.coordinates.y]);
+
+        if (!currentClientPointer) {
+          currentClientPointer = {
+            username: client.user.username,
+            displayName: client.user.display_name,
+            color: client.user.color,
+            coordinates: {
+              x: pixel[0],
+              y: pixel[1],
+            },
+            lonLat: {
+              longitude: lonLat[0],
+              latitude: lonLat[1],
+            },
+          };
+        } else {
+          currentClientPointer = {
+            ...currentClientPointer,
+            coordinates: {
+              x: pixel[0],
+              y: pixel[1],
+            },
+            lonLat: {
+              longitude: lonLat[0],
+              latitude: lonLat[1],
+            },
+          };
+        }
+
+        clientPointers[clientId] = currentClientPointer;
+      } else {
+        delete clientPointers[clientId];
+      }
+    });
+
+    this.setState(old => ({ ...old, clientPointers }));
   }
 
   private _onSharedOptionsChanged(): void {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -258,19 +258,18 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._onSharedOptionsChanged,
       this,
     );
-    this._model.clientStateChanged.connect(
-      this._onClientSharedStateChanged,
-      this,
-    );
     this._model.temporalControllerActiveChanged.connect(
       this._syncTemporalControllerVisibility,
       this,
     );
+    this._model.remoteUserChanged.connect(this._syncRemoteUserState, this);
+    this._model.viewportStateChanged.connect(this._syncRemoteUserState, this);
     this._model.pointerChanged.connect(this._syncClientPointers, this);
     this._model.selectedChanged.connect(
       this._syncTemporalControllerVisibility,
       this,
     );
+    this._model.selectedChanged.connect(this._syncEditingVectorLayer, this);
     this._model.sharedLayersChanged.connect(this._onLayersChanged, this);
     this._model.sharedLayerTreeChanged.connect(this._onLayerTreeChange, this);
     this._model.sharedSourcesChanged.connect(this._onSourcesChange, this);
@@ -355,8 +354,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const zoom = options.zoom !== undefined ? options.zoom : 1;
 
     await this.generateMap(center, zoom, projection);
+    this._syncRemoteUserState();
     this._syncClientPointers();
     this._syncTemporalControllerVisibility();
+    this._syncEditingVectorLayer();
     this._mainViewModel.initSignal();
     if (window.jupytergisMaps !== undefined && this._documentPath) {
       window.jupytergisMaps[this._documentPath] = this._Map;
@@ -391,12 +392,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this,
     );
 
-    this._model.clientStateChanged.disconnect(
-      this._onClientSharedStateChanged,
-      this,
-    );
     this._model.temporalControllerActiveChanged.disconnect(
       this._syncTemporalControllerVisibility,
+      this,
+    );
+    this._model.remoteUserChanged.disconnect(this._syncRemoteUserState, this);
+    this._model.viewportStateChanged.disconnect(
+      this._syncRemoteUserState,
       this,
     );
     this._model.pointerChanged.disconnect(this._syncClientPointers, this);
@@ -404,6 +406,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._syncTemporalControllerVisibility,
       this,
     );
+    this._model.selectedChanged.disconnect(this._syncEditingVectorLayer, this);
     this._model.identifiedFeaturesChanged.disconnect(
       this._clearHighlightWhenIdentifyDisabled,
       this,
@@ -2217,51 +2220,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   }
 
-  private _onClientSharedStateChanged = (
-    sender: IJupyterGISModel,
-    clients: Map<number, IJupyterGISClientState>,
-  ): void => {
+  private _syncEditingVectorLayer = (): void => {
     const localState = this._model.localState;
     if (!localState) {
       return;
-    }
-
-    const remoteUser = localState.remoteUser;
-    // If we are in following mode, we update our position and selection
-    if (remoteUser) {
-      const remoteState = clients.get(remoteUser);
-      if (!remoteState) {
-        return;
-      }
-
-      if (remoteState.user?.username !== this.state.remoteUser?.username) {
-        this.setState(old => ({
-          ...old,
-          remoteUser: remoteState.user,
-        }));
-      }
-
-      const remoteViewport = remoteState.viewportState;
-
-      if (remoteViewport.value) {
-        const { x, y } = remoteViewport.value.coordinates;
-        const zoom = remoteViewport.value.zoom;
-
-        this._moveToPosition({ x, y }, zoom, 0);
-      }
-    } else {
-      // If we are unfollowing a remote user, we reset our center and zoom to their previous values
-      if (this.state.remoteUser !== null) {
-        this.setState(old => ({
-          ...old,
-          remoteUser: null,
-        }));
-        const viewportState = localState.viewportState?.value;
-
-        if (viewportState) {
-          this._moveToPosition(viewportState.coordinates, viewportState.zoom);
-        }
-      }
     }
 
     /* check if the currently selected layer is a drawVector layer
@@ -2321,6 +2283,54 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     if (JGISLayer && !this._model.checkIfIsADrawVectorLayer(JGISLayer)) {
       this._model.editingVectorLayer = false;
       this._updateEditingVectorLayer();
+    }
+  }
+
+  private _syncRemoteUserState(): void {
+    const localState = this._model.localState;
+    if (!localState) {
+      return;
+    }
+
+    const remoteUser = localState.remoteUser;
+    const clients = this._model.sharedModel.awareness.getStates() as Map<
+      number,
+      IJupyterGISClientState
+    >;
+
+    // If we are in following mode, update UI and viewport from the remote user.
+    if (remoteUser) {
+      const remoteState = clients.get(remoteUser);
+      if (!remoteState) {
+        return;
+      }
+
+      if (remoteState.user?.username !== this.state.remoteUser?.username) {
+        this.setState(old => ({
+          ...old,
+          remoteUser: remoteState.user,
+        }));
+      }
+
+      const remoteViewport = remoteState.viewportState;
+      if (remoteViewport.value) {
+        const { x, y } = remoteViewport.value.coordinates;
+        const zoom = remoteViewport.value.zoom;
+        this._moveToPosition({ x, y }, zoom, 0);
+      }
+      return;
+    }
+
+    // If we are unfollowing, reset to local viewport and clear follow UI.
+    if (this.state.remoteUser !== null) {
+      this.setState(old => ({
+        ...old,
+        remoteUser: null,
+      }));
+      const viewportState = localState.viewportState?.value;
+      if (viewportState) {
+        this._moveToPosition(viewportState.coordinates, viewportState.zoom);
+      }
     }
   }
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -262,6 +262,14 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._onClientSharedStateChanged,
       this,
     );
+    this._model.temporalControllerActiveChanged.connect(
+      this._syncTemporalControllerVisibility,
+      this,
+    );
+    this._model.selectedChanged.connect(
+      this._syncTemporalControllerVisibility,
+      this,
+    );
     this._model.sharedLayersChanged.connect(this._onLayersChanged, this);
     this._model.sharedLayerTreeChanged.connect(this._onLayerTreeChange, this);
     this._model.sharedSourcesChanged.connect(this._onSourcesChange, this);
@@ -346,6 +354,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const zoom = options.zoom !== undefined ? options.zoom : 1;
 
     await this.generateMap(center, zoom, projection);
+    this._syncTemporalControllerVisibility();
     this._mainViewModel.initSignal();
     if (window.jupytergisMaps !== undefined && this._documentPath) {
       window.jupytergisMaps[this._documentPath] = this._Map;
@@ -382,6 +391,14 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     this._model.clientStateChanged.disconnect(
       this._onClientSharedStateChanged,
+      this,
+    );
+    this._model.temporalControllerActiveChanged.disconnect(
+      this._syncTemporalControllerVisibility,
+      this,
+    );
+    this._model.selectedChanged.disconnect(
+      this._syncTemporalControllerVisibility,
       this,
     );
     this._model.identifiedFeaturesChanged.disconnect(
@@ -2304,10 +2321,29 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this.setState(old => ({ ...old, clientPointers }));
     });
 
-    // Compute displayTemporalController: active AND current selection is valid
+    /* check if the currently selected layer is a drawVector layer
+    and update isDrawVectorLayer to remove the display of the geometry selection overlay if required*/
+    const selectedLayers = localState.selected?.value;
+    if (!selectedLayers) {
+      return;
+    }
+
+    const selectedLayerID = Object.keys(selectedLayers)[0];
+    const JGISLayer = this._model.getLayer(selectedLayerID);
+    if (JGISLayer && !this._model.checkIfIsADrawVectorLayer(JGISLayer)) {
+      this._model.editingVectorLayer = false;
+      this._updateEditingVectorLayer();
+    }
+  };
+
+  private _syncTemporalControllerVisibility(): void {
+    const localState = this._model.localState;
+    if (!localState) {
+      return;
+    }
+
     const isTemporalControllerActive =
       localState.isTemporalControllerActive === true;
-
     const selectedLayers = localState.selected?.value;
     const selectedLayerId = selectedLayers
       ? (Object.keys(selectedLayers)[0] ?? null)
@@ -2343,7 +2379,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._model.editingVectorLayer = false;
       this._updateEditingVectorLayer();
     }
-  };
+  }
 
   private _onSharedOptionsChanged(): void {
     if (!this._Map) {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -259,17 +259,22 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this,
     );
     this._model.temporalControllerActiveChanged.connect(
-      this._syncTemporalControllerVisibility,
+      this._handleTemporalControllerActiveChanged,
       this,
     );
-    this._model.remoteUserChanged.connect(this._syncRemoteUserState, this);
-    this._model.viewportStateChanged.connect(this._syncRemoteUserState, this);
-    this._model.pointerChanged.connect(this._syncClientPointers, this);
+    const remoteUserSignals = [
+      this._model.remoteUserChanged,
+      this._model.viewportStateChanged,
+    ];
+    remoteUserSignals.forEach(signal =>
+      signal.connect(this._handleRemoteUserChanged, this),
+    );
+    this._model.pointerChanged.connect(this._handlePointerChanged, this);
     this._model.selectedChanged.connect(
-      this._syncTemporalControllerVisibility,
+      this._handleTemporalControllerActiveChanged,
       this,
     );
-    this._model.selectedChanged.connect(this._syncEditingVectorLayer, this);
+    this._model.selectedChanged.connect(this._handleSelectedChanged, this);
     this._model.sharedLayersChanged.connect(this._onLayersChanged, this);
     this._model.sharedLayerTreeChanged.connect(this._onLayerTreeChange, this);
     this._model.sharedSourcesChanged.connect(this._onSourcesChange, this);
@@ -354,10 +359,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const zoom = options.zoom !== undefined ? options.zoom : 1;
 
     await this.generateMap(center, zoom, projection);
-    this._syncRemoteUserState();
-    this._syncClientPointers();
-    this._syncTemporalControllerVisibility();
-    this._syncEditingVectorLayer();
+    this._handleRemoteUserChanged();
+    this._handlePointerChanged();
+    this._handleTemporalControllerActiveChanged();
+    this._handleSelectedChanged();
     this._mainViewModel.initSignal();
     if (window.jupytergisMaps !== undefined && this._documentPath) {
       window.jupytergisMaps[this._documentPath] = this._Map;
@@ -393,20 +398,22 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     );
 
     this._model.temporalControllerActiveChanged.disconnect(
-      this._syncTemporalControllerVisibility,
+      this._handleTemporalControllerActiveChanged,
       this,
     );
-    this._model.remoteUserChanged.disconnect(this._syncRemoteUserState, this);
-    this._model.viewportStateChanged.disconnect(
-      this._syncRemoteUserState,
-      this,
+    const remoteUserSignals = [
+      this._model.remoteUserChanged,
+      this._model.viewportStateChanged,
+    ];
+    remoteUserSignals.forEach(signal =>
+      signal.disconnect(this._handleRemoteUserChanged, this),
     );
-    this._model.pointerChanged.disconnect(this._syncClientPointers, this);
+    this._model.pointerChanged.disconnect(this._handlePointerChanged, this);
     this._model.selectedChanged.disconnect(
-      this._syncTemporalControllerVisibility,
+      this._handleTemporalControllerActiveChanged,
       this,
     );
-    this._model.selectedChanged.disconnect(this._syncEditingVectorLayer, this);
+    this._model.selectedChanged.disconnect(this._handleSelectedChanged, this);
     this._model.identifiedFeaturesChanged.disconnect(
       this._clearHighlightWhenIdentifyDisabled,
       this,
@@ -2220,14 +2227,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   }
 
-  private _syncEditingVectorLayer = (): void => {
+  private _handleSelectedChanged = (): void => {
     const localState = this._model.localState;
     if (!localState) {
       return;
     }
 
-    /* check if the currently selected layer is a drawVector layer
-    and update isDrawVectorLayer to remove the display of the geometry selection overlay if required*/
     const selectedLayers = localState.selected?.value;
     if (!selectedLayers) {
       return;
@@ -2235,13 +2240,22 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     const selectedLayerID = Object.keys(selectedLayers)[0];
     const JGISLayer = this._model.getLayer(selectedLayerID);
-    if (JGISLayer && !this._model.checkIfIsADrawVectorLayer(JGISLayer)) {
+    this._handleDrawVectorLayerSelectionChanged(JGISLayer);
+  };
+
+  /* check if the currently selected layer is a drawVector layer
+  and update isDrawVectorLayer to remove the display of the 
+  geometry selection overlay if required */
+  private _handleDrawVectorLayerSelectionChanged(
+    layer: IJGISLayer | undefined,
+  ): void {
+    if (layer && !this._model.checkIfIsADrawVectorLayer(layer)) {
       this._model.editingVectorLayer = false;
       this._updateEditingVectorLayer();
     }
-  };
+  }
 
-  private _syncTemporalControllerVisibility(): void {
+  private _handleTemporalControllerActiveChanged(): void {
     const localState = this._model.localState;
     if (!localState) {
       return;
@@ -2286,7 +2300,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   }
 
-  private _syncRemoteUserState(): void {
+  private _handleRemoteUserChanged(): void {
     const localState = this._model.localState;
     if (!localState) {
       return;
@@ -2334,7 +2348,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   }
 
-  private _syncClientPointers(): void {
+  private _handlePointerChanged(): void {
     const clients = this._model.sharedModel.awareness.getStates() as Map<
       number,
       IJupyterGISClientState

--- a/packages/base/src/workspace/panels/components/layers.tsx
+++ b/packages/base/src/workspace/panels/components/layers.tsx
@@ -272,15 +272,15 @@ const LayerGroupComponent: React.FC<ILayerGroupProps> = props => {
    * Listen to the changes on the current layer.
    */
   useEffect(() => {
-    const syncSelected = () => {
+    const handleSelectedChanged = () => {
       // TODO Support follow mode and remoteUser state
       setSelected(isSelected(group.name, gisModel));
     };
-    gisModel?.selectedChanged.connect(syncSelected);
-    syncSelected();
+    gisModel?.selectedChanged.connect(handleSelectedChanged);
+    handleSelectedChanged();
 
     return () => {
-      gisModel?.selectedChanged.disconnect(syncSelected);
+      gisModel?.selectedChanged.disconnect(handleSelectedChanged);
     };
   }, [gisModel, group.name]);
 
@@ -475,15 +475,15 @@ const LayerComponent: React.FC<ILayerProps> = props => {
    * Listen to the changes on the current layer.
    */
   useEffect(() => {
-    const syncSelected = () => {
+    const handleSelectedChanged = () => {
       // TODO Support follow mode and remoteUser state
       setSelected(isSelected(layerId, gisModel));
     };
-    gisModel?.selectedChanged.connect(syncSelected);
-    syncSelected();
+    gisModel?.selectedChanged.connect(handleSelectedChanged);
+    handleSelectedChanged();
 
     return () => {
-      gisModel?.selectedChanged.disconnect(syncSelected);
+      gisModel?.selectedChanged.disconnect(handleSelectedChanged);
     };
   }, [gisModel, layerId]);
 

--- a/packages/base/src/workspace/panels/components/layers.tsx
+++ b/packages/base/src/workspace/panels/components/layers.tsx
@@ -1,7 +1,6 @@
 import {
   IJGISLayerGroup,
   IJGISLayerTree,
-  IJupyterGISClientState,
   IJupyterGISModel,
   ISelection,
   SelectionType,
@@ -273,14 +272,15 @@ const LayerGroupComponent: React.FC<ILayerGroupProps> = props => {
    * Listen to the changes on the current layer.
    */
   useEffect(() => {
-    const onClientSharedStateChanged = () => {
+    const syncSelected = () => {
       // TODO Support follow mode and remoteUser state
       setSelected(isSelected(group.name, gisModel));
     };
-    gisModel?.clientStateChanged.connect(onClientSharedStateChanged);
+    gisModel?.selectedChanged.connect(syncSelected);
+    syncSelected();
 
     return () => {
-      gisModel?.clientStateChanged.disconnect(onClientSharedStateChanged);
+      gisModel?.selectedChanged.disconnect(syncSelected);
     };
   }, [gisModel, group.name]);
 
@@ -475,17 +475,15 @@ const LayerComponent: React.FC<ILayerProps> = props => {
    * Listen to the changes on the current layer.
    */
   useEffect(() => {
-    const onClientSharedStateChanged = (
-      sender: IJupyterGISModel,
-      clients: Map<number, IJupyterGISClientState>,
-    ) => {
+    const syncSelected = () => {
       // TODO Support follow mode and remoteUser state
       setSelected(isSelected(layerId, gisModel));
     };
-    gisModel?.clientStateChanged.connect(onClientSharedStateChanged);
+    gisModel?.selectedChanged.connect(syncSelected);
+    syncSelected();
 
     return () => {
-      gisModel?.clientStateChanged.disconnect(onClientSharedStateChanged);
+      gisModel?.selectedChanged.disconnect(syncSelected);
     };
   }, [gisModel, layerId]);
 

--- a/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
+++ b/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
@@ -55,7 +55,7 @@ export function useRightPanelOptions(
 
     let currentlyIdentifiedFeatures: any = undefined;
 
-    const syncIdentifiedFeatures = () => {
+    const handleIdentifiedFeaturesChanged = () => {
       const identifiedFeatures = model.localState?.identifiedFeatures?.value;
       if (!identifiedFeatures) {
         return;
@@ -68,12 +68,12 @@ export function useRightPanelOptions(
     };
 
     model.sharedOptionsChanged.connect(onOptionsChanged);
-    model.identifiedFeaturesChanged.connect(syncIdentifiedFeatures);
-    syncIdentifiedFeatures();
+    model.identifiedFeaturesChanged.connect(handleIdentifiedFeaturesChanged);
+    handleIdentifiedFeaturesChanged();
 
     return () => {
       model.sharedOptionsChanged.disconnect(onOptionsChanged);
-      model.identifiedFeaturesChanged.disconnect(syncIdentifiedFeatures);
+      model.identifiedFeaturesChanged.disconnect(handleIdentifiedFeaturesChanged);
     };
   }, [model]);
 

--- a/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
+++ b/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
@@ -73,7 +73,9 @@ export function useRightPanelOptions(
 
     return () => {
       model.sharedOptionsChanged.disconnect(onOptionsChanged);
-      model.identifiedFeaturesChanged.disconnect(handleIdentifiedFeaturesChanged);
+      model.identifiedFeaturesChanged.disconnect(
+        handleIdentifiedFeaturesChanged,
+      );
     };
   }, [model]);
 

--- a/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
+++ b/packages/base/src/workspace/panels/hooks/useRightPanelOptions.ts
@@ -1,4 +1,4 @@
-import { IJupyterGISClientState, IJupyterGISModel } from '@jupytergis/schema';
+import { IJupyterGISModel } from '@jupytergis/schema';
 import * as React from 'react';
 
 interface IUseRightPanelOptionsResult {
@@ -52,30 +52,28 @@ export function useRightPanelOptions(
         onPresentationModeEnabledRef.current?.();
       }
     };
-    let currentlyIdentifiedFeatures: any = undefined;
-    const onAwarenessChanged = (
-      _: IJupyterGISModel,
-      clients: Map<number, IJupyterGISClientState>,
-    ) => {
-      const clientId = model.getClientId();
-      const localState = clientId ? clients.get(clientId) : null;
 
-      if (
-        localState &&
-        localState.identifiedFeatures?.value &&
-        localState.identifiedFeatures.value !== currentlyIdentifiedFeatures
-      ) {
-        currentlyIdentifiedFeatures = localState.identifiedFeatures.value;
+    let currentlyIdentifiedFeatures: any = undefined;
+
+    const syncIdentifiedFeatures = () => {
+      const identifiedFeatures = model.localState?.identifiedFeatures?.value;
+      if (!identifiedFeatures) {
+        return;
+      }
+
+      if (identifiedFeatures !== currentlyIdentifiedFeatures) {
+        currentlyIdentifiedFeatures = identifiedFeatures;
         onIdentifyFeaturesRef.current?.();
       }
     };
 
     model.sharedOptionsChanged.connect(onOptionsChanged);
-    model.clientStateChanged.connect(onAwarenessChanged);
+    model.identifiedFeaturesChanged.connect(syncIdentifiedFeatures);
+    syncIdentifiedFeatures();
 
     return () => {
       model.sharedOptionsChanged.disconnect(onOptionsChanged);
-      model.clientStateChanged.disconnect(onAwarenessChanged);
+      model.identifiedFeaturesChanged.disconnect(syncIdentifiedFeatures);
     };
   }, [model]);
 

--- a/packages/base/src/workspace/statusbar/StatusBar.tsx
+++ b/packages/base/src/workspace/statusbar/StatusBar.tsx
@@ -25,7 +25,7 @@ const StatusBar: React.FC<IStatusBarProps> = ({
   const [coords, setCoords] = useState<JgisCoordinates>({ x: 0, y: 0 });
 
   useEffect(() => {
-    const syncPointerCoords = () => {
+    const handlePointerChanged = () => {
       const pointer = jgisModel?.localState?.pointer?.value;
 
       if (!pointer) {
@@ -35,11 +35,11 @@ const StatusBar: React.FC<IStatusBarProps> = ({
       setCoords({ x: pointer?.coordinates.x, y: pointer?.coordinates.y });
     };
 
-    jgisModel.pointerChanged.connect(syncPointerCoords);
-    syncPointerCoords();
+    jgisModel.pointerChanged.connect(handlePointerChanged);
+    handlePointerChanged();
 
     return () => {
-      jgisModel.pointerChanged.disconnect(syncPointerCoords);
+      jgisModel.pointerChanged.disconnect(handlePointerChanged);
     };
   }, [jgisModel]);
 

--- a/packages/base/src/workspace/statusbar/StatusBar.tsx
+++ b/packages/base/src/workspace/statusbar/StatusBar.tsx
@@ -25,7 +25,7 @@ const StatusBar: React.FC<IStatusBarProps> = ({
   const [coords, setCoords] = useState<JgisCoordinates>({ x: 0, y: 0 });
 
   useEffect(() => {
-    const handleClientStateChanged = () => {
+    const syncPointerCoords = () => {
       const pointer = jgisModel?.localState?.pointer?.value;
 
       if (!pointer) {
@@ -35,10 +35,11 @@ const StatusBar: React.FC<IStatusBarProps> = ({
       setCoords({ x: pointer?.coordinates.x, y: pointer?.coordinates.y });
     };
 
-    jgisModel.clientStateChanged.connect(handleClientStateChanged);
+    jgisModel.pointerChanged.connect(syncPointerCoords);
+    syncPointerCoords();
 
     return () => {
-      jgisModel.clientStateChanged.disconnect(handleClientStateChanged);
+      jgisModel.pointerChanged.disconnect(syncPointerCoords);
     };
   }, [jgisModel]);
 

--- a/packages/schema/src/__tests__/awarenessSignals.spec.ts
+++ b/packages/schema/src/__tests__/awarenessSignals.spec.ts
@@ -1,13 +1,16 @@
-// JupyterGISModel reads from `document` during initialization.
-// Provide a minimal DOM stub for node test environment before importing it.
-(globalThis as any).document = {
-  querySelectorAll: () => [],
-};
-
 import { JupyterGISModel } from '../model';
 
 describe('awareness field signals', () => {
   let model: JupyterGISModel;
+  const originalDocument = (globalThis as any).document;
+
+  beforeAll(() => {
+    // JupyterGISModel reads from `document` during initialization.
+    // Provide a minimal DOM stub for node test environment.
+    (globalThis as any).document = {
+      querySelectorAll: () => [],
+    };
+  });
 
   beforeEach(() => {
     model = new JupyterGISModel({});
@@ -15,6 +18,10 @@ describe('awareness field signals', () => {
 
   afterEach(() => {
     model.dispose();
+  });
+
+  afterAll(() => {
+    (globalThis as any).document = originalDocument;
   });
 
   it('emits selectedChanged when selected changes', () => {

--- a/packages/schema/src/__tests__/awarenessSignals.spec.ts
+++ b/packages/schema/src/__tests__/awarenessSignals.spec.ts
@@ -1,0 +1,116 @@
+// JupyterGISModel reads from `document` during initialization.
+// Provide a minimal DOM stub for node test environment before importing it.
+(globalThis as any).document = {
+  querySelectorAll: () => [],
+};
+
+import { JupyterGISModel } from '../model';
+
+describe('awareness field signals', () => {
+  let model: JupyterGISModel;
+
+  beforeEach(() => {
+    model = new JupyterGISModel({});
+  });
+
+  afterEach(() => {
+    model.dispose();
+  });
+
+  it('emits selectedChanged when selected changes', () => {
+    const events: any[] = [];
+    model.selectedChanged.connect((_, args) => {
+      events.push(args);
+    });
+
+    model.syncSelected({ layerA: { type: 'layer' } }, 'test');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].field).toBe('selected');
+    expect(events[0].isLocalClient).toBe(true);
+    expect(events[0].currentValue?.value).toEqual({
+      layerA: { type: 'layer' },
+    });
+  });
+
+  it('emits pointerChanged when pointer changes', () => {
+    const events: any[] = [];
+    model.pointerChanged.connect((_, args) => {
+      events.push(args);
+    });
+
+    model.syncPointer({ coordinates: { x: 1, y: 2 } }, 'test');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].field).toBe('pointer');
+    expect(events[0].isLocalClient).toBe(true);
+    expect(events[0].currentValue?.value).toEqual({
+      coordinates: { x: 1, y: 2 },
+    });
+  });
+
+  it('emits viewportStateChanged when viewport changes', () => {
+    const events: any[] = [];
+    model.viewportStateChanged.connect((_, args) => {
+      events.push(args);
+    });
+
+    model.syncViewport(
+      { coordinates: { x: 10, y: 20 }, zoom: 4, extent: [0, 1, 2, 3] },
+      'test',
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].field).toBe('viewportState');
+    expect(events[0].isLocalClient).toBe(true);
+    expect(events[0].currentValue?.value).toEqual({
+      coordinates: { x: 10, y: 20 },
+      zoom: 4,
+      extent: [0, 1, 2, 3],
+    });
+  });
+
+  it('emits identifiedFeaturesChanged when identified features change', () => {
+    const events: any[] = [];
+    model.identifiedFeaturesChanged.connect((_, args) => {
+      events.push(args);
+    });
+
+    model.syncIdentifiedFeatures({ 0: { name: 'Feature 1' } }, 'test');
+
+    expect(events).toHaveLength(1);
+    expect(events[0].field).toBe('identifiedFeatures');
+    expect(events[0].isLocalClient).toBe(true);
+    expect(events[0].currentValue?.value).toEqual({
+      0: { name: 'Feature 1' },
+    });
+  });
+
+  it('emits remoteUserChanged when follow target changes', () => {
+    const events: any[] = [];
+    model.remoteUserChanged.connect((_, args) => {
+      events.push(args);
+    });
+
+    model.setUserToFollow(42);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].field).toBe('remoteUser');
+    expect(events[0].isLocalClient).toBe(true);
+    expect(events[0].currentValue).toBe(42);
+  });
+
+  it('emits temporalControllerActiveChanged when toggled', () => {
+    const events: any[] = [];
+    model.temporalControllerActiveChanged.connect((_, args) => {
+      events.push(args);
+    });
+
+    model.toggleTemporalController();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].field).toBe('isTemporalControllerActive');
+    expect(events[0].isLocalClient).toBe(true);
+    expect(events[0].currentValue).toBe(true);
+  });
+});

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -53,7 +53,7 @@ import {
   IWebGlLayer,
   Modes,
 } from './types';
-export { IGeoJSONSource } from './_interface/project/sources/geoJsonSource';
+export type { IGeoJSONSource } from './_interface/project/sources/geoJsonSource';
 
 export interface IJGISUIState {
   leftPanelOpen?: boolean;

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -253,14 +253,6 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
     IJupyterGISModel,
     IChangedArgs<string, string | null, string>
   >;
-  /**
-   * @deprecated Prefer field-specific awareness signals such as
-   * `selectedChanged`, `pointerChanged`, and `identifiedFeaturesChanged`.
-   */
-  clientStateChanged: ISignal<
-    IJupyterGISModel,
-    Map<number, IJupyterGISClientState>
-  >;
   selectedChanged: ISignal<
     IJupyterGISModel,
     IAwarenessFieldChange<IJupyterGISClientState['selected']>

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -114,6 +114,7 @@ export interface ISelection {
 
 export interface IJupyterGISClientState {
   selected: { value?: { [key: string]: ISelection }; emitter?: string | null };
+  lastAddedLayer?: { layerId?: string };
   selectedPropField?: {
     id: string | null;
     value: any;
@@ -128,16 +129,22 @@ export interface IJupyterGISClientState {
   isTemporalControllerActive: boolean;
 }
 
-export const AWARENESS_FIELD_KEYS = [
-  'selected',
-  'pointer',
-  'viewportState',
-  'identifiedFeatures',
-  'remoteUser',
-  'isTemporalControllerActive',
-] as const;
+export const AWARENESS_STATE_FIELDS = {
+  selected: 'selected',
+  pointer: 'pointer',
+  viewportState: 'viewportState',
+  identifiedFeatures: 'identifiedFeatures',
+  remoteUser: 'remoteUser',
+  isTemporalControllerActive: 'isTemporalControllerActive',
+  lastAddedLayer: 'lastAddedLayer',
+} as const;
 
-export type AwarenessFieldKey = (typeof AWARENESS_FIELD_KEYS)[number];
+export type AwarenessFieldKey =
+  (typeof AWARENESS_STATE_FIELDS)[keyof typeof AWARENESS_STATE_FIELDS];
+
+export const AWARENESS_FIELD_KEYS = Object.values(
+  AWARENESS_STATE_FIELDS,
+) as AwarenessFieldKey[];
 
 export interface IAwarenessFieldChange<T = any> {
   clientId: number;

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -128,6 +128,26 @@ export interface IJupyterGISClientState {
   isTemporalControllerActive: boolean;
 }
 
+export const AWARENESS_FIELD_KEYS = [
+  'selected',
+  'pointer',
+  'viewportState',
+  'identifiedFeatures',
+  'remoteUser',
+  'isTemporalControllerActive',
+] as const;
+
+export type AwarenessFieldKey = (typeof AWARENESS_FIELD_KEYS)[number];
+
+export interface IAwarenessFieldChange<T = any> {
+  clientId: number;
+  field: AwarenessFieldKey;
+  previousValue: T | undefined;
+  currentValue: T | undefined;
+  fullState: IJupyterGISClientState | undefined;
+  isLocalClient: boolean;
+}
+
 export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
   options: IJGISOptions;
   layers: IJGISLayers;
@@ -233,9 +253,37 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
     IJupyterGISModel,
     IChangedArgs<string, string | null, string>
   >;
+  /**
+   * @deprecated Prefer field-specific awareness signals such as
+   * `selectedChanged`, `pointerChanged`, and `identifiedFeaturesChanged`.
+   */
   clientStateChanged: ISignal<
     IJupyterGISModel,
     Map<number, IJupyterGISClientState>
+  >;
+  selectedChanged: ISignal<
+    IJupyterGISModel,
+    IAwarenessFieldChange<IJupyterGISClientState['selected']>
+  >;
+  pointerChanged: ISignal<
+    IJupyterGISModel,
+    IAwarenessFieldChange<IJupyterGISClientState['pointer']>
+  >;
+  viewportStateChanged: ISignal<
+    IJupyterGISModel,
+    IAwarenessFieldChange<IJupyterGISClientState['viewportState']>
+  >;
+  identifiedFeaturesChanged: ISignal<
+    IJupyterGISModel,
+    IAwarenessFieldChange<IJupyterGISClientState['identifiedFeatures']>
+  >;
+  remoteUserChanged: ISignal<
+    IJupyterGISModel,
+    IAwarenessFieldChange<IJupyterGISClientState['remoteUser']>
+  >;
+  temporalControllerActiveChanged: ISignal<
+    IJupyterGISModel,
+    IAwarenessFieldChange<IJupyterGISClientState['isTemporalControllerActive']>
   >;
   sharedOptionsChanged: ISignal<IJupyterGISDoc, MapChange>;
   sharedLayersChanged: ISignal<IJupyterGISDoc, IJGISLayerDocChange>;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -27,6 +27,7 @@ import {
 import { DEFAULT_PROJECTION, JupyterGISDoc } from './doc';
 import {
   AWARENESS_FIELD_KEYS,
+  AWARENESS_STATE_FIELDS,
   AwarenessFieldKey,
   IAwarenessFieldChange,
   IAnnotationModel,
@@ -616,30 +617,36 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   syncViewport(viewport?: IViewPortState, emitter?: string): void {
-    this.sharedModel.awareness.setLocalStateField('viewportState', {
+    this.sharedModel.awareness.setLocalStateField(
+      AWARENESS_STATE_FIELDS.viewportState,
+      {
       value: viewport,
       emitter,
-    });
+      },
+    );
   }
 
   syncPointer(pointer?: Pointer, emitter?: string): void {
-    this.sharedModel.awareness.setLocalStateField('pointer', {
+    this.sharedModel.awareness.setLocalStateField(AWARENESS_STATE_FIELDS.pointer, {
       value: pointer,
       emitter,
     });
   }
 
   syncSelected(value: { [key: string]: ISelection }, emitter?: string): void {
-    this.sharedModel.awareness.setLocalStateField('selected', {
+    this.sharedModel.awareness.setLocalStateField(AWARENESS_STATE_FIELDS.selected, {
       value,
       emitter,
     });
   }
 
   syncLastAddedLayer(layerId: string): void {
-    this.sharedModel.awareness.setLocalStateField('lastAddedLayer', {
+    this.sharedModel.awareness.setLocalStateField(
+      AWARENESS_STATE_FIELDS.lastAddedLayer,
+      {
       layerId,
-    });
+      },
+    );
   }
   get selected(): { [key: string]: ISelection } | undefined {
     return this.localState?.selected?.value;
@@ -650,15 +657,21 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   syncIdentifiedFeatures(features: IDict<any>, emitter?: string): void {
-    this.sharedModel.awareness.setLocalStateField('identifiedFeatures', {
-      value: features,
-      emitter,
-    });
+    this.sharedModel.awareness.setLocalStateField(
+      AWARENESS_STATE_FIELDS.identifiedFeatures,
+      {
+        value: features,
+        emitter,
+      },
+    );
   }
 
   setUserToFollow(userId?: number): void {
     if (this._sharedModel) {
-      this._sharedModel.awareness.setLocalStateField('remoteUser', userId);
+      this._sharedModel.awareness.setLocalStateField(
+        AWARENESS_STATE_FIELDS.remoteUser,
+        userId,
+      );
     }
   }
 
@@ -1087,7 +1100,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     this._isTemporalControllerActive = !this._isTemporalControllerActive;
 
     this.sharedModel.awareness.setLocalStateField(
-      'isTemporalControllerActive',
+      AWARENESS_STATE_FIELDS.isTemporalControllerActive,
       this._isTemporalControllerActive,
     );
   }
@@ -1178,42 +1191,42 @@ export class JupyterGISModel implements IJupyterGISModel {
         };
 
         switch (field) {
-          case 'selected':
+          case AWARENESS_STATE_FIELDS.selected:
             this._selectedChanged.emit(
               payload as IAwarenessFieldChange<
                 IJupyterGISClientState['selected']
               >,
             );
             break;
-          case 'pointer':
+          case AWARENESS_STATE_FIELDS.pointer:
             this._pointerChanged.emit(
               payload as IAwarenessFieldChange<
                 IJupyterGISClientState['pointer']
               >,
             );
             break;
-          case 'viewportState':
+          case AWARENESS_STATE_FIELDS.viewportState:
             this._viewportStateChanged.emit(
               payload as IAwarenessFieldChange<
                 IJupyterGISClientState['viewportState']
               >,
             );
             break;
-          case 'identifiedFeatures':
+          case AWARENESS_STATE_FIELDS.identifiedFeatures:
             this._identifiedFeaturesChanged.emit(
               payload as IAwarenessFieldChange<
                 IJupyterGISClientState['identifiedFeatures']
               >,
             );
             break;
-          case 'remoteUser':
+          case AWARENESS_STATE_FIELDS.remoteUser:
             this._remoteUserChanged.emit(
               payload as IAwarenessFieldChange<
                 IJupyterGISClientState['remoteUser']
               >,
             );
             break;
-          case 'isTemporalControllerActive':
+          case AWARENESS_STATE_FIELDS.isTemporalControllerActive:
             this._temporalControllerActiveChanged.emit(
               payload as IAwarenessFieldChange<
                 IJupyterGISClientState['isTemporalControllerActive']

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -26,6 +26,9 @@ import {
 } from './_interface/project/layers/storySegmentLayer';
 import { DEFAULT_PROJECTION, JupyterGISDoc } from './doc';
 import {
+  AWARENESS_FIELD_KEYS,
+  AwarenessFieldKey,
+  IAwarenessFieldChange,
   IAnnotationModel,
   IDict,
   IJGISLayerDocChange,
@@ -261,6 +264,48 @@ export class JupyterGISModel implements IJupyterGISModel {
 
   get clientStateChanged(): ISignal<this, Map<number, IJupyterGISClientState>> {
     return this._clientStateChanged;
+  }
+
+  get selectedChanged(): ISignal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['selected']>
+  > {
+    return this._selectedChanged;
+  }
+
+  get pointerChanged(): ISignal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['pointer']>
+  > {
+    return this._pointerChanged;
+  }
+
+  get viewportStateChanged(): ISignal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['viewportState']>
+  > {
+    return this._viewportStateChanged;
+  }
+
+  get identifiedFeaturesChanged(): ISignal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['identifiedFeatures']>
+  > {
+    return this._identifiedFeaturesChanged;
+  }
+
+  get remoteUserChanged(): ISignal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['remoteUser']>
+  > {
+    return this._remoteUserChanged;
+  }
+
+  get temporalControllerActiveChanged(): ISignal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['isTemporalControllerActive']>
+  > {
+    return this._temporalControllerActiveChanged;
   }
 
   get sharedOptionsChanged(): ISignal<IJupyterGISDoc, MapChange> {
@@ -1086,18 +1131,114 @@ export class JupyterGISModel implements IJupyterGISModel {
     };
   }
 
+  // changed is clientID where the changes happened
+  // clients has the actual state
   private _onClientStateChanged = (changed: any) => {
     const clients = this.sharedModel.awareness.getStates() as Map<
       number,
       IJupyterGISClientState
     >;
+    this._emitAwarenessFieldDeltas(changed, clients);
 
+    // Remove after adding all the new signals
     this._clientStateChanged.emit(clients);
 
     if (changed.added.length || changed.removed.length) {
       this._userChanged.emit(this.users);
     }
+
+    // ? reuse map?
+    this._previousClientStates = new Map(clients);
   };
+
+  private _emitAwarenessFieldDeltas(
+    changed: {
+      added?: number[];
+      updated?: number[];
+      removed?: number[];
+    },
+    clients: Map<number, IJupyterGISClientState>,
+  ): void {
+    const changedClientIds = new Set<number>([
+      ...(changed.added ?? []),
+      ...(changed.updated ?? []),
+      ...(changed.removed ?? []),
+    ]);
+
+    if (!changedClientIds.size) {
+      return;
+    }
+
+    const fields: readonly AwarenessFieldKey[] = AWARENESS_FIELD_KEYS;
+    const localClientId = this.getClientId();
+
+    changedClientIds.forEach(clientId => {
+      const previousState = this._previousClientStates.get(clientId);
+      const currentState = clients.get(clientId);
+
+      fields.forEach(field => {
+        const previousValue = previousState?.[field];
+        const currentValue = currentState?.[field];
+        if (previousValue === currentValue) {
+          return;
+        }
+
+        const payload: IAwarenessFieldChange = {
+          clientId,
+          field,
+          previousValue,
+          currentValue,
+          fullState: currentState,
+          isLocalClient: clientId === localClientId,
+        };
+
+        switch (field) {
+          case 'selected':
+            this._selectedChanged.emit(
+              payload as IAwarenessFieldChange<
+                IJupyterGISClientState['selected']
+              >,
+            );
+            break;
+          case 'pointer':
+            this._pointerChanged.emit(
+              payload as IAwarenessFieldChange<
+                IJupyterGISClientState['pointer']
+              >,
+            );
+            break;
+          case 'viewportState':
+            this._viewportStateChanged.emit(
+              payload as IAwarenessFieldChange<
+                IJupyterGISClientState['viewportState']
+              >,
+            );
+            break;
+          case 'identifiedFeatures':
+            this._identifiedFeaturesChanged.emit(
+              payload as IAwarenessFieldChange<
+                IJupyterGISClientState['identifiedFeatures']
+              >,
+            );
+            break;
+          case 'remoteUser':
+            this._remoteUserChanged.emit(
+              payload as IAwarenessFieldChange<
+                IJupyterGISClientState['remoteUser']
+              >,
+            );
+            break;
+          case 'isTemporalControllerActive':
+            this._temporalControllerActiveChanged.emit(
+              payload as IAwarenessFieldChange<
+                IJupyterGISClientState['isTemporalControllerActive']
+              >,
+            );
+            break;
+        }
+      });
+    });
+  }
 
   addFeatureAsMs = (id: string, selectedFeature: string) => {
     this.addFeatureAsMsSignal.emit(JSON.stringify({ id, selectedFeature }));
@@ -1184,6 +1325,31 @@ export class JupyterGISModel implements IJupyterGISModel {
     this,
     Map<number, IJupyterGISClientState>
   >(this);
+  private _selectedChanged = new Signal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['selected']>
+  >(this);
+  private _pointerChanged = new Signal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['pointer']>
+  >(this);
+  private _viewportStateChanged = new Signal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['viewportState']>
+  >(this);
+  private _identifiedFeaturesChanged = new Signal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['identifiedFeatures']>
+  >(this);
+  private _remoteUserChanged = new Signal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['remoteUser']>
+  >(this);
+  private _temporalControllerActiveChanged = new Signal<
+    this,
+    IAwarenessFieldChange<IJupyterGISClientState['isTemporalControllerActive']>
+  >(this);
+  private _previousClientStates = new Map<number, IJupyterGISClientState>();
   private _sharedMetadataChanged = new Signal<this, MapChange>(this);
   private _zoomToPositionSignal = new Signal<this, string>(this);
 

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -262,10 +262,6 @@ export class JupyterGISModel implements IJupyterGISModel {
     return this.sharedModel.awareness.getLocalState() as IJupyterGISClientState | null;
   }
 
-  get clientStateChanged(): ISignal<this, Map<number, IJupyterGISClientState>> {
-    return this._clientStateChanged;
-  }
-
   get selectedChanged(): ISignal<
     this,
     IAwarenessFieldChange<IJupyterGISClientState['selected']>
@@ -1131,23 +1127,12 @@ export class JupyterGISModel implements IJupyterGISModel {
     };
   }
 
-  // changed is clientID where the changes happened
-  // clients has the actual state
   private _onClientStateChanged = (changed: any) => {
     const clients = this.sharedModel.awareness.getStates() as Map<
       number,
       IJupyterGISClientState
     >;
     this._emitAwarenessFieldDeltas(changed, clients);
-
-    // Remove after adding all the new signals
-    this._clientStateChanged.emit(clients);
-
-    if (changed.added.length || changed.removed.length) {
-      this._userChanged.emit(this.users);
-    }
-
-    // ? reuse map?
     this._previousClientStates = new Map(clients);
   };
 
@@ -1321,10 +1306,6 @@ export class JupyterGISModel implements IJupyterGISModel {
   private _contentChanged = new Signal<this, void>(this);
   private _stateChanged = new Signal<this, IChangedArgs<any>>(this);
   private _themeChanged = new Signal<this, IChangedArgs<any>>(this);
-  private _clientStateChanged = new Signal<
-    this,
-    Map<number, IJupyterGISClientState>
-  >(this);
   private _selectedChanged = new Signal<
     this,
     IAwarenessFieldChange<IJupyterGISClientState['selected']>

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -620,31 +620,37 @@ export class JupyterGISModel implements IJupyterGISModel {
     this.sharedModel.awareness.setLocalStateField(
       AWARENESS_STATE_FIELDS.viewportState,
       {
-      value: viewport,
-      emitter,
+        value: viewport,
+        emitter,
       },
     );
   }
 
   syncPointer(pointer?: Pointer, emitter?: string): void {
-    this.sharedModel.awareness.setLocalStateField(AWARENESS_STATE_FIELDS.pointer, {
-      value: pointer,
-      emitter,
-    });
+    this.sharedModel.awareness.setLocalStateField(
+      AWARENESS_STATE_FIELDS.pointer,
+      {
+        value: pointer,
+        emitter,
+      },
+    );
   }
 
   syncSelected(value: { [key: string]: ISelection }, emitter?: string): void {
-    this.sharedModel.awareness.setLocalStateField(AWARENESS_STATE_FIELDS.selected, {
-      value,
-      emitter,
-    });
+    this.sharedModel.awareness.setLocalStateField(
+      AWARENESS_STATE_FIELDS.selected,
+      {
+        value,
+        emitter,
+      },
+    );
   }
 
   syncLastAddedLayer(layerId: string): void {
     this.sharedModel.awareness.setLocalStateField(
       AWARENESS_STATE_FIELDS.lastAddedLayer,
       {
-      layerId,
+        layerId,
       },
     );
   }


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Previously, nearly every awareness change triggered broad listeners (`clientStateChanged` / raw awareness change handlers), even when the changed field was irrelevant to that consumer. This was especially a problem for pointer updates, since they happen almost constantly and triggered unrelated consumers which caused unnecessary recomputation, UI updates (identify panel state, selection-driven panels, temporal controller visibility checks, etc.), avoidable React updates, and noisier state flow throughout the project.

This PR resolves that by

- Added field-specific awareness signals in schema/model
- Implemented per-field delta emission in JupyterGISModel
- Removed old broad `clientStateChanged` usage/path
- Migrated consumers to use specific signals
- Added unit tests to `schema` for awareness signal emission


So now we have less unnecessary handler invocations caused by pointer updates,  awareness-driven behavior is easier to reason about with clear signal-to-consumer mappings, and improved maintainability and lower risk of cross-feature regressions from unrelated awareness changes.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1343.org.readthedocs.build/en/1343/
💡 JupyterLite preview: https://jupytergis--1343.org.readthedocs.build/en/1343/lite
💡 Specta preview: https://jupytergis--1343.org.readthedocs.build/en/1343/lite/specta

<!-- readthedocs-preview jupytergis end -->