### PR TITLE
Update download link in tutorial docs for the NYC Roads shapefile layer

### DIFF
--- a/docs/user_guide/tutorials/01-intro/index.md
+++ b/docs/user_guide/tutorials/01-intro/index.md
@@ -118,7 +118,7 @@ Let's do an exercise to practice adding a new layer.
 
 1. Add a new Shapefile Layer to your map:
    ```
-   https://docs.geoserver.org/stable/en/user/_downloads/30e405b790e068c43354367cb08e71bc/nyc_roads.zip
+   https://docs-archive.geoserver.org/stable/en/user/_downloads/30e405b790e068c43354367cb08e71bc/nyc_roads.zip
    ```
 2. Zoom over New-York (USA) and check if you can see the newly added layer.
 3. Rename both the newly added layer and its corresponding source, e.g. 'NYC Roads'.


### PR DESCRIPTION
Current link goes to `404 Page not found on this server`. Adding the link that the page redirects to.

## Description

Tutorial download link for the NYC Roads shapefile layer goes to a 404 page. This updates the link to a working zip file.

## Checklist

- [X] PR has a descriptive title and content.
- [n/a] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [X] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [n/a] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
-  #[n/a] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1353.org.readthedocs.build/en/1353/
💡 JupyterLite preview: https://jupytergis--1353.org.readthedocs.build/en/1353/lite
💡 Specta preview: https://jupytergis--1353.org.readthedocs.build/en/1353/lite/specta

<!-- readthedocs-preview jupytergis end -->