### PR TITLE
fix: categorized symbology on VectorTile sources

### DIFF
--- a/packages/base/src/features/layers/symbology/styleBuilder.ts
+++ b/packages/base/src/features/layers/symbology/styleBuilder.ts
@@ -102,11 +102,19 @@ export function buildTransparentFallbackFilter(
       return ['has', field];
 
     case 'Categorized': {
-      // For categorized, only show features whose value is in the unique-values
-      // list (i.e. has a matching stop).
-      const uniqueValues = [
-        ...new Set(featureValues.filter(v => v !== undefined && v !== null)),
-      ];
+      // For categorized, only show features whose value is in the stop list.
+      // Prefer stopsOverride (persisted by the dialog for all source types),
+      // fall back to featureValues for in-memory VectorSource layers.
+      let uniqueValues: unknown[];
+      if (state.stopsOverride && state.stopsOverride.length > 0) {
+        uniqueValues = state.stopsOverride
+          .map(s => s.value)
+          .filter(v => v !== undefined && v !== null);
+      } else {
+        uniqueValues = [
+          ...new Set(featureValues.filter(v => v !== undefined && v !== null)),
+        ];
+      }
       if (uniqueValues.length === 0) {
         return ['==', 0, 1];
       }

--- a/packages/base/src/features/layers/symbology/vector_layer/types/Categorized.tsx
+++ b/packages/base/src/features/layers/symbology/vector_layer/types/Categorized.tsx
@@ -75,6 +75,8 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     return;
   }
   const layer = model.getLayer(layerId);
+  const isTileSource =
+    model.getSource(layer?.parameters?.source)?.type === 'VectorTileSource';
 
   const params = useEffectiveSymbologyParams<VectorSymbologyParams>({
     model,
@@ -133,7 +135,7 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     if (state?.renderType === 'Categorized') {
       hasAutoClassified.current = true;
 
-      // If user previously saved manual overrides, restore them.
+      // If user previously saved overrides, restore them.
       if (state.stopsOverride && state.stopsOverride.length > 0) {
         setStopRows(
           state.stopsOverride
@@ -144,7 +146,10 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
               output: s.color as [number, number, number, number],
             })),
         );
-        hasColorOverrides.current = true;
+        // For non-tile sources, re-arm the flag so OK re-saves the overrides.
+        if (!isTileSource) {
+          hasColorOverrides.current = true;
+        }
         return;
       }
 
@@ -209,13 +214,17 @@ const Categorized: React.FC<ISymbologyTabbedDialogWithAttributesProps> = ({
     const method =
       symbologyTab === 'radius' ? ('radius' as const) : ('color' as const);
 
-    // Save manual color overrides if user edited stops.
-    const stopsOverride = hasColorOverrides.current
-      ? (stopRowsRef.current ?? []).map(row => ({
-          value: row.stop,
-          color: row.output as [number, number, number, number],
-        }))
-      : undefined;
+    // For tile sources, stops must be persisted because features cannot be
+    // enumerated at render time. For in-memory sources, only persist when the
+    // user manually edited colors; otherwise the renderer recomputes from the
+    // color ramp and live feature data.
+    const stopsOverride =
+      isTileSource || hasColorOverrides.current
+        ? (stopRowsRef.current ?? []).map(row => ({
+            value: row.stop,
+            color: row.output as [number, number, number, number],
+          }))
+        : undefined;
 
     const symbologyState: IVectorLayer['symbologyState'] = {
       renderType: 'Categorized',


### PR DESCRIPTION
## Summary

- For VectorTile sources, `featureValues` is always empty at render time (tiles load asynchronously, `source.getFeatures()` is only available for in-memory `VectorSource`). This caused two failures with categorized symbology:
  1. `buildCategorized` fell back to a flat default blue because `computeCategorizedColorStops` received an empty array and returned no stops — so the OL `case` expression was never built.
  2. `buildTransparentFallbackFilter` emitted `['==', 0, 1]` (always-false) when `featureValues` was empty, hiding every feature whenever `fallbackColor` alpha is 0.

- Fix: the Categorized dialog now persists `stopsOverride` for VectorTile sources (`isTileSource` flag), giving the render path the stop values it needs. For in-memory VectorSource layers the original behaviour is preserved — stops are only persisted when the user manually edits individual stop colors.

- `buildTransparentFallbackFilter` is updated to prefer `stopsOverride` values over `featureValues` when building the per-category filter expression.

## Test plan

- [ ] Add a VectorTile layer (e.g. Macrostrat), open symbology, set Categorized on a string field — features should render with per-category colors
- [ ] Changing fallback opacity to 0 should hide only unmatched features, not all features
- [ ] For a GeoJSON/VectorSource layer with Categorized symbology and no manual color edits, confirm `stopsOverride` is not written to the saved file
- [ ] For a GeoJSON layer with manually edited stop colors, confirm `stopsOverride` is still saved correctly

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1363.org.readthedocs.build/en/1363/
💡 JupyterLite preview: https://jupytergis--1363.org.readthedocs.build/en/1363/lite
💡 Specta preview: https://jupytergis--1363.org.readthedocs.build/en/1363/lite/specta

<!-- readthedocs-preview jupytergis end -->