### PR TITLE
Let lint handle no unused vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/no-unused-vars": [
-      "warn",
+      "error",
       {
         args: "none",
         varsIgnorePattern: "^_$"

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
     "strict": true,


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Having a build fail because of an unused var while I'm actively working on something is maybe the most annoying thing. Listen, TypeScript, I'm sorry I can't one-shot perfect code and have to experiment a little bit sometimes, but it's not that big of a deal, really. 

So this PR disables the rule in TS and upgrades it to an error when linting so the CI will still point it out. 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1372.org.readthedocs.build/en/1372/
💡 JupyterLite preview: https://jupytergis--1372.org.readthedocs.build/en/1372/lite
💡 Specta preview: https://jupytergis--1372.org.readthedocs.build/en/1372/lite/specta

<!-- readthedocs-preview jupytergis end -->