### PR TITLE
Add nbstripout pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,9 @@ repos:
     rev: "b6045d78aac9e02b039703b030588d54d53262ac"
     hooks:
       - id: validate-cff
+
+  # Strip output cells from notebooks
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.5.0
+    hooks:
+      - id: nbstripout

--- a/examples/99-Explore_data_in_a_map.ipynb
+++ b/examples/99-Explore_data_in_a_map.ipynb
@@ -94,7 +94,6 @@
    "id": "34f7f4d6-28d6-4716-8e03-ac32c6ae3bb7",
    "metadata": {
     "editable": true,
-    "scrolled": true,
     "slideshow": {
      "slide_type": ""
     },


### PR DESCRIPTION
## Description

This pre-commit hook will automatically strip outputs from Notebooks so we don't accidentally commit notebooks with e.g. large images baked in to them. It will also cause CI to fail if someone doesn't have prek/pre-commit installed and pushes a Notebook with outputs. This will prevent us from merging notebooks with outputs into main and bloating our repository!


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1374.org.readthedocs.build/en/1374/
💡 JupyterLite preview: https://jupytergis--1374.org.readthedocs.build/en/1374/lite
💡 Specta preview: https://jupytergis--1374.org.readthedocs.build/en/1374/lite/specta

<!-- readthedocs-preview jupytergis end -->