### PR TITLE
Improve GHA job/workflow names for readability

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -1,10 +1,11 @@
-name: Binder Badge
+name: Binder link comment
 on:
   pull_request_target:
     types: [opened]
 
 jobs:
   binder:
+    name: Add/update Comment
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/build-test-without-lockfile.yml
+++ b/.github/workflows/build-test-without-lockfile.yml
@@ -9,8 +9,8 @@ on:
 permissions: {}
 
 jobs:
-  test_build_without_lockfile:
-    name: Test-build without lockfile
+  build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Build jupytergis
+    name: Build artifacts
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -113,6 +113,7 @@ jobs:
         run: node packages/schema/scripts/validate-examples.js
 
   test_isolated:
+    name: Test artifact in isolated env
     needs: build
     runs-on: ubuntu-latest
 
@@ -136,7 +137,7 @@ jobs:
           jupyter labextension list 2>&1 | grep -ie "jupytergis.*OK"
 
   integration-tests:
-    name: Integration tests
+    name: Integration test
     needs: build
     runs-on: ubuntu-latest
 
@@ -251,7 +252,7 @@ jobs:
           retention-days: 30
 
   integration-tests-lite:
-    name: Integration tests Lite
+    name: JupyterLite integration test
     needs: build-lite
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,4 +1,4 @@
-name: Check Release
+name: Check release
 on:
   push:
     branches:
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check_release:
+    name: Release dry-run
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -5,6 +5,7 @@ on:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:
+    name: Check for required labels
     runs-on: ubuntu-latest
     steps:
       - name: enforce-triage-label

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   lint-js:
-    name: Lint JavaScript
+    name: eslint & prettier
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-test-js.yml
+++ b/.github/workflows/unit-test-js.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   unit-test-js:
-    name: Run JavaScript unit tests
+    name: jest
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   unit-test-python:
-    name: Run Python unit tests
+    name: pytest
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Description

I was bothered by many job/workflow names repeating each other and/or not providing any additional information.

For example:

* `Build / test_isolated`: Unclear what this means unless familiar with the workflow
* `Check release / check_release`: Both repetitive and unclear what this means unless familiar
* `Unit test JavaScript / Run JavaScript unit tests`: Repetitive, the job name tells me nothing
* `Binder Badge / binder`: Both repetitive and unclear what this means unless familiar

So I did a quick pass at improving the information density of the names so they're more useful in the GitHub Checks UI at the bottom of a PR.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1375.org.readthedocs.build/en/1375/
💡 JupyterLite preview: https://jupytergis--1375.org.readthedocs.build/en/1375/lite
💡 Specta preview: https://jupytergis--1375.org.readthedocs.build/en/1375/lite/specta

<!-- readthedocs-preview jupytergis end -->