### PR TITLE
Make simple CI workflows more responsive

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   binder:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: enforce-triage-label
         uses: jupyterlab/maintainer-tools/.github/actions/enforce-label@7bebe19dab1c58587eb734aca9184d8e59fdf911 # v1

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   autolink-rtd-previews:
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-slim'
     steps:
       - uses: 'mfisher87/readthedocs-actions/preview@382564110b66bee5eae9d1202b492bfe4f1adec7' # main
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   zizmor:
     name: 'Run zizmor 🌈'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-slim'
     permissions:
       security-events: 'write' # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   zizmor:
     name: 'Run zizmor 🌈'
-    runs-on: 'ubuntu-slim'
+    runs-on: 'ubuntu-latest'
     permissions:
       security-events: 'write' # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
     steps:


### PR DESCRIPTION
## Description

In late 2025, GitHub made a container-based instead of vm-based runner available. It will start up faster but has limited resources. Great for labeling PRs, checking PR labels, adding/modifying comments, reacting, etc.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

I initially wanted to move zizmor to ubuntu-slim, but the action itself requires Docker and I had to roll it back :shrug: 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1377.org.readthedocs.build/en/1377/
💡 JupyterLite preview: https://jupytergis--1377.org.readthedocs.build/en/1377/lite
💡 Specta preview: https://jupytergis--1377.org.readthedocs.build/en/1377/lite/specta

<!-- readthedocs-preview jupytergis end -->