### PR TITLE
Add legend for Single band GeoTIFF

### DIFF
--- a/packages/base/src/features/layers/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
+++ b/packages/base/src/features/layers/symbology/tiff_layer/types/SingleBandPseudoColor.tsx
@@ -73,20 +73,38 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
   const [colorRampOptions, setColorRampOptions] = useState<
     ColorRampControlsOptions | undefined
   >();
+  const [stopsAltered, setStopsAltered] = useState(false);
 
   const stopRowsRef = useLatest(stopRows);
   const bandRowsRef = useLatest(bandRows);
   const selectedFunctionRef = useLatest(selectedFunction);
   const colorRampOptionsRef = useLatest(colorRampOptions);
   const selectedBandRef = useLatest(selectedBand);
+  const stopsAlteredRef = useLatest(stopsAltered);
 
   useEffect(() => {
     populateOptions();
   }, []);
 
   useEffect(() => {
-    buildColorInfo();
-  }, [bandRows]);
+    if (bandRows.length === 0) {
+      return;
+    }
+
+    if (params.symbologyState?.stopsOverride) {
+      return;
+    }
+
+    const state = params.symbologyState;
+
+    buildColorInfoFromClassification(
+      (state?.mode ?? 'equal interval') as ClassificationMode,
+      Number(state?.nClasses ?? 9),
+      (state?.colorRamp ?? 'viridis') as ColorRampName,
+      state?.reverseRamp ?? false,
+      () => undefined,
+    );
+  }, [bandRows, selectedBand]);
 
   const populateOptions = async () => {
     const layerState = (await stateDb?.fetch(
@@ -100,6 +118,13 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
 
     setSelectedBand(band);
     setSelectedFunction(interpolation);
+
+    if (params.symbologyState?.stopsOverride) {
+      setStopRows(params.symbologyState.stopsOverride as IStopRow[]);
+      setStopsAltered(true);
+    } else {
+      buildColorInfo();
+    }
   };
 
   const buildColorInfo = () => {
@@ -165,6 +190,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
     }
 
     setStopRows(valueColorPairs);
+    setStopsAltered(false);
   };
 
   const handleOk = () => {
@@ -248,6 +274,9 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
           : undefined,
       mode: colorRampOptionsRef.current?.selectedMode,
       reverseRamp: colorRampOptionsRef.current?.reverseRamp,
+      ...(stopsAlteredRef.current
+        ? { stopsOverride: stopRowsRef.current }
+        : {}),
     } as IGeoTiffLayer['symbologyState'];
 
     if (!isStorySegmentOverride) {
@@ -284,6 +313,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
   useOkSignal(okSignalPromise, handleOk);
 
   const addStopRow = () => {
+    setStopsAltered(true);
     setStopRows([
       {
         id: UUID.uuid4(),
@@ -295,12 +325,17 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
   };
 
   const deleteStopRow = (index: number) => {
+    setStopsAltered(true);
     const newFilters = [...stopRows];
     newFilters.splice(index, 1);
 
     setStopRows(newFilters);
   };
 
+  const updateStopRows = (rows: IStopRow[]) => {
+    setStopsAltered(true);
+    setStopRows(rows);
+  };
   const buildColorInfoFromClassification = async (
     selectedMode: ClassificationMode,
     numberOfShades: number,
@@ -368,6 +403,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
     );
 
     setStopRows(valueColorPairs);
+    setStopsAltered(false);
   };
 
   const scaleValue = (bandValue: number, isQuantile: boolean) => {
@@ -463,7 +499,7 @@ const SingleBandPseudoColor: React.FC<ISymbologyDialogProps> = ({
             dataValue={stop.stop}
             symbologyValue={stop.output}
             stopRows={stopRows}
-            setStopRows={setStopRows}
+            setStopRows={updateStopRows}
             deleteRow={() => deleteStopRow(index)}
           />
         ))}

--- a/packages/base/src/workspace/panels/components/legendItem.tsx
+++ b/packages/base/src/workspace/panels/components/legendItem.tsx
@@ -1,9 +1,15 @@
 import { IJupyterGISModel } from '@jupytergis/schema';
 import React, { useEffect, useState } from 'react';
 
-import { findExprNode } from '@/src/features/layers/symbology/colorRampUtils';
+import { GeoTiffClassifications } from '@/src/features/layers/symbology/classificationModes';
+import {
+  ColorRampName,
+  findExprNode,
+  getColorMap,
+} from '@/src/features/layers/symbology/colorRampUtils';
 import { useGetSymbology } from '@/src/features/layers/symbology/hooks/useGetSymbology';
 import { buildVectorFlatStyle } from '@/src/features/layers/symbology/styleBuilder';
+import { Utils } from '@/src/features/layers/symbology/symbologyUtils';
 
 export const LegendItem: React.FC<{
   layerId: string;
@@ -336,6 +342,162 @@ export const LegendItem: React.FC<{
             {reversed && (
               <span style={{ fontWeight: 'bold' }}>Reversed ramp</span>
             )}
+          </div>
+        </div>,
+      );
+      return;
+    }
+
+    if (renderType === 'Singleband Pseudocolor') {
+      const colorExpr = symbology.color;
+      const interpolation = state?.interpolation ?? 'linear';
+      const band = state?.band ?? 1;
+      const mode = state?.mode ?? 'equal interval';
+      const shouldShowStops = mode === 'equal interval';
+
+      let stops: { value: number; color: string }[] = [];
+
+      if (!stops.length && shouldShowStops) {
+        const layer = model.getLayer(layerId);
+        const sourceId = layer?.parameters?.source;
+        const source = sourceId ? model.getSource(sourceId) : undefined;
+        const sourceInfo = source?.parameters?.urls?.[0];
+
+        const min = Number(sourceInfo?.min);
+        const max = Number(sourceInfo?.max);
+
+        if (Number.isFinite(min) && Number.isFinite(max)) {
+          const nClasses = Number(state?.nClasses ?? 9);
+
+          const classifiedStops =
+            GeoTiffClassifications.classifyEqualIntervalBreaks(
+              nClasses,
+              min,
+              max,
+              interpolation,
+            );
+
+          const colorRamp = getColorMap(
+            (state?.colorRamp ?? 'viridis') as ColorRampName,
+          );
+
+          if (colorRamp && classifiedStops.length) {
+            stops = Utils.getValueColorPairs(
+              classifiedStops,
+              colorRamp,
+              nClasses,
+              state?.reverseRamp ?? false,
+            ).map(row => ({
+              value: Number(row.stop),
+              color: Array.isArray(row.output)
+                ? `rgba(${row.output[0]},${row.output[1]},${row.output[2]},${row.output[3]})`
+                : String(row.output),
+            }));
+          }
+        }
+      }
+
+      const cats = parseCaseCategories(colorExpr);
+
+      if (!stops.length) {
+        stops = parseColorStops(colorExpr);
+
+        if (cats.length) {
+          stops = cats.map(c => ({
+            value: Number(c.category),
+            color: c.color,
+          }));
+        }
+      }
+
+      stops = stops.filter(s => !s.color.endsWith(',0)')); // Filter out transparent colors
+
+      if (!stops.length) {
+        setContent(
+          <p style={{ fontSize: '0.8em' }}>No pseudocolor symbology</p>,
+        );
+        return;
+      }
+
+      const min = stops[0].value;
+      const max = stops[stops.length - 1].value;
+
+      const getStopPct = (value: number) => {
+        if (min === max) {
+          return 0;
+        }
+        return ((value - min) / (max - min)) * 100;
+      };
+
+      const segments = stops
+        .map(s => `${s.color} ${getStopPct(s.value)}%`)
+        .join(', ');
+
+      const gradient = `linear-gradient(to right, ${segments})`;
+
+      setContent(
+        <div style={{ padding: 6, width: '90%' }}>
+          <div style={{ fontSize: '1em', marginBottom: 20 }}>
+            <strong>Band {band}</strong>
+          </div>
+
+          <div
+            style={{
+              position: 'relative',
+              height: 12,
+              background: gradient,
+              border: '1px solid #ccc',
+              borderRadius: 3,
+              marginBottom: 20,
+              marginTop: 10,
+            }}
+          >
+            {shouldShowStops &&
+              stops.map((s, i) => {
+                const left = getStopPct(s.value);
+                const up = i % 2 === 0;
+
+                return (
+                  <div
+                    key={i}
+                    style={{
+                      position: 'absolute',
+                      left: `${left}%`,
+                      transform: 'translateX(-50%)',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: 1,
+                        height: 8,
+                        background: '#333',
+                        margin: '0 auto',
+                      }}
+                    />
+
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: up ? -18 : 12,
+                        fontSize: '0.7em',
+                        whiteSpace: 'nowrap',
+                        marginTop: up ? 0 : 4,
+                        marginLeft: -8,
+                      }}
+                    >
+                      {s.value.toFixed(2)}
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+
+          <div
+            style={{ fontWeight: 'bold', fontSize: '0.75em', opacity: 0.75 }}
+          >
+            {interpolation.charAt(0).toUpperCase() + interpolation.slice(1)}{' '}
+            interpolation
+            {state?.reverseRamp ? ' · Reversed ramp' : ''}
           </div>
         </div>,
       );

--- a/packages/schema/src/schema/project/layers/geoTiffLayer.json
+++ b/packages/schema/src/schema/project/layers/geoTiffLayer.json
@@ -86,6 +86,10 @@
           "type": "string",
           "default": "viridis"
         },
+        "reverseRamp": {
+          "type": "boolean",
+          "default": false
+        },
         "nClasses": {
           "type": "string",
           "default": "9"
@@ -94,6 +98,10 @@
           "type": "string",
           "default": "equal interval",
           "enum": ["continuous", "equal interval", "quantile"]
+        },
+        "stopsOverride": {
+          "type": "array",
+          "description": "User-customized color stops that override the computed classification. Saved only when the user manually edits stop colors in the dialog."
         }
       },
       "additionalProperties": false,
@@ -107,7 +115,8 @@
         "interpolation": "linear",
         "colorRamp": "viridis",
         "nClasses": "9",
-        "mode": "equal interval"
+        "mode": "equal interval",
+        "reverseRamp": false
       }
     }
   }


### PR DESCRIPTION
## Description
This Pr adds the legend section for the `Singleband Pseudocolor` that shows colorRamp and stops only for Equal interval, Interpolation type and If a ramp is reversed or not.

https://github.com/user-attachments/assets/6922b780-beb4-4a13-aa5a-305d2a05694f



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1380.org.readthedocs.build/en/1380/
💡 JupyterLite preview: https://jupytergis--1380.org.readthedocs.build/en/1380/lite
💡 Specta preview: https://jupytergis--1380.org.readthedocs.build/en/1380/lite/specta

<!-- readthedocs-preview jupytergis end -->