### PR TITLE
Upgrade jupyter-releaser action to fix broken release workflows

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@f5d710df1483f19b666dd96aeabbe949a53642c2 # v1
 
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: next

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@f5d710df1483f19b666dd96aeabbe949a53642c2 # v1
 
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v1.11.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: next

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v1.11.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Finalize Release
         id: finalize-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@3e74486d1011d24cd5e9977202fd349dece0db9c # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v1.11.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Finalize Release
         id: finalize-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@f1cb16e30ea64b0c39609ba8000f571e1f81f20f # v1.11.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}


### PR DESCRIPTION
## Description

The older version of `jupyter-releaser` would pull the latest version of `build`, but the latest version of `build` changed its entrypoint from `build` to `pyproject-build`. `jupyter-releaser` does not constrain the version of `build` it uses.

See: <https://github.com/jupyter-server/jupyter_releaser/pull/654>

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1408.org.readthedocs.build/en/1408/
💡 JupyterLite preview: https://jupytergis--1408.org.readthedocs.build/en/1408/lite
💡 Specta preview: https://jupytergis--1408.org.readthedocs.build/en/1408/lite/specta

<!-- readthedocs-preview jupytergis end -->