### PR TITLE
Add jupyter-collaboration cache files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ packages/schema/src/processing/_generated/*
 examples/local_examples/*
 
 packages/base/_generated/
+
+# jupyter-collaboration cache
+.jupyter


### PR DESCRIPTION


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1413.org.readthedocs.build/en/1413/
💡 JupyterLite preview: https://jupytergis--1413.org.readthedocs.build/en/1413/lite
💡 Specta preview: https://jupytergis--1413.org.readthedocs.build/en/1413/lite/specta

<!-- readthedocs-preview jupytergis end -->