### PR TITLE
fix: identify no longer shrinks circle on Grammar vector layers

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -677,7 +677,15 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         }
         const selectedLayerId = Object.keys(selectedLayers)[0];
         const expected = this.getLayer(selectedLayerId);
-        return layer === expected;
+        if (layer === expected) {
+          return true;
+        }
+        // Grammar multi-layer symbology wraps sub-layers in a LayerGroup.
+        // OL Select flattens groups, so we receive leaf layers, not the group.
+        if (expected instanceof LayerGroup) {
+          return expected.getLayers().getArray().includes(layer);
+        }
+        return false;
       },
       condition: (event: MapBrowserEvent<any>) => {
         return singleClick(event) && this._model.currentMode === 'identifying';
@@ -700,10 +708,20 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       const mapLayer = selectedLayerId
         ? this.getLayer(selectedLayerId)
         : undefined;
-      const styleFn =
-        mapLayer && 'getStyleFunction' in mapLayer
-          ? (mapLayer as VectorLayer).getStyleFunction()
-          : undefined;
+
+      // For LayerGroup (multi-layer grammar), collect style functions from
+      // all sub-layers so we can match the right one per feature.
+      const styleFnCandidates: ReturnType<VectorLayer['getStyleFunction']>[] =
+        [];
+      if (mapLayer instanceof LayerGroup) {
+        for (const sub of mapLayer.getLayers().getArray()) {
+          if ('getStyleFunction' in sub) {
+            styleFnCandidates.push((sub as VectorLayer).getStyleFunction());
+          }
+        }
+      } else if (mapLayer && 'getStyleFunction' in mapLayer) {
+        styleFnCandidates.push((mapLayer as VectorLayer).getStyleFunction());
+      }
       const resolution = this._Map.getView().getResolution() ?? 1;
 
       selectInteraction.getFeatures().forEach(feature => {
@@ -714,17 +732,26 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         const geom = feature.getGeometry();
         if (geom) {
           const hlFeature = new Feature({ geometry: geom });
-          if (styleFn) {
-            const resolved = styleFn(feature, resolution);
+          // Try each style function candidate; use the first that resolves
+          // a non-empty style array (important for LayerGroup sub-layers
+          // where only one sub-layer's style applies to this feature).
+          for (const fn of styleFnCandidates) {
+            if (!fn) {
+              continue;
+            }
+            const resolved = fn(feature, resolution);
             const styles = Array.isArray(resolved)
               ? resolved
               : resolved
                 ? [resolved]
                 : [];
-            const gType = geom.getType();
-            hlFeature.setStyle(
-              styles.map(s => this._buildHighlightStyle(s, gType)),
-            );
+            if (styles.length > 0) {
+              const gType = geom.getType();
+              hlFeature.setStyle(
+                styles.map(s => this._buildHighlightStyle(s, gType)),
+              );
+              break;
+            }
           }
           highlightFeatures.push(hlFeature);
         }

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2097,7 +2097,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return;
     }
     if (!this._highlightLayer) {
-      this._highlightLayer = new VectorLayer({
+      this._highlightLayer = new VectorImageLayer({
         source: new VectorSource(),
         style: feature => {
           const geomType = feature.getGeometry()?.getType();
@@ -4081,7 +4081,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _contextMenu: ContextMenu;
   private _loadingLayers: Set<string>;
   private _originalFeatures: IDict<Feature<Geometry>[]> = {};
-  private _highlightLayer: VectorLayer<VectorSource>;
+  private _highlightLayer: VectorImageLayer<VectorSource>;
   private _draw: Draw;
   private _snap: Snap;
   private _modify: Modify;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -676,8 +676,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           return false;
         }
         const selectedLayerId = Object.keys(selectedLayers)[0];
-
-        return layer === this.getLayer(selectedLayerId);
+        const expected = this.getLayer(selectedLayerId);
+        return layer === expected;
       },
       condition: (event: MapBrowserEvent<any>) => {
         return singleClick(event) && this._model.currentMode === 'identifying';
@@ -721,7 +721,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
               : resolved
                 ? [resolved]
                 : [];
-            hlFeature.setStyle(styles.map(s => this._buildHighlightStyle(s)));
+            const gType = geom.getType();
+            hlFeature.setStyle(
+              styles.map(s => this._buildHighlightStyle(s, gType)),
+            );
           }
           highlightFeatures.push(hlFeature);
         }
@@ -2057,58 +2060,66 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   }
 
   private _ensureHighlightLayer(): void {
-    if (this._highlightLayer) {
+    // Check that the layer both exists AND is still in the map.
+    // _updateLayersImpl removes layers whose id isn't in the JGIS model,
+    // which includes this layer (it has no JGIS id).
+    if (
+      this._highlightLayer &&
+      this._Map.getLayers().getArray().includes(this._highlightLayer)
+    ) {
       return;
     }
-    this._highlightLayer = new VectorLayer({
-      source: new VectorSource(),
-      style: feature => {
-        const geomType = feature.getGeometry()?.getType();
-        switch (geomType) {
-          case 'Point':
-          case 'MultiPoint':
-            return new Style({
-              image: new Circle({
-                radius: 8,
-                fill: new Fill({
-                  color: 'transparent',
+    if (!this._highlightLayer) {
+      this._highlightLayer = new VectorLayer({
+        source: new VectorSource(),
+        style: feature => {
+          const geomType = feature.getGeometry()?.getType();
+          switch (geomType) {
+            case 'Point':
+            case 'MultiPoint':
+              return new Style({
+                image: new Circle({
+                  radius: 8,
+                  fill: new Fill({
+                    color: 'transparent',
+                  }),
+                  stroke: new Stroke({
+                    color: '#ff0',
+                    width: 3,
+                  }),
                 }),
+              });
+            case 'LineString':
+            case 'MultiLineString':
+              return new Style({
                 stroke: new Stroke({
-                  color: '#ff0',
+                  color: 'rgba(255, 255, 0, 0.8)',
                   width: 3,
                 }),
-              }),
-            });
-          case 'LineString':
-          case 'MultiLineString':
-            return new Style({
-              stroke: new Stroke({
-                color: 'rgba(255, 255, 0, 0.8)',
-                width: 3,
-              }),
-            });
-          case 'Polygon':
-          case 'MultiPolygon':
-            return new Style({
-              stroke: new Stroke({
-                color: '#ff0',
-                width: 2,
-              }),
-              fill: new Fill({
-                color: 'rgba(255, 255, 0, 0.15)',
-              }),
-            });
-          default:
-            return new Style({
-              stroke: new Stroke({
-                color: '#ff0',
-                width: 2,
-              }),
-            });
-        }
-      },
-      zIndex: 999,
-    });
+              });
+            case 'Polygon':
+            case 'MultiPolygon':
+              return new Style({
+                stroke: new Stroke({
+                  color: '#ff0',
+                  width: 2,
+                }),
+                fill: new Fill({
+                  color: 'rgba(255, 255, 0, 0.15)',
+                }),
+              });
+            default:
+              return new Style({
+                stroke: new Stroke({
+                  color: '#ff0',
+                  width: 2,
+                }),
+              });
+          }
+        },
+        zIndex: 999,
+      });
+    }
     this._Map.addLayer(this._highlightLayer);
   }
 
@@ -2144,16 +2155,22 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
    * Preserves data-driven properties (circle radius, line width) and swaps in
    * a constant yellow highlight color.
    */
-  private _buildHighlightStyle(original: Style): Style {
-    const image = original.getImage();
-    if (image instanceof CircleStyle) {
-      return new Style({
-        image: new Circle({
-          radius: image.getRadius() + 4,
-          fill: new Fill({ color: 'transparent' }),
-          stroke: new Stroke({ color: '#ff0', width: 3 }),
-        }),
-      });
+  private _buildHighlightStyle(original: Style, geomType?: string): Style {
+    // Only use the circle branch for point geometries.  The OL default style
+    // includes a circle image alongside fill/stroke; without this guard the
+    // circle branch would fire for polygons and produce an invisible style.
+    const isPoint = geomType === 'Point' || geomType === 'MultiPoint';
+    if (isPoint) {
+      const image = original.getImage();
+      if (image instanceof CircleStyle) {
+        return new Style({
+          image: new Circle({
+            radius: image.getRadius() + 4,
+            fill: new Fill({ color: 'transparent' }),
+            stroke: new Stroke({ color: '#ff0', width: 3 }),
+          }),
+        });
+      }
     }
 
     const origStroke = original.getStroke();

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -676,15 +676,21 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           return false;
         }
         const selectedLayerId = Object.keys(selectedLayers)[0];
-
-        return layer === this.getLayer(selectedLayerId);
+        if (layer !== this.getLayer(selectedLayerId)) {
+          return false;
+        }
+        // Select moves matched features to its internal overlay with style:[],
+        // removing them from the original layer's rendering. VectorLayer features
+        // are handled in _identifyFeature via forEachFeatureAtPixel instead so
+        // their original style is preserved.
+        const jgisLayer = this._model.getLayer(selectedLayerId);
+        return jgisLayer?.type !== 'VectorLayer';
       },
       condition: (event: MapBrowserEvent<any>) => {
         return singleClick(event) && this._model.currentMode === 'identifying';
       },
-      // Return an empty style so the select interaction does not visually
-      // override the layer's own style.  Visual feedback is provided by
-      // _highlightLayer (zIndex 999) via highlightFeatureSignal.
+      // Return an empty style — visual feedback for VectorTileLayer comes from
+      // _highlightLayer.  VectorLayer is excluded from this interaction entirely.
       style: () => [],
     });
 
@@ -2045,13 +2051,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           case 'MultiPoint':
             return new Style({
               image: new Circle({
-                radius: 6,
+                radius: 8,
                 fill: new Fill({
-                  color: 'rgba(255, 255, 0, 0.8)',
+                  color: 'transparent',
                 }),
                 stroke: new Stroke({
                   color: '#ff0',
-                  width: 2,
+                  width: 3,
                 }),
               }),
             });
@@ -2067,17 +2073,17 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           case 'MultiPolygon':
             return new Style({
               stroke: new Stroke({
-                color: '#f00',
+                color: '#ff0',
                 width: 2,
               }),
               fill: new Fill({
-                color: 'rgba(255, 255, 0, 0.8)',
+                color: 'rgba(255, 255, 0, 0.15)',
               }),
             });
           default:
             return new Style({
               stroke: new Stroke({
-                color: '#000',
+                color: '#ff0',
                 width: 2,
               }),
             });
@@ -2100,6 +2106,57 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     for (const geom of geometries) {
       source?.addFeature(new Feature({ geometry: geom }));
     }
+  }
+
+  /**
+   * Replace the highlight layer contents with pre-styled features.
+   * Each feature carries its own highlight style via feature.setStyle().
+   */
+  private _setHighlightFeatures(features: Feature[]): void {
+    this._ensureHighlightLayer();
+    const source = this._highlightLayer.getSource();
+    source?.clear();
+    for (const f of features) {
+      source?.addFeature(f);
+    }
+  }
+
+  /**
+   * Build a highlight style from an original resolved style.
+   * Preserves data-driven properties (circle radius, line width) and swaps in
+   * a constant yellow highlight color.
+   */
+  private _buildHighlightStyle(original: Style): Style {
+    const image = original.getImage();
+    if (image instanceof CircleStyle) {
+      return new Style({
+        image: new Circle({
+          radius: image.getRadius(),
+          fill: new Fill({ color: 'rgba(255, 255, 0, 0.3)' }),
+          stroke: new Stroke({ color: '#ff0', width: 3 }),
+        }),
+      });
+    }
+
+    const origStroke = original.getStroke();
+    const origFill = original.getFill();
+
+    if (origStroke || origFill) {
+      return new Style({
+        stroke: new Stroke({
+          color: '#ff0',
+          width: (origStroke?.getWidth() ?? 1) + 2,
+        }),
+        ...(origFill
+          ? { fill: new Fill({ color: 'rgba(255, 255, 0, 0.15)' }) }
+          : {}),
+      });
+    }
+
+    // Fallback
+    return new Style({
+      stroke: new Stroke({ color: '#ff0', width: 2 }),
+    });
   }
 
   /**
@@ -3345,10 +3402,48 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const jgisLayer = this._model.getLayer(layerId);
 
     switch (jgisLayer?.type) {
-      case 'VectorLayer':
-        // Feature selection, property sync, and highlight for VectorLayer are
-        // handled entirely by the selectInteraction (createSelectInteraction).
+      case 'VectorLayer': {
+        const highlightFeatures: Feature[] = [];
+        const identified: IIdentifiedFeatureEntry[] = [];
+        const mapLayer = this.getLayer(layerId) as VectorLayer | undefined;
+        const styleFn = mapLayer?.getStyleFunction();
+        const resolution = this._Map.getView().getResolution() ?? 1;
+
+        this._Map.forEachFeatureAtPixel(
+          e.pixel,
+          (feature: FeatureLike) => {
+            if (feature instanceof RenderFeature) {
+              return true;
+            }
+            const geom = feature.getGeometry();
+            if (geom) {
+              const hlFeature = new Feature({ geometry: geom });
+              if (styleFn) {
+                const resolved = styleFn(feature, resolution);
+                const styles = Array.isArray(resolved)
+                  ? resolved
+                  : resolved
+                    ? [resolved]
+                    : [];
+                hlFeature.setStyle(
+                  styles.map(s => this._buildHighlightStyle(s)),
+                );
+              }
+              highlightFeatures.push(hlFeature);
+            }
+            identified.push({
+              feature: feature.getProperties(),
+              floaterOpen: false,
+            });
+            return true;
+          },
+          { layerFilter: l => l === this.getLayer(layerId) },
+        );
+
+        this._model.syncIdentifiedFeatures(identified, this._mainViewModel.id);
+        this._setHighlightFeatures(highlightFeatures);
         break;
+      }
 
       case 'VectorTileLayer': {
         const geometries: Geometry[] = [];

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2162,8 +2162,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     if (origStroke || origFill) {
       return new Style({
         stroke: new Stroke({
-          color: '#ff0',
-          width: (origStroke?.getWidth() ?? 1) + 2,
+          color: 'rgba(255, 255, 0, 0.4)',
+          width: (origStroke?.getWidth() ?? 1) + 4,
         }),
         ...(origFill
           ? { fill: new Fill({ color: 'rgba(255, 255, 0, 0.15)' }) }
@@ -2173,7 +2173,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     // Fallback
     return new Style({
-      stroke: new Stroke({ color: '#ff0', width: 2 }),
+      stroke: new Stroke({ color: 'rgba(255, 255, 0, 0.4)', width: 4 }),
     });
   }
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -665,49 +665,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   };
 
   createSelectInteraction = () => {
-    const pointStyle = new Style({
-      image: new Circle({
-        radius: 5,
-        fill: new Fill({
-          color: '#C52707',
-        }),
-        stroke: new Stroke({
-          color: '#171717',
-          width: 2,
-        }),
-      }),
-    });
-
-    const lineStyle = new Style({
-      stroke: new Stroke({
-        color: '#171717',
-        width: 2,
-      }),
-    });
-
-    const polygonStyle = new Style({
-      fill: new Fill({ color: '#C5270780' }),
-      stroke: new Stroke({
-        color: '#171717',
-        width: 2,
-      }),
-    });
-
-    const styleFunction = (feature: FeatureLike) => {
-      const geometryType = feature.getGeometry()?.getType();
-      switch (geometryType) {
-        case 'Point':
-        case 'MultiPoint':
-          return pointStyle;
-        case 'LineString':
-        case 'MultiLineString':
-          return lineStyle;
-        case 'Polygon':
-        case 'MultiPolygon':
-          return polygonStyle;
-      }
-    };
-
     const selectInteraction = new Select({
       hitTolerance: 5,
       multi: true,
@@ -725,7 +682,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       condition: (event: MapBrowserEvent<any>) => {
         return singleClick(event) && this._model.currentMode === 'identifying';
       },
-      style: styleFunction,
+      // Return an empty style so the select interaction does not visually
+      // override the layer's own style.  Visual feedback is provided by
+      // _highlightLayer (zIndex 999) via highlightFeatureSignal.
+      style: () => [],
     });
 
     selectInteraction.on('select', event => {
@@ -3358,6 +3318,41 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const jgisLayer = this._model.getLayer(layerId);
 
     switch (jgisLayer?.type) {
+      case 'VectorLayer': {
+        const olLayer = this.getLayer(layerId);
+        const geometries: Geometry[] = [];
+        const features: IIdentifiedFeatureEntry[] = [];
+
+        this._Map.forEachFeatureAtPixel(
+          e.pixel,
+          (feature: FeatureLike) => {
+            const geom =
+              feature instanceof Feature ? feature.getGeometry() : undefined;
+            const props = feature.getProperties?.() ?? {};
+            if (geom) {
+              geometries.push(geom);
+            }
+            if (Object.keys(props).length > 0) {
+              features.push({ feature: props, floaterOpen: false });
+            }
+            return true;
+          },
+          { layerFilter: layer => layer === olLayer },
+        );
+
+        this._model.syncIdentifiedFeatures(
+          features,
+          this._model.getClientId().toString(),
+        );
+
+        if (geometries.length > 0) {
+          for (const geom of geometries) {
+            this._model.highlightFeatureSignal.emit(geom);
+          }
+        }
+        break;
+      }
+
       case 'VectorTileLayer': {
         const geometries: Geometry[] = [];
         const features: IIdentifiedFeatureEntry[] = [];

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -690,17 +690,26 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     selectInteraction.on('select', event => {
       const identifiedFeatures: IIdentifiedFeatureEntry[] = [];
+      const geometries: Geometry[] = [];
+
       selectInteraction.getFeatures().forEach(feature => {
         identifiedFeatures.push({
           feature: feature.getProperties(),
           floaterOpen: false,
         });
+        const geom = feature.getGeometry();
+        if (geom) {
+          geometries.push(geom);
+        }
       });
 
       this._model.syncIdentifiedFeatures(
         identifiedFeatures,
         this._mainViewModel.id,
       );
+
+      // Sync _highlightLayer with the current selection (clears on deselect).
+      this._setHighlightGeometries(geometries);
     });
 
     this._Map.addInteraction(selectInteraction);
@@ -2017,62 +2026,80 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       ...(geometry !== featureOrGeometry ? featureOrGeometry : {}),
     });
 
-    if (!this._highlightLayer) {
-      this._highlightLayer = new VectorLayer({
-        source: new VectorSource(),
-        style: feature => {
-          const geomType = feature.getGeometry()?.getType();
-          switch (geomType) {
-            case 'Point':
-            case 'MultiPoint':
-              return new Style({
-                image: new Circle({
-                  radius: 6,
-                  fill: new Fill({
-                    color: 'rgba(255, 255, 0, 0.8)',
-                  }),
-                  stroke: new Stroke({
-                    color: '#ff0',
-                    width: 2,
-                  }),
-                }),
-              });
-            case 'LineString':
-            case 'MultiLineString':
-              return new Style({
-                stroke: new Stroke({
-                  color: 'rgba(255, 255, 0, 0.8)',
-                  width: 3,
-                }),
-              });
-            case 'Polygon':
-            case 'MultiPolygon':
-              return new Style({
-                stroke: new Stroke({
-                  color: '#f00',
-                  width: 2,
-                }),
-                fill: new Fill({
-                  color: 'rgba(255, 255, 0, 0.8)',
-                }),
-              });
-            default:
-              return new Style({
-                stroke: new Stroke({
-                  color: '#000',
-                  width: 2,
-                }),
-              });
-          }
-        },
-        zIndex: 999,
-      });
-      this._Map.addLayer(this._highlightLayer);
-    }
-
+    this._ensureHighlightLayer();
     const source = this._highlightLayer.getSource();
     source?.clear();
     source?.addFeature(olFeature);
+  }
+
+  private _ensureHighlightLayer(): void {
+    if (this._highlightLayer) {
+      return;
+    }
+    this._highlightLayer = new VectorLayer({
+      source: new VectorSource(),
+      style: feature => {
+        const geomType = feature.getGeometry()?.getType();
+        switch (geomType) {
+          case 'Point':
+          case 'MultiPoint':
+            return new Style({
+              image: new Circle({
+                radius: 6,
+                fill: new Fill({
+                  color: 'rgba(255, 255, 0, 0.8)',
+                }),
+                stroke: new Stroke({
+                  color: '#ff0',
+                  width: 2,
+                }),
+              }),
+            });
+          case 'LineString':
+          case 'MultiLineString':
+            return new Style({
+              stroke: new Stroke({
+                color: 'rgba(255, 255, 0, 0.8)',
+                width: 3,
+              }),
+            });
+          case 'Polygon':
+          case 'MultiPolygon':
+            return new Style({
+              stroke: new Stroke({
+                color: '#f00',
+                width: 2,
+              }),
+              fill: new Fill({
+                color: 'rgba(255, 255, 0, 0.8)',
+              }),
+            });
+          default:
+            return new Style({
+              stroke: new Stroke({
+                color: '#000',
+                width: 2,
+              }),
+            });
+        }
+      },
+      zIndex: 999,
+    });
+    this._Map.addLayer(this._highlightLayer);
+  }
+
+  /**
+   * Replace the highlight layer contents with the given geometries.
+   * Clears the source first so that stale highlights are always removed,
+   * including when the selection becomes empty (geometries = []).
+   */
+  private _setHighlightGeometries(geometries: Geometry[]): void {
+    this._ensureHighlightLayer();
+    const source = this._highlightLayer.getSource();
+    source?.clear();
+    for (const geom of geometries) {
+      source?.addFeature(new Feature({ geometry: geom }));
+    }
   }
 
   /**
@@ -3318,40 +3345,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const jgisLayer = this._model.getLayer(layerId);
 
     switch (jgisLayer?.type) {
-      case 'VectorLayer': {
-        const olLayer = this.getLayer(layerId);
-        const geometries: Geometry[] = [];
-        const features: IIdentifiedFeatureEntry[] = [];
-
-        this._Map.forEachFeatureAtPixel(
-          e.pixel,
-          (feature: FeatureLike) => {
-            const geom =
-              feature instanceof Feature ? feature.getGeometry() : undefined;
-            const props = feature.getProperties?.() ?? {};
-            if (geom) {
-              geometries.push(geom);
-            }
-            if (Object.keys(props).length > 0) {
-              features.push({ feature: props, floaterOpen: false });
-            }
-            return true;
-          },
-          { layerFilter: layer => layer === olLayer },
-        );
-
-        this._model.syncIdentifiedFeatures(
-          features,
-          this._model.getClientId().toString(),
-        );
-
-        if (geometries.length > 0) {
-          for (const geom of geometries) {
-            this._model.highlightFeatureSignal.emit(geom);
-          }
-        }
+      case 'VectorLayer':
+        // Feature selection, property sync, and highlight for VectorLayer are
+        // handled entirely by the selectInteraction (createSelectInteraction).
         break;
-      }
 
       case 'VectorTileLayer': {
         const geometries: Geometry[] = [];

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -676,27 +676,35 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           return false;
         }
         const selectedLayerId = Object.keys(selectedLayers)[0];
-        if (layer !== this.getLayer(selectedLayerId)) {
-          return false;
-        }
-        // Select moves matched features to its internal overlay with style:[],
-        // removing them from the original layer's rendering. VectorLayer features
-        // are handled in _identifyFeature via forEachFeatureAtPixel instead so
-        // their original style is preserved.
-        const jgisLayer = this._model.getLayer(selectedLayerId);
-        return jgisLayer?.type !== 'VectorLayer';
+
+        return layer === this.getLayer(selectedLayerId);
       },
       condition: (event: MapBrowserEvent<any>) => {
         return singleClick(event) && this._model.currentMode === 'identifying';
       },
-      // Return an empty style — visual feedback for VectorTileLayer comes from
-      // _highlightLayer.  VectorLayer is excluded from this interaction entirely.
-      style: () => [],
+      // Use the layer's own style so selected features keep their original
+      // appearance.  Visual highlight feedback comes from _highlightLayer.
+      style: null,
     });
 
     selectInteraction.on('select', event => {
       const identifiedFeatures: IIdentifiedFeatureEntry[] = [];
-      const geometries: Geometry[] = [];
+      const highlightFeatures: Feature[] = [];
+
+      // Look up the selected layer's style function for adaptive highlights.
+      const localState = this._model?.sharedModel.awareness.getLocalState();
+      const selectedLayers = localState?.selected?.value;
+      const selectedLayerId = selectedLayers
+        ? Object.keys(selectedLayers)[0]
+        : undefined;
+      const mapLayer = selectedLayerId
+        ? this.getLayer(selectedLayerId)
+        : undefined;
+      const styleFn =
+        mapLayer && 'getStyleFunction' in mapLayer
+          ? (mapLayer as VectorLayer).getStyleFunction()
+          : undefined;
+      const resolution = this._Map.getView().getResolution() ?? 1;
 
       selectInteraction.getFeatures().forEach(feature => {
         identifiedFeatures.push({
@@ -705,7 +713,17 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         });
         const geom = feature.getGeometry();
         if (geom) {
-          geometries.push(geom);
+          const hlFeature = new Feature({ geometry: geom });
+          if (styleFn) {
+            const resolved = styleFn(feature, resolution);
+            const styles = Array.isArray(resolved)
+              ? resolved
+              : resolved
+                ? [resolved]
+                : [];
+            hlFeature.setStyle(styles.map(s => this._buildHighlightStyle(s)));
+          }
+          highlightFeatures.push(hlFeature);
         }
       });
 
@@ -715,7 +733,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       );
 
       // Sync _highlightLayer with the current selection (clears on deselect).
-      this._setHighlightGeometries(geometries);
+      this._setHighlightFeatures(highlightFeatures);
     });
 
     this._Map.addInteraction(selectInteraction);
@@ -2131,8 +2149,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     if (image instanceof CircleStyle) {
       return new Style({
         image: new Circle({
-          radius: image.getRadius(),
-          fill: new Fill({ color: 'rgba(255, 255, 0, 0.3)' }),
+          radius: image.getRadius() + 4,
+          fill: new Fill({ color: 'transparent' }),
           stroke: new Stroke({ color: '#ff0', width: 3 }),
         }),
       });
@@ -3402,48 +3420,9 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const jgisLayer = this._model.getLayer(layerId);
 
     switch (jgisLayer?.type) {
-      case 'VectorLayer': {
-        const highlightFeatures: Feature[] = [];
-        const identified: IIdentifiedFeatureEntry[] = [];
-        const mapLayer = this.getLayer(layerId) as VectorLayer | undefined;
-        const styleFn = mapLayer?.getStyleFunction();
-        const resolution = this._Map.getView().getResolution() ?? 1;
-
-        this._Map.forEachFeatureAtPixel(
-          e.pixel,
-          (feature: FeatureLike) => {
-            if (feature instanceof RenderFeature) {
-              return true;
-            }
-            const geom = feature.getGeometry();
-            if (geom) {
-              const hlFeature = new Feature({ geometry: geom });
-              if (styleFn) {
-                const resolved = styleFn(feature, resolution);
-                const styles = Array.isArray(resolved)
-                  ? resolved
-                  : resolved
-                    ? [resolved]
-                    : [];
-                hlFeature.setStyle(
-                  styles.map(s => this._buildHighlightStyle(s)),
-                );
-              }
-              highlightFeatures.push(hlFeature);
-            }
-            identified.push({
-              feature: feature.getProperties(),
-              floaterOpen: false,
-            });
-            return true;
-          },
-          { layerFilter: l => l === this.getLayer(layerId) },
-        );
-
-        this._model.syncIdentifiedFeatures(identified, this._mainViewModel.id);
-        this._setHighlightFeatures(highlightFeatures);
+      case 'VectorLayer':
+        // Handled by selectInteraction (createSelectInteraction).
         break;
-      }
 
       case 'VectorTileLayer': {
         const geometries: Geometry[] = [];


### PR DESCRIPTION
## Summary

The select interaction applied a fixed-radius-5 red circle style on top of the layer's flat-style expression when a point was clicked in identify mode. For Grammar layers where the circle radius is larger, this made the selected point appear to shrink. When another point was selected, the first was deselected and its original style restored — giving the impression of it "expanding again".

- Add `VectorLayer` case to `_identifyFeature` using `forEachFeatureAtPixel` + `highlightFeatureSignal`, consistent with how `VectorTileLayer` identify already works
- Set `selectInteraction` style to `() => []` so it does not visually override the layer's own style; visual feedback is provided by `_highlightLayer` (zIndex 999)

Part of #1421
fixes #1424 

## Test plan

- [ ] Click a point feature on a Grammar vector layer in identify mode — circle should not shrink
- [ ] Yellow highlight circle appears on the selected point
- [ ] Clicking another point: previous point restores correctly, new point highlights
- [ ] Clicking empty space: highlight clears
- [ ] Non-Grammar VectorLayer identify still works

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1425.org.readthedocs.build/en/1425/
💡 JupyterLite preview: https://jupytergis--1425.org.readthedocs.build/en/1425/lite
💡 Specta preview: https://jupytergis--1425.org.readthedocs.build/en/1425/lite/specta

<!-- readthedocs-preview jupytergis end -->