### PR TITLE
fix: marker tool no longer auto-zooms to maximum zoom level

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2208,23 +2208,24 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._model.updateLayerViewState(layerId, view);
 
       if (shouldZoom) {
-        // Don't auto-zoom for marker layers: they are placed at the user's
-        // current view position, and fitting to a single point would zoom
-        // in to the maximum zoom level (#1422).
+
         const jgisLayer = this._model.getLayer(layerId);
         const sourceId = jgisLayer?.parameters?.source as string | undefined;
         const jgisSource = sourceId
           ? this._model.getSource(sourceId)
           : undefined;
         const isMarker = jgisSource?.type === 'MarkerSource';
+        if (isMarker) {
+          // Don't auto-zoom for marker layers: they are placed at the user's
+          // current view position, and fitting to a single point would zoom
+          // in to the maximum zoom level (#1422).
+          return
+        }
+        const creatorId = this._getLayerCreatorId(layerId);
+        const currentClientId = this._model.getClientId();
 
-        if (!isMarker) {
-          const creatorId = this._getLayerCreatorId(layerId);
-          const currentClientId = this._model.getClientId();
-
-          if (creatorId === currentClientId) {
-            this._model.centerOnPosition(layerId);
-          }
+        if (creatorId === currentClientId) {
+          this._model.centerOnPosition(layerId);
         }
       }
     }

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2208,7 +2208,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._model.updateLayerViewState(layerId, view);
 
       if (shouldZoom) {
-
         const jgisLayer = this._model.getLayer(layerId);
         const sourceId = jgisLayer?.parameters?.source as string | undefined;
         const jgisSource = sourceId
@@ -2219,7 +2218,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           // Don't auto-zoom for marker layers: they are placed at the user's
           // current view position, and fitting to a single point would zoom
           // in to the maximum zoom level (#1422).
-          return
+          return;
         }
         const creatorId = this._getLayerCreatorId(layerId);
         const currentClientId = this._model.getClientId();

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2208,11 +2208,23 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._model.updateLayerViewState(layerId, view);
 
       if (shouldZoom) {
-        const creatorId = this._getLayerCreatorId(layerId);
-        const currentClientId = this._model.getClientId();
+        // Don't auto-zoom for marker layers: they are placed at the user's
+        // current view position, and fitting to a single point would zoom
+        // in to the maximum zoom level (#1422).
+        const jgisLayer = this._model.getLayer(layerId);
+        const sourceId = jgisLayer?.parameters?.source as string | undefined;
+        const jgisSource = sourceId
+          ? this._model.getSource(sourceId)
+          : undefined;
+        const isMarker = jgisSource?.type === 'MarkerSource';
 
-        if (creatorId === currentClientId) {
-          this._model.centerOnPosition(layerId);
+        if (!isMarker) {
+          const creatorId = this._getLayerCreatorId(layerId);
+          const currentClientId = this._model.getClientId();
+
+          if (creatorId === currentClientId) {
+            this._model.centerOnPosition(layerId);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

When placing a marker, the map was fitting the view to a single-point extent which zoomed in fully — bad UX since the marker was placed at the user's current view position.

Skip `centerOnPosition` for `MarkerSource`-backed layers in `_trackLayerViewState`.

Closes #1422

## Test plan

- [x] Place a marker — map stays at the current zoom level
- [x] Adding other layer types (GeoJSON, WMS, etc.) still auto-zooms to their extent as before

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1426.org.readthedocs.build/en/1426/
💡 JupyterLite preview: https://jupytergis--1426.org.readthedocs.build/en/1426/lite
💡 Specta preview: https://jupytergis--1426.org.readthedocs.build/en/1426/lite/specta

<!-- readthedocs-preview jupytergis end -->