### PR TITLE
fix: categorical color maps now cycle correctly through D3 palettes

### DIFF
--- a/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
+++ b/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
@@ -18,7 +18,10 @@ jest.mock('@/src/tools', () => ({ objectEntries: Object.entries }));
 
 import { IGrammarSymbologyState } from '@jupytergis/schema';
 
-import { grammarToOLStyle } from '../grammarToOLStyle';
+import {
+  extractEncodingFieldValues,
+  grammarToOLStyle,
+} from '../grammarToOLStyle';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -659,5 +662,106 @@ describe('grammarToOLStyle — OL runtime evaluation', () => {
       0, 0, 255, 1,
     ]);
     expect(evaluate(expr, ColorType, { type: 'other' })).toEqual([0, 0, 0, 0]);
+  });
+
+  it('cycled categorical expression routes 11th value to same color as 1st', () => {
+    // schemeCategory10 has 10 colors; with 12 unique values the 11th and 12th
+    // must cycle back to palette[0] and palette[1].  This test would fail
+    // before the hex-color fix in generateColors (geojupyter/jupytergis#1415)
+    // because all colors were parsed as DEFAULT_COLOR, making all 12 equal.
+    const style = grammarToOLStyle(
+      makeState({
+        id: '1',
+        fields: ['cat'],
+        mappings: [
+          {
+            scale: {
+              scheme: 'categorical',
+              params: {
+                colorRamp: 'schemeCategory10',
+                fallback: [0, 0, 0, 0] as [number, number, number, number],
+              },
+            },
+            channels: ['fill-color'],
+          },
+        ],
+      }),
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'],
+    ) as any;
+
+    const color_a = evaluate(style['fill-color'], ColorType, { cat: 'a' });
+    const color_b = evaluate(style['fill-color'], ColorType, { cat: 'b' });
+    const color_k = evaluate(style['fill-color'], ColorType, { cat: 'k' });
+    const color_l = evaluate(style['fill-color'], ColorType, { cat: 'l' });
+
+    // 11th value ('k') cycles back to palette[0] → same color as 'a'
+    expect(color_k).toEqual(color_a);
+    // 12th value ('l') cycles back to palette[1] → same color as 'b'
+    expect(color_l).toEqual(color_b);
+    // First two palette colors must be distinct (palette is not degenerate)
+    expect(color_a).not.toEqual(color_b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractEncodingFieldValues (#1415)
+// ---------------------------------------------------------------------------
+
+describe('extractEncodingFieldValues', () => {
+  const rows = [
+    { type: 'road', lanes: 2, length: 100 },
+    { type: 'river', lanes: 0, length: 500 },
+    { type: 'lake', lanes: 0, length: 200 },
+  ];
+
+  const stateWithField = makeState({
+    id: '1',
+    fields: ['type'],
+    mappings: [
+      {
+        scale: {
+          scheme: 'categorical',
+          params: { colorRamp: 'schemeCategory10', fallback: [0, 0, 0, 0] },
+        },
+        channels: ['fill-color'],
+      },
+    ],
+  });
+
+  it('returns only the values for the encoding field', () => {
+    expect(extractEncodingFieldValues(stateWithField, rows)).toEqual([
+      'road',
+      'river',
+      'lake',
+    ]);
+  });
+
+  it('categorical scale with field-specific values produces the correct branch count', () => {
+    const values = extractEncodingFieldValues(stateWithField, rows);
+    const style = grammarToOLStyle(stateWithField, values) as any;
+    // ['case', c1,v1, c2,v2, c3,v3, fallback] — 3 branches, not 8
+    expect(style['fill-color'].length).toBe(1 + 2 * 3 + 1);
+  });
+
+  it('returns empty array when no named field is in the state', () => {
+    const fieldlessState = makeState({
+      id: '1',
+      mappings: [
+        {
+          scale: {
+            scheme: 'colorRamp',
+            params: {
+              name: 'viridis',
+              nShades: 3,
+              mode: 'equal interval',
+              reverse: false,
+              fallback: [0, 0, 0, 0],
+            },
+          },
+          channels: ['fill-color'],
+        },
+      ],
+    });
+    expect(extractEncodingFieldValues(fieldlessState, rows)).toEqual([]);
   });
 });

--- a/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
+++ b/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
@@ -703,10 +703,6 @@ describe('grammarToOLStyle — OL runtime evaluation', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// extractEncodingFieldValues (#1415)
-// ---------------------------------------------------------------------------
-
 describe('extractEncodingFieldValues', () => {
   const rows = [
     { type: 'road', lanes: 2, length: 100 },

--- a/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
@@ -157,6 +157,42 @@ export function grammarToOLStyle(
 }
 
 // ---------------------------------------------------------------------------
+// Feature-value extraction helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the encoding field column from feature property rows.
+ * colorRamp and categorical scales take a single input field; this returns
+ * all values for that field so the compiler can compute classification breaks.
+ */
+export function extractEncodingFieldValues(
+  state: IGrammarSymbologyState,
+  rows: Record<string, unknown>[],
+): unknown[] {
+  let field: string | undefined;
+  for (const gl of state.layers ?? []) {
+    for (const rule of gl.rules ?? []) {
+      const f = rule.fields?.[0];
+      if (f && !f.startsWith('$')) {
+        field = f;
+        break;
+      }
+    }
+    if (field) {
+      break;
+    }
+  }
+
+  if (!field) {
+    console.debug(
+      'extractEncodingFieldValues: no encoding field found in Grammar state',
+    );
+    return [];
+  }
+  return rows.map(r => r[field]).filter(v => v !== null && v !== undefined);
+}
+
+// ---------------------------------------------------------------------------
 // Channel expression builder
 // ---------------------------------------------------------------------------
 

--- a/packages/base/src/features/layers/symbology/styleBuilder.ts
+++ b/packages/base/src/features/layers/symbology/styleBuilder.ts
@@ -4,7 +4,7 @@ import { FlatStyle } from 'ol/style/flat';
 
 import { VectorClassifications } from './classificationModes';
 import {
-  DEFAULT_COLOR,
+  colorToRgba,
   DEFAULT_STROKE_WIDTH,
   getColorMapList,
   IColorMap,
@@ -189,24 +189,12 @@ function generateColors(
     } else {
       rawColors = rawColors.slice(0, nClasses);
     }
-    // Parse categorical colors (they're CSS strings like "rgb(...)") to RGBA.
-    colorMap = rawColors.map(c => {
-      if (typeof c === 'string') {
-        const match = c.match(
-          /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/,
-        );
-        if (match) {
-          return [
-            +match[1],
-            +match[2],
-            +match[3],
-            match[4] !== undefined ? +match[4] : 1,
-          ] as RgbaColor;
-        }
-        return DEFAULT_COLOR;
-      }
-      return c as RgbaColor;
-    });
+    // Parse categorical colors to RGBA.  D3 categorical schemes produce hex
+    // strings (#rrggbb); continuous colormaps produce rgb() strings.
+    // colorToRgba handles both formats.
+    colorMap = rawColors.map(c =>
+      typeof c === 'string' ? colorToRgba(c) : (c as RgbaColor),
+    );
   } else {
     const nShades = Math.max(nClasses, 9);
     colorMap = colormap({

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -153,7 +153,10 @@ import {
 } from './geoJsonFeaturePatch';
 import { MainViewModel } from './mainviewmodel';
 import { grammarToOLLayer } from '../features/layers/symbology/grammarToOLLayer';
-import { grammarToOLStyle } from '../features/layers/symbology/grammarToOLStyle';
+import {
+  extractEncodingFieldValues,
+  grammarToOLStyle,
+} from '../features/layers/symbology/grammarToOLStyle';
 import { DEFAULT_FLAT_STYLE } from '../features/layers/symbology/styleBuilder';
 import { SpectaPanel } from '../features/story/SpectaPanel';
 import type { IStoryViewerPanelHandle } from '../features/story/StoryViewerPanel';
@@ -1495,12 +1498,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           const olSource = this._sources[
             layerParameters.source
           ] as VectorSource;
-          const featureValues =
+          const grammarState =
+            layerParameters.symbologyState as IGrammarSymbologyState;
+          const rows =
             olSource instanceof VectorSource
-              ? olSource
-                  .getFeatures()
-                  .flatMap(f => Object.values((f as Feature).getProperties()))
+              ? olSource.getFeatures().map(f => (f as Feature).getProperties())
               : [];
+          const featureValues = extractEncodingFieldValues(grammarState, rows);
           newMapLayer = grammarToOLLayer(
             layerParameters.symbologyState as IGrammarSymbologyState,
             olSource,


### PR DESCRIPTION
## Summary

D3 categorical schemes (`schemeCategory10` etc.) produce hex strings (`#rrggbb`) which the old `rgb()` regex in `generateColors` could not parse — every category fell back to `DEFAULT_COLOR`, making all points the same color.

- Replace the inline `rgb()` parser with `colorToRgba()` which handles both hex and `rgb()` formats
- Add `extractEncodingFieldValues()` helper to extract the encoding field column from feature property rows, so `grammarToOLStyle` receives only the relevant field values rather than a flat mix of all properties
- Use the helper in `mainView` when building Grammar VectorLayers

Closes #1415

## Test plan

- [ ] `jlpm run test` passes
- [ ] New test `cycled categorical expression routes 11th value to same color as 1st` fails without the fix and passes with it
- [ ] `extractEncodingFieldValues` tests verify correct column extraction
- [ ] Categorical layer on a GeoJSON source shows distinct colors per category

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1427.org.readthedocs.build/en/1427/
💡 JupyterLite preview: https://jupytergis--1427.org.readthedocs.build/en/1427/lite
💡 Specta preview: https://jupytergis--1427.org.readthedocs.build/en/1427/lite/specta

<!-- readthedocs-preview jupytergis end -->