### PR TITLE
fix: symbology panel takes full width and stacks fields on mobile

### DIFF
--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -227,9 +227,7 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
       </div>
       <div className="jp-gis-symbology-row">
         <label>Domain</label>
-        <div
-          style={{ display: 'flex', gap: 4, flex: '1 0 50%', maxWidth: '50%' }}
-        >
+        <div className="jp-gis-domain-inputs">
           <NumericInput
             className="jp-mod-styled"
             placeholder="min"
@@ -438,9 +436,7 @@ export const ScalarEditor: React.FC<IScalarEditorProps> = ({
     <div className="jp-gis-color-ramp-container">
       <div className="jp-gis-symbology-row">
         <label>Input range</label>
-        <div
-          style={{ display: 'flex', gap: 4, flex: '1 0 50%', maxWidth: '50%' }}
-        >
+        <div className="jp-gis-domain-inputs">
           <NumericInput
             className="jp-mod-styled"
             placeholder="min"
@@ -457,9 +453,7 @@ export const ScalarEditor: React.FC<IScalarEditorProps> = ({
       </div>
       <div className="jp-gis-symbology-row">
         <label>Output range</label>
-        <div
-          style={{ display: 'flex', gap: 4, flex: '1 0 50%', maxWidth: '50%' }}
-        >
+        <div className="jp-gis-domain-inputs">
           <NumericInput
             className="jp-mod-styled"
             placeholder="min"

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -14,6 +14,18 @@ select option {
   max-height: 80%;
 }
 
+@media (max-width: 768px) {
+  .jp-gis-symbology-dialog .jp-Dialog-content {
+    width: 100%;
+    max-width: 100%;
+    max-height: 90%;
+    margin: 0;
+    border-radius: 0;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+}
+
 .jp-gis-symbology-row {
   display: flex;
   justify-content: space-between;
@@ -325,6 +337,12 @@ select option {
   padding: 4px 6px;
 }
 
+@media (max-width: 768px) {
+  .jp-gis-grammar-rule-grid {
+    grid-template-columns: 1fr 1fr auto;
+  }
+}
+
 .jp-gis-grammar-rule-editor {
   border-top: 1px solid var(--jp-border-color2);
   padding: 8px;
@@ -494,6 +512,30 @@ select option {
 .jp-gis-grammar-when-ok:disabled {
   opacity: 0.4;
   cursor: default;
+}
+
+/* Domain min/max pair inside a symbology row */
+.jp-gis-domain-inputs {
+  display: flex;
+  gap: 4px;
+  flex: 1 0 50%;
+  max-width: 50%;
+}
+
+@media (max-width: 768px) {
+  .jp-gis-symbology-row {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .jp-gis-symbology-row > .jp-select-wrapper,
+  .jp-gis-symbology-row > .jp-mod-styled,
+  .jp-gis-symbology-row > .jp-gis-rgba-picker,
+  .jp-gis-canvas-button-wrapper,
+  .jp-gis-domain-inputs {
+    flex: 1 0 100%;
+    max-width: 100%;
+  }
 }
 
 .jp-gis-transparent-label {


### PR DESCRIPTION
## Summary

The symbology panel was too narrow on mobile: the dialog used a fixed 80% width, the 6-column grammar rule grid had hardcoded pixel widths, and domain min/max input pairs had inline `maxWidth: 50%` constraints that made them inaccessible on small screens.

- Dialog takes full width with reduced side padding (8px) on viewports ≤ 768px, matching the breakpoint used elsewhere in the codebase
- Grammar rule grid collapses from 6 fixed-pixel columns to a 3-column responsive layout on mobile
- Domain min/max input pairs and other symbology row controls stack vertically on mobile via a new `jp-gis-domain-inputs` CSS class (replacing three identical inline styles in `ScaleEditor`) and a media query on `jp-gis-symbology-row`

Closes #1411

## Test plan

- [ ] Open symbology panel on a mobile viewport (≤ 768px) — panel takes full width
- [ ] Domain min/max fields are visible and usable
- [ ] Grammar rule grid is readable on narrow screens
- [ ] Desktop layout unchanged

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1428.org.readthedocs.build/en/1428/
💡 JupyterLite preview: https://jupytergis--1428.org.readthedocs.build/en/1428/lite
💡 Specta preview: https://jupytergis--1428.org.readthedocs.build/en/1428/lite/specta

<!-- readthedocs-preview jupytergis end -->