### PR TITLE
fix: layer gallery takes full width and uses 2-column grid on mobile

### DIFF
--- a/packages/base/style/layerBrowser.css
+++ b/packages/base/style/layerBrowser.css
@@ -9,6 +9,16 @@
   max-height: 100%;
 }
 
+@media (max-width: 768px) {
+  .jGIS-layerbrowser-FormDialog .jp-Dialog-content {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    border-radius: 0;
+    padding: 0;
+  }
+}
+
 .jGIS-layerbrowser-FormDialog form {
   padding: 10px;
 }
@@ -84,6 +94,24 @@
 @media (min-width: 1400px) {
   .jGIS-layer-browser-grid {
     grid-template-columns: repeat(5, minmax(0px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .jGIS-layer-browser-grid {
+    grid-template-columns: repeat(2, minmax(0px, 1fr));
+    padding: 0.5rem;
+    gap: 0.5rem;
+  }
+
+  .jGIS-layer-browser-header {
+    padding: 0.5rem;
+    gap: 8px;
+  }
+
+  .jGIS-layer-browser-categories {
+    padding: 0 0.5rem;
+    gap: 1rem;
   }
 }
 


### PR DESCRIPTION
## Summary

The layer gallery dialog was too narrow on mobile: the `calc(100% - 4rem)` width left unused margins, and the 3-column grid with 2rem padding made tiles too small to interact with.

- Dialog takes full width with no margin on viewports ≤ 768px (matching the breakpoint used elsewhere)
- Grid switches from 3 columns to 2 columns on mobile for more usable tile sizes
- Header, category tabs and grid padding reduced on mobile

Closes #1412

## Test plan

- [ ] Open layer gallery on a mobile viewport (≤ 768px) — dialog takes full width
- [ ] Tiles display in 2 columns and are easily tappable
- [ ] Search and category tabs remain usable
- [ ] Desktop layout (3 columns, 5 columns at 1400px+) unchanged

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1429.org.readthedocs.build/en/1429/
💡 JupyterLite preview: https://jupytergis--1429.org.readthedocs.build/en/1429/lite
💡 Specta preview: https://jupytergis--1429.org.readthedocs.build/en/1429/lite/specta

<!-- readthedocs-preview jupytergis end -->