### PR TITLE
fix: mobile bottom sheet collapses to pill-only minimum

### DIFF
--- a/packages/base/src/workspace/panels/mergedpanel.tsx
+++ b/packages/base/src/workspace/panels/mergedpanel.tsx
@@ -53,7 +53,7 @@ export const MergedPanel: React.FC<IMergedPanelProps> = props => {
 
     const applyResize = (clientY: number) => {
       const clamped = Math.max(
-        60,
+        24,
         Math.min(startHeight + (startY - clientY), window.innerHeight * 0.9),
       );
       panelHeightRef.current = clamped;
@@ -254,7 +254,11 @@ export const MergedPanel: React.FC<IMergedPanelProps> = props => {
         ...(panelHeight !== null ? { height: `${panelHeight}px` } : {}),
       }}
     >
-      <div className="jgis-resize-handle" />
+      <div
+        className="jgis-resize-handle"
+        onMouseDown={onTabListMouseDown}
+        onTouchStart={onTabListTouchStart}
+      />
       <TabbedPanel
         tabs={tabs}
         curTab={effectiveCurTab}

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -135,7 +135,7 @@ button.jp-mod-styled.jp-mod-reject {
 @media (max-width: 768px) {
   .jgis-merged-panel-container {
     position: fixed;
-    bottom: 0;
+    bottom: var(--jp-statusbar-height, 0px);
     left: 0;
     right: 0;
     z-index: 1000;
@@ -146,14 +146,14 @@ button.jp-mod-styled.jp-mod-reject {
     height: 30vh;
   }
 
-  /* Drag-to-resize handle — visual pill only */
+  /* Drag-to-resize handle */
   .jgis-resize-handle {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 14px;
+    height: 24px;
     flex-shrink: 0;
-    pointer-events: none;
+    cursor: ns-resize;
   }
 
   .jgis-resize-handle::before {
@@ -162,6 +162,7 @@ button.jp-mod-styled.jp-mod-reject {
     height: 4px;
     border-radius: 2px;
     background-color: var(--jp-border-color1);
+    opacity: 0.5;
   }
 
   /* Panel tabs fill the remaining height */


### PR DESCRIPTION
## Summary

- Panel can now be dragged all the way down until only the semi-transparent resize pill is visible (24px minimum height)
- Resize handle is now a direct drag target (was `pointer-events: none` before), so it remains grabbable even at minimum height
- Panel is offset by `--jp-statusbar-height` so the pill stays visible above the status bar
- Pill is semi-transparent (`opacity: 0.5`) for a cleaner look

Fixes #1433

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1436.org.readthedocs.build/en/1436/
💡 JupyterLite preview: https://jupytergis--1436.org.readthedocs.build/en/1436/lite
💡 Specta preview: https://jupytergis--1436.org.readthedocs.build/en/1436/lite/specta

<!-- readthedocs-preview jupytergis end -->