### PR TITLE
refactor: extract identify highlight utilities from mainView

### DIFF
--- a/packages/base/src/features/identify/utils/highlightLayer.ts
+++ b/packages/base/src/features/identify/utils/highlightLayer.ts
@@ -1,0 +1,67 @@
+import { Map as OlMap } from 'ol';
+import Feature from 'ol/Feature';
+import { VectorImage as VectorImageLayer } from 'ol/layer';
+import { Vector as VectorSource } from 'ol/source';
+import { Circle, Fill, Stroke, Style } from 'ol/style';
+
+/**
+ * Style function used by the highlight overlay layer.
+ * Returns a fixed highlight style based on geometry type.
+ */
+function highlightStyleFunction(feature: Feature): Style {
+  const geomType = feature.getGeometry()?.getType();
+  switch (geomType) {
+    case 'Point':
+    case 'MultiPoint':
+      return new Style({
+        image: new Circle({
+          radius: 8,
+          fill: new Fill({ color: 'transparent' }),
+          stroke: new Stroke({ color: '#ff0', width: 3 }),
+        }),
+      });
+    case 'LineString':
+    case 'MultiLineString':
+      return new Style({
+        stroke: new Stroke({ color: 'rgba(255, 255, 0, 0.8)', width: 3 }),
+      });
+    case 'Polygon':
+    case 'MultiPolygon':
+      return new Style({
+        stroke: new Stroke({ color: '#ff0', width: 2 }),
+        fill: new Fill({ color: 'rgba(255, 255, 0, 0.15)' }),
+      });
+    default:
+      return new Style({
+        stroke: new Stroke({ color: '#ff0', width: 2 }),
+      });
+  }
+}
+
+/**
+ * Ensure the highlight layer exists and is attached to the map.
+ * Creates it on first call; re-adds it if the map removed it
+ * (e.g. during a layer sync that strips non-model layers).
+ */
+export function ensureHighlightLayer(
+  map: OlMap,
+  layerRef: { current: VectorImageLayer<VectorSource> | null },
+): VectorImageLayer<VectorSource> {
+  if (
+    layerRef.current &&
+    map.getLayers().getArray().includes(layerRef.current)
+  ) {
+    return layerRef.current;
+  }
+
+  if (!layerRef.current) {
+    layerRef.current = new VectorImageLayer({
+      source: new VectorSource(),
+      style: highlightStyleFunction as any,
+      zIndex: 999,
+    });
+  }
+
+  map.addLayer(layerRef.current);
+  return layerRef.current;
+}

--- a/packages/base/src/features/identify/utils/highlightStyle.ts
+++ b/packages/base/src/features/identify/utils/highlightStyle.ts
@@ -1,0 +1,46 @@
+import { Circle, Fill, Stroke, Style } from 'ol/style';
+import CircleStyle from 'ol/style/Circle';
+
+/**
+ * Build a highlight style from an original resolved style.
+ * Preserves data-driven properties (circle radius, line width) and swaps in
+ * a constant yellow highlight color.
+ */
+export function buildHighlightStyle(original: Style, geomType?: string): Style {
+  // Only use the circle branch for point geometries.  The OL default style
+  // includes a circle image alongside fill/stroke; without this guard the
+  // circle branch would fire for polygons and produce an invisible style.
+  const isPoint = geomType === 'Point' || geomType === 'MultiPoint';
+  if (isPoint) {
+    const image = original.getImage();
+    if (image instanceof CircleStyle) {
+      return new Style({
+        image: new Circle({
+          radius: image.getRadius() + 4,
+          fill: new Fill({ color: 'transparent' }),
+          stroke: new Stroke({ color: '#ff0', width: 3 }),
+        }),
+      });
+    }
+  }
+
+  const origStroke = original.getStroke();
+  const origFill = original.getFill();
+
+  if (origStroke || origFill) {
+    return new Style({
+      stroke: new Stroke({
+        color: 'rgba(255, 255, 0, 0.4)',
+        width: (origStroke?.getWidth() ?? 1) + 4,
+      }),
+      ...(origFill
+        ? { fill: new Fill({ color: 'rgba(255, 255, 0, 0.15)' }) }
+        : {}),
+    });
+  }
+
+  // Fallback
+  return new Style({
+    stroke: new Stroke({ color: 'rgba(255, 255, 0, 0.4)', width: 4 }),
+  });
+}

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -117,7 +117,7 @@ import {
 } from 'ol/source';
 import Static from 'ol/source/ImageStatic';
 import { TileSourceEvent } from 'ol/source/Tile';
-import { Circle, Fill, Icon, Stroke, Style } from 'ol/style';
+import { Fill, Icon, Stroke, Style } from 'ol/style';
 import CircleStyle from 'ol/style/Circle';
 import { Rule } from 'ol/style/flat';
 //@ts-expect-error no types for ol-pmtiles
@@ -152,6 +152,7 @@ import {
   type PatchGeoJSONFeatureProperties,
 } from './geoJsonFeaturePatch';
 import { MainViewModel } from './mainviewmodel';
+import { ensureHighlightLayer } from '../features/identify/utils/highlightLayer';
 import { buildHighlightStyle } from '../features/identify/utils/highlightStyle';
 import { grammarToOLLayer } from '../features/layers/symbology/grammarToOLLayer';
 import {
@@ -2082,73 +2083,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     });
 
     this._ensureHighlightLayer();
-    const source = this._highlightLayer.getSource();
+    const source = this._highlightLayerRef.current?.getSource();
     source?.clear();
     source?.addFeature(olFeature);
   }
 
   private _ensureHighlightLayer(): void {
-    // Check that the layer both exists AND is still in the map.
-    // _updateLayersImpl removes layers whose id isn't in the JGIS model,
-    // which includes this layer (it has no JGIS id).
-    if (
-      this._highlightLayer &&
-      this._Map.getLayers().getArray().includes(this._highlightLayer)
-    ) {
-      return;
-    }
-    if (!this._highlightLayer) {
-      this._highlightLayer = new VectorImageLayer({
-        source: new VectorSource(),
-        style: feature => {
-          const geomType = feature.getGeometry()?.getType();
-          switch (geomType) {
-            case 'Point':
-            case 'MultiPoint':
-              return new Style({
-                image: new Circle({
-                  radius: 8,
-                  fill: new Fill({
-                    color: 'transparent',
-                  }),
-                  stroke: new Stroke({
-                    color: '#ff0',
-                    width: 3,
-                  }),
-                }),
-              });
-            case 'LineString':
-            case 'MultiLineString':
-              return new Style({
-                stroke: new Stroke({
-                  color: 'rgba(255, 255, 0, 0.8)',
-                  width: 3,
-                }),
-              });
-            case 'Polygon':
-            case 'MultiPolygon':
-              return new Style({
-                stroke: new Stroke({
-                  color: '#ff0',
-                  width: 2,
-                }),
-                fill: new Fill({
-                  color: 'rgba(255, 255, 0, 0.15)',
-                }),
-              });
-            default:
-              return new Style({
-                stroke: new Stroke({
-                  color: '#ff0',
-                  width: 2,
-                }),
-              });
-          }
-        },
-        zIndex: 999,
-      });
-    }
-    this._Map.addLayer(this._highlightLayer);
+    ensureHighlightLayer(this._Map, this._highlightLayerRef);
   }
 
   /**
@@ -2158,7 +2099,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
    */
   private _setHighlightGeometries(geometries: Geometry[]): void {
     this._ensureHighlightLayer();
-    const source = this._highlightLayer.getSource();
+    const source = this._highlightLayerRef.current?.getSource();
     source?.clear();
     for (const geom of geometries) {
       source?.addFeature(new Feature({ geometry: geom }));
@@ -2171,7 +2112,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
    */
   private _setHighlightFeatures(features: Feature[]): void {
     this._ensureHighlightLayer();
-    const source = this._highlightLayer.getSource();
+    const source = this._highlightLayerRef.current?.getSource();
     source?.clear();
     for (const f of features) {
       source?.addFeature(f);
@@ -2876,8 +2817,11 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   };
 
   private _clearHighlightWhenIdentifyDisabled(): void {
-    if (this._model.currentMode !== 'identifying' && this._highlightLayer) {
-      this._highlightLayer.getSource()?.clear();
+    if (
+      this._model.currentMode !== 'identifying' &&
+      this._highlightLayerRef.current
+    ) {
+      this._highlightLayerRef.current?.getSource()?.clear();
     }
   }
 
@@ -4042,7 +3986,9 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _contextMenu: ContextMenu;
   private _loadingLayers: Set<string>;
   private _originalFeatures: IDict<Feature<Geometry>[]> = {};
-  private _highlightLayer: VectorImageLayer<VectorSource>;
+  private _highlightLayerRef: {
+    current: VectorImageLayer<VectorSource> | null;
+  } = { current: null };
   private _draw: Draw;
   private _snap: Snap;
   private _modify: Modify;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -152,6 +152,7 @@ import {
   type PatchGeoJSONFeatureProperties,
 } from './geoJsonFeaturePatch';
 import { MainViewModel } from './mainviewmodel';
+import { buildHighlightStyle } from '../features/identify/utils/highlightStyle';
 import { grammarToOLLayer } from '../features/layers/symbology/grammarToOLLayer';
 import {
   extractEncodingFieldValues,
@@ -2177,48 +2178,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   }
 
-  /**
-   * Build a highlight style from an original resolved style.
-   * Preserves data-driven properties (circle radius, line width) and swaps in
-   * a constant yellow highlight color.
-   */
   private _buildHighlightStyle(original: Style, geomType?: string): Style {
-    // Only use the circle branch for point geometries.  The OL default style
-    // includes a circle image alongside fill/stroke; without this guard the
-    // circle branch would fire for polygons and produce an invisible style.
-    const isPoint = geomType === 'Point' || geomType === 'MultiPoint';
-    if (isPoint) {
-      const image = original.getImage();
-      if (image instanceof CircleStyle) {
-        return new Style({
-          image: new Circle({
-            radius: image.getRadius() + 4,
-            fill: new Fill({ color: 'transparent' }),
-            stroke: new Stroke({ color: '#ff0', width: 3 }),
-          }),
-        });
-      }
-    }
-
-    const origStroke = original.getStroke();
-    const origFill = original.getFill();
-
-    if (origStroke || origFill) {
-      return new Style({
-        stroke: new Stroke({
-          color: 'rgba(255, 255, 0, 0.4)',
-          width: (origStroke?.getWidth() ?? 1) + 4,
-        }),
-        ...(origFill
-          ? { fill: new Fill({ color: 'rgba(255, 255, 0, 0.15)' }) }
-          : {}),
-      });
-    }
-
-    // Fallback
-    return new Style({
-      stroke: new Stroke({ color: 'rgba(255, 255, 0, 0.4)', width: 4 }),
-    });
+    return buildHighlightStyle(original, geomType);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Extract `buildHighlightStyle` into `features/identify/utils/highlightStyle.ts`
- Extract `ensureHighlightLayer` (with its style function) into `features/identify/utils/highlightLayer.ts`
- Remove unused `Circle` import from mainView

This partially addresses #1438. The remaining identify functions (`_identifyFeature`, `createSelectInteraction`, `highlightFeatureOnMap`) are orchestrators tightly coupled to MainView state and don't benefit from extraction at this point.

## Test plan

- [ ] Verify identify tool still works on vector layers (select interaction highlights)
- [ ] Verify identify tool still works on vector tile layers
- [ ] Verify highlight overlay appears/disappears correctly

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1447.org.readthedocs.build/en/1447/
💡 JupyterLite preview: https://jupytergis--1447.org.readthedocs.build/en/1447/lite
💡 Specta preview: https://jupytergis--1447.org.readthedocs.build/en/1447/lite/specta

<!-- readthedocs-preview jupytergis end -->