### PR TITLE
fix: remove implicit autozoom on layer add

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -1738,12 +1738,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         const numLayers = this._Map.getLayers().getLength();
         const safeIndex = Math.min(index, numLayers);
         this._Map.getLayers().insertAt(safeIndex, newMapLayer);
-        // const newLayerExtent = newMapLayer.getExtent();
-        // const shouldZoom = Boolean(
-        //   this.state.initialLayersReady && newLayerExtent,
-        // );
-        const shouldZoom = Boolean(this.state.initialLayersReady);
-        this._trackLayerViewState(id, newMapLayer, shouldZoom);
+        this._trackLayerViewState(id, newMapLayer);
 
         // doing +1 instead of calling method again
         if (
@@ -2271,25 +2266,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     return zoom ?? view.getZoom() ?? 0;
   }
 
-  private _getLayerCreatorId(layerId: string): number | undefined {
-    const states = this._model.sharedModel.awareness.getStates();
-
-    for (const [clientId, state] of states.entries()) {
-      if (state?.lastAddedLayer?.layerId === layerId) {
-        return clientId;
-      }
-    }
-
-    return undefined;
-  }
-
   /**
    * Track layer's extent and zoom in model's view state
    */
   private _trackLayerViewState(
     layerId: string,
     olLayer: Layer | LayerGroup,
-    shouldZoom = false,
   ): void {
     const effectiveLayer =
       olLayer instanceof LayerGroup
@@ -2316,27 +2298,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
       const view: IViewState[string] = { extent, zoom };
       this._model.updateLayerViewState(layerId, view);
-
-      if (shouldZoom) {
-        const jgisLayer = this._model.getLayer(layerId);
-        const sourceId = jgisLayer?.parameters?.source as string | undefined;
-        const jgisSource = sourceId
-          ? this._model.getSource(sourceId)
-          : undefined;
-        const isMarker = jgisSource?.type === 'MarkerSource';
-        if (isMarker) {
-          // Don't auto-zoom for marker layers: they are placed at the user's
-          // current view position, and fitting to a single point would zoom
-          // in to the maximum zoom level (#1422).
-          return;
-        }
-        const creatorId = this._getLayerCreatorId(layerId);
-        const currentClientId = this._model.getClientId();
-
-        if (creatorId === currentClientId) {
-          this._model.centerOnPosition(layerId);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove the implicit autozoom that fired whenever a layer was added after initial load
- Root cause of flaky UI test screenshots (#1435): schema migration (0.5→0.6) replaces layers, triggering autozoom non-deterministically
- The explicit "zoom to layer" button still works via `centerOnPosition`
- Clean up dead code (`shouldZoom` parameter, `_getLayerCreatorId`)

Fixes #1444, partially addresses #1422.

Follow-up issues for opt-in autozoom:
- #1448 — frontend setting
- #1449 — Python API `zoom_to` parameter

## Test plan

- [ ] Open a v0.5 .jGIS file (e.g. `local.jGIS`) — verify viewport stays at stored position, no autozoom
- [ ] Add a new layer via UI — verify no autozoom
- [ ] Click "zoom to layer" button — verify it still works
- [ ] Add a layer via Python API — verify no autozoom

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1450.org.readthedocs.build/en/1450/
💡 JupyterLite preview: https://jupytergis--1450.org.readthedocs.build/en/1450/lite
💡 Specta preview: https://jupytergis--1450.org.readthedocs.build/en/1450/lite/specta

<!-- readthedocs-preview jupytergis end -->