### PR TITLE
fix: append trailing newline when saving jGIS files

### DIFF
--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -372,7 +372,8 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   toString(): string {
-    return JSON.stringify(this.getContent(), null, 2);
+    // Trailing newline for POSIX compliance (e.g. end-of-file-fixer pre-commit hook)
+    return JSON.stringify(this.getContent(), null, 2) + '\n';
   }
 
   fromString(data: string): void {


### PR DESCRIPTION
## Summary
- Appends `\n` to the `toString()` serialization so `.jGIS` files end with a trailing newline
- Fixes `end-of-file-fixer` pre-commit hook failures on freshly saved files

Closes #1445

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1453.org.readthedocs.build/en/1453/
💡 JupyterLite preview: https://jupytergis--1453.org.readthedocs.build/en/1453/lite
💡 Specta preview: https://jupytergis--1453.org.readthedocs.build/en/1453/lite/specta

<!-- readthedocs-preview jupytergis end -->