### PR TITLE
fix: reduce identify hit tolerance from 5 to 3 pixels

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -666,7 +666,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
   createSelectInteraction = () => {
     const selectInteraction = new Select({
-      hitTolerance: 5,
+      hitTolerance: 3,
       multi: true,
       layers: layer => {
         const localState = this._model?.sharedModel.awareness.getLocalState();


### PR DESCRIPTION
## Summary
- Reduces the `hitTolerance` of the identify `Select` interaction from 5 to 3 pixels
- Mitigates over-selection of adjacent polygon features, especially in browsers where `devicePixelRatio` is spoofed (e.g. LibreWolf with `privacy.resistFingerprinting`), which effectively multiplies the tolerance

Closes #1452

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1454.org.readthedocs.build/en/1454/
💡 JupyterLite preview: https://jupytergis--1454.org.readthedocs.build/en/1454/lite
💡 Specta preview: https://jupytergis--1454.org.readthedocs.build/en/1454/lite/specta

<!-- readthedocs-preview jupytergis end -->