### PR TITLE
fix: pin react-draggable to 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lerna": "^8.1.9",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
-    "react-draggable": "^4.5.0",
+    "react-draggable": "4.5.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.4.9",
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- Pins `react-draggable` to `4.5.0` (removes `^`) to avoid `4.6.0` which has a type definition bug
- In `4.6.0`, `props: DraggableProps` overrides the `Partial<DraggableProps>` generic, making all props required and breaking builds without a lockfile

## Test plan
- [ ] CI build passes without lockfile

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1457.org.readthedocs.build/en/1457/
💡 JupyterLite preview: https://jupytergis--1457.org.readthedocs.build/en/1457/lite
💡 Specta preview: https://jupytergis--1457.org.readthedocs.build/en/1457/lite/specta

<!-- readthedocs-preview jupytergis end -->