### PR TITLE
fix: Update lockfile for react-draggable pin

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,7 +1686,7 @@ __metadata:
     lerna: ^8.1.9
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
-    react-draggable: ^4.5.0
+    react-draggable: 4.5.0
     rimraf: ^3.0.2
     ts-jest: ^29.4.9
     typescript: ^5
@@ -15787,7 +15787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-draggable@npm:^4.4.5, react-draggable@npm:^4.5.0":
+"react-draggable@npm:4.5.0, react-draggable@npm:^4.4.5":
   version: 4.5.0
   resolution: "react-draggable@npm:4.5.0"
   dependencies:


### PR DESCRIPTION
## Description

Followup on #1457 

The lockfile currently doesn't match up with `package.json`. Unbreaks CI ([ref](https://github.com/geojupyter/jupytergis/actions/runs/26764611954/job/78887372302?pr=1347)) and dev setup which rely on `--immutable` installs! They fail with `The lockfile would have been modified by this install, which is explicitly forbidden.`


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1461.org.readthedocs.build/en/1461/
💡 JupyterLite preview: https://jupytergis--1461.org.readthedocs.build/en/1461/lite
💡 Specta preview: https://jupytergis--1461.org.readthedocs.build/en/1461/lite/specta

<!-- readthedocs-preview jupytergis end -->