### PR TITLE
Add mobile view for vertical scroll stories

### DIFF
--- a/packages/base/src/features/story/SpectaPanel.tsx
+++ b/packages/base/src/features/story/SpectaPanel.tsx
@@ -73,15 +73,18 @@ export function SpectaPanel({
   if (isMobile) {
     return (
       <SpectaMobileView
+        model={model}
         segmentContainerRef={segmentContainerRef}
         storyData={storyData}
         currentIndex={currentIndex}
+        setIndex={setIndex}
         activeSlide={activeSlide}
         layerName={layerName}
         handlePrev={handlePrev}
         handleNext={handleNext}
         hasPrev={hasPrev}
         hasNext={hasNext}
+        onSegmentTransitionChange={onSegmentTransitionChange}
       />
     );
   }

--- a/packages/base/src/features/story/__tests__/computeListStoryScrollState.spec.ts
+++ b/packages/base/src/features/story/__tests__/computeListStoryScrollState.spec.ts
@@ -37,16 +37,25 @@ describe('computeListStoryScrollState', () => {
     storyItem('c', 2, 'map'),
   ];
 
-  it('returns first segment when only one segment', () => {
+  it('scrolls a single segment via intra-segment transition', () => {
     const segments = layoutSegments({
       items: [storyItem('only', 0, 'map')],
       viewportHeight: 400,
       mapViewportHeight: 350,
     });
 
+    const only = segments[0];
+    const progress = 50 / (only.end - only.start);
+
     expect(compute(50, segments)).toEqual({
       activeIndex: 0,
-      segmentTransition: null,
+      segmentTransition: {
+        progress,
+        fromIndex: 0,
+        toIndex: 0,
+        fromMode: 'map',
+        toMode: 'map',
+      },
     });
   });
 
@@ -100,7 +109,7 @@ describe('computeListStoryScrollState', () => {
     });
   });
 
-  it('has no segmentTransition in the last segment body after its handoff completes', () => {
+  it('scrolls through a trailing map segment via intra-segment transition', () => {
     const segments = layoutSegments({
       items: threeSegmentItems,
       viewportHeight: 400,
@@ -108,11 +117,52 @@ describe('computeListStoryScrollState', () => {
       heightsById: { b: 400 },
     });
 
-    const bodyScroll = segments[2].start + 100;
+    const last = segments[2];
+    const bodyScroll = last.start + 100;
+    const progress = 100 / (last.end - last.start);
+
     expect(compute(bodyScroll, segments)).toEqual({
       activeIndex: 2,
-      segmentTransition: null,
+      segmentTransition: {
+        progress,
+        fromIndex: 2,
+        toIndex: 2,
+        fromMode: 'map',
+        toMode: 'map',
+      },
     });
+  });
+
+  it('scrolls through a trailing markdown segment via intra-segment transition', () => {
+    const segments = layoutSegments({
+      items: [
+        storyItem('map', 0, 'map'),
+        storyItem('md', 1, 'markdown', 'line\nline'),
+      ],
+      viewportHeight: 400,
+      mapViewportHeight: 350,
+      heightsById: { md: 500 },
+    });
+
+    const last = segments[1];
+    const span = last.end - last.start;
+
+    expect(compute(last.start, segments)?.segmentTransition).toEqual({
+      progress: 0,
+      fromIndex: 1,
+      toIndex: 1,
+      fromMode: 'markdown',
+      toMode: 'markdown',
+    });
+
+    expect(
+      compute(last.start + Math.floor(span / 2), segments)?.segmentTransition
+        ?.progress,
+    ).toBeCloseTo(0.5, 2);
+
+    expect(
+      compute(last.end - 1, segments)?.segmentTransition?.progress,
+    ).toBeCloseTo(1, 2);
   });
 
   it('activates the next pair during later handoffs', () => {
@@ -177,7 +227,7 @@ describe('computeListStoryScrollState', () => {
     });
   });
 
-  it('has no segmentTransition before the first segment', () => {
+  it('clamps intra-segment progress before the first segment', () => {
     const segments = layoutSegments({
       items: twoSegmentItems,
       viewportHeight: 400,
@@ -187,11 +237,17 @@ describe('computeListStoryScrollState', () => {
 
     expect(compute(-50, segments)).toEqual({
       activeIndex: 0,
-      segmentTransition: null,
+      segmentTransition: {
+        progress: 0,
+        fromIndex: 0,
+        toIndex: 0,
+        fromMode: 'map',
+        toMode: 'map',
+      },
     });
   });
 
-  it('falls through when a transition segment has zero height', () => {
+  it('falls through to intra-segment when a transition segment has zero height', () => {
     expect(
       compute(200, [
         {
@@ -222,7 +278,16 @@ describe('computeListStoryScrollState', () => {
           contentMode: 'map',
         },
       ]),
-    ).toEqual({ activeIndex: 2, segmentTransition: null });
+    ).toEqual({
+      activeIndex: 2,
+      segmentTransition: {
+        progress: 0,
+        fromIndex: 2,
+        toIndex: 2,
+        fromMode: 'map',
+        toMode: 'map',
+      },
+    });
   });
 
   it('clamps progress to [0, 1]', () => {

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -154,20 +154,22 @@ export function ListStoryStageOverlay({
       };
     }
 
-    return {
+    const fromItem = items.find(item => item.index === transition.fromIndex);
+    const toItem = items.find(item => item.index === transition.toIndex);
+
+    const fromPaneConfig = buildPaneConfig(fromItem, transition.fromMode);
+    const toPaneConfig = intraSegmentScroll
+      ? EMPTY_MARKDOWN_PANE
+      : buildPaneConfig(toItem, transition.toMode);
+
+    const paneState = {
       fromIndex: transition.fromIndex,
       toIndex: transition.toIndex,
-      fromPaneConfig: buildPaneConfig(
-        items.find(item => item.index === transition.fromIndex),
-        transition.fromMode,
-      ),
-      toPaneConfig: intraSegmentScroll
-        ? EMPTY_MARKDOWN_PANE
-        : buildPaneConfig(
-            items.find(item => item.index === transition.toIndex),
-            transition.toMode,
-          ),
+      fromPaneConfig,
+      toPaneConfig,
     };
+
+    return paneState;
   }, [items, currentIndex, transition, intraSegmentScroll, model]);
 
   const overlayHeight = Math.max(stageHeight, 0);

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -118,7 +118,19 @@ export function ListStoryStageOverlay({
   const isTransitioning = segmentTransition !== null;
   const activeItem = items.find(item => item.index === currentIndex);
   const activeMode = getSegmentDisplayMode(activeItem?.activeSlide);
-  const transitionProgress = isTransitioning ? segmentTransition.progress : 1;
+  const effectiveTransition = useMemo((): IListStorySegmentTransition => {
+    if (segmentTransition) {
+      return segmentTransition;
+    }
+
+    return {
+      progress: 0,
+      fromIndex: currentIndex,
+      toIndex: currentIndex,
+      fromMode: activeMode,
+      toMode: activeMode,
+    };
+  }, [segmentTransition, currentIndex, activeMode]);
 
   const { fromIndex, toIndex, fromPaneConfig, toPaneConfig } = useMemo(() => {
     if (!model || !activeItem) {
@@ -130,28 +142,19 @@ export function ListStoryStageOverlay({
       };
     }
 
-    if (segmentTransition) {
-      return {
-        fromIndex: segmentTransition.fromIndex,
-        toIndex: segmentTransition.toIndex,
-        fromPaneConfig: buildPaneConfig(
-          items.find(item => item.index === segmentTransition.fromIndex),
-          segmentTransition.fromMode,
-        ),
-        toPaneConfig: buildPaneConfig(
-          items.find(item => item.index === segmentTransition.toIndex),
-          segmentTransition.toMode,
-        ),
-      };
-    }
-
     return {
-      fromIndex: currentIndex,
-      toIndex: currentIndex,
-      fromPaneConfig: EMPTY_MARKDOWN_PANE,
-      toPaneConfig: buildPaneConfig(activeItem, activeMode),
+      fromIndex: effectiveTransition.fromIndex,
+      toIndex: effectiveTransition.toIndex,
+      fromPaneConfig: buildPaneConfig(
+        items.find(item => item.index === effectiveTransition.fromIndex),
+        effectiveTransition.fromMode,
+      ),
+      toPaneConfig: buildPaneConfig(
+        items.find(item => item.index === effectiveTransition.toIndex),
+        effectiveTransition.toMode,
+      ),
     };
-  }, [items, activeItem, currentIndex, activeMode, segmentTransition]);
+  }, [items, activeItem, currentIndex, effectiveTransition, model]);
 
   const overlayHeight = Math.max(stageHeight, 0);
 
@@ -179,11 +182,6 @@ export function ListStoryStageOverlay({
   }, [model, story]);
 
   useLayoutEffect(() => {
-    if (!isTransitioning) {
-      setTransitionTranslatePx(0);
-      return;
-    }
-
     const stack = stackRef.current;
     if (!stack) {
       return;
@@ -208,7 +206,7 @@ export function ListStoryStageOverlay({
     return () => {
       ro.disconnect();
     };
-  }, [isTransitioning, fromIndex, toIndex, fromPaneConfig, toPaneConfig]);
+  }, [fromIndex, toIndex, fromPaneConfig, toPaneConfig]);
 
   const overlaySized = stageHeight > 0;
 
@@ -221,11 +219,11 @@ export function ListStoryStageOverlay({
       ref={overlayRef}
       className={`jgis-story-stage-overlay${
         overlaySized ? ' jgis-story-stage-overlay--sized' : ''
-      }${isTransitioning ? ' jgis-story-stage-overlay--transitioning' : ''}`}
+      } jgis-story-stage-overlay--transitioning`}
       style={
         {
           ...spectaPresentationStyle,
-          '--jgis-segment-transition-progress': transitionProgress,
+          '--jgis-segment-transition-progress': effectiveTransition.progress,
           ...(overlaySized
             ? {
                 height: overlayHeight,
@@ -236,25 +234,15 @@ export function ListStoryStageOverlay({
         } as React.CSSProperties
       }
     >
-      {isTransitioning ? (
-        <div ref={stackRef} className="jgis-story-segment-transition-stack">
-          <SegmentOverlayPane
-            pane="from"
-            segmentIndex={fromIndex}
-            config={fromPaneConfig}
-            storyData={story}
-            items={items}
-          />
-          <div className="jgis-story-segment-transition-gap" aria-hidden />
-          <SegmentOverlayPane
-            pane="to"
-            segmentIndex={toIndex}
-            config={toPaneConfig}
-            storyData={story}
-            items={items}
-          />
-        </div>
-      ) : (
+      <div ref={stackRef} className="jgis-story-segment-transition-stack">
+        <SegmentOverlayPane
+          pane="from"
+          segmentIndex={fromIndex}
+          config={fromPaneConfig}
+          storyData={story}
+          items={items}
+        />
+        <div className="jgis-story-segment-transition-gap" aria-hidden />
         <SegmentOverlayPane
           pane="to"
           segmentIndex={toIndex}
@@ -262,7 +250,7 @@ export function ListStoryStageOverlay({
           storyData={story}
           items={items}
         />
-      )}
+      </div>
     </div>
   );
 }

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -9,6 +9,7 @@ import type {
   StorySegmentDisplayMode,
   IStorySegmentViewItem,
 } from '@/src/features/story/types/types';
+import { isIntraSegmentScroll } from '@/src/features/story/utils/computeListStoryScrollState';
 import { getSpectaPresentationCssVars } from '@/src/features/story/utils/spectaPresentation';
 import {
   buildStorySegmentViewItems,
@@ -86,9 +87,21 @@ function SegmentOverlayPane({
   );
 }
 
+function buildFallbackTransition(
+  activeItem: IStorySegmentViewItem,
+): IListStorySegmentTransition {
+  const mode = getSegmentDisplayMode(activeItem.activeSlide);
+  return {
+    progress: 0,
+    fromIndex: activeItem.index,
+    toIndex: activeItem.index,
+    fromMode: mode,
+    toMode: mode,
+  };
+}
+
 /**
  * List-story stage overlay: map + markdown segments on the map stage.
- * The story column scrolls only the virtual track; this is the visible UI.
  */
 export function ListStoryStageOverlay({
   model,
@@ -115,25 +128,24 @@ export function ListStoryStageOverlay({
     ],
   );
 
-  const isTransitioning = segmentTransition !== null;
   const activeItem = items.find(item => item.index === currentIndex);
-  const activeMode = getSegmentDisplayMode(activeItem?.activeSlide);
-  const effectiveTransition = useMemo((): IListStorySegmentTransition => {
+
+  const transition = useMemo((): IListStorySegmentTransition | null => {
     if (segmentTransition) {
       return segmentTransition;
     }
 
-    return {
-      progress: 0,
-      fromIndex: currentIndex,
-      toIndex: currentIndex,
-      fromMode: activeMode,
-      toMode: activeMode,
-    };
-  }, [segmentTransition, currentIndex, activeMode]);
+    if (activeItem) {
+      return buildFallbackTransition(activeItem);
+    }
+
+    return null;
+  }, [segmentTransition, activeItem]);
+
+  const intraSegmentScroll = isIntraSegmentScroll(transition);
 
   const { fromIndex, toIndex, fromPaneConfig, toPaneConfig } = useMemo(() => {
-    if (!model || !activeItem) {
+    if (!model || !transition) {
       return {
         fromIndex: currentIndex,
         toIndex: currentIndex,
@@ -143,20 +155,23 @@ export function ListStoryStageOverlay({
     }
 
     return {
-      fromIndex: effectiveTransition.fromIndex,
-      toIndex: effectiveTransition.toIndex,
+      fromIndex: transition.fromIndex,
+      toIndex: transition.toIndex,
       fromPaneConfig: buildPaneConfig(
-        items.find(item => item.index === effectiveTransition.fromIndex),
-        effectiveTransition.fromMode,
+        items.find(item => item.index === transition.fromIndex),
+        transition.fromMode,
       ),
-      toPaneConfig: buildPaneConfig(
-        items.find(item => item.index === effectiveTransition.toIndex),
-        effectiveTransition.toMode,
-      ),
+      toPaneConfig: intraSegmentScroll
+        ? EMPTY_MARKDOWN_PANE
+        : buildPaneConfig(
+            items.find(item => item.index === transition.toIndex),
+            transition.toMode,
+          ),
     };
-  }, [items, activeItem, currentIndex, effectiveTransition, model]);
+  }, [items, currentIndex, transition, intraSegmentScroll, model]);
 
   const overlayHeight = Math.max(stageHeight, 0);
+  const transitionProgress = transition?.progress ?? 0;
 
   useLayoutEffect(() => {
     const parent = overlayRef.current?.parentElement;
@@ -189,12 +204,18 @@ export function ListStoryStageOverlay({
 
     const measure = (): void => {
       const fromPane = stack.querySelector('[data-pane="from"]');
-      const gap = stack.querySelector('.jgis-story-segment-transition-gap');
-      if (!(fromPane instanceof HTMLElement) || !(gap instanceof HTMLElement)) {
+
+      if (!(fromPane instanceof HTMLElement)) {
         return;
       }
 
-      const travel = fromPane.offsetHeight + gap.offsetHeight;
+      const gap = stack.querySelector('.jgis-story-segment-transition-gap');
+      const gapHeight =
+        gap instanceof HTMLElement && !intraSegmentScroll
+          ? gap.offsetHeight
+          : 0;
+
+      const travel = fromPane.offsetHeight + gapHeight;
       setTransitionTranslatePx(prev => (prev === travel ? prev : travel));
     };
 
@@ -206,11 +227,11 @@ export function ListStoryStageOverlay({
     return () => {
       ro.disconnect();
     };
-  }, [fromIndex, toIndex, fromPaneConfig, toPaneConfig]);
+  }, [fromIndex, toIndex, fromPaneConfig, toPaneConfig, intraSegmentScroll]);
 
   const overlaySized = stageHeight > 0;
 
-  if (!model || !story || !activeItem) {
+  if (!model || !story || !activeItem || !transition) {
     return null;
   }
 
@@ -223,7 +244,7 @@ export function ListStoryStageOverlay({
       style={
         {
           ...spectaPresentationStyle,
-          '--jgis-segment-transition-progress': effectiveTransition.progress,
+          '--jgis-segment-transition-progress': transitionProgress,
           ...(overlaySized
             ? {
                 height: overlayHeight,
@@ -242,14 +263,18 @@ export function ListStoryStageOverlay({
           storyData={story}
           items={items}
         />
-        <div className="jgis-story-segment-transition-gap" aria-hidden />
-        <SegmentOverlayPane
-          pane="to"
-          segmentIndex={toIndex}
-          config={toPaneConfig}
-          storyData={story}
-          items={items}
-        />
+        {!intraSegmentScroll ? (
+          <>
+            <div className="jgis-story-segment-transition-gap" aria-hidden />
+            <SegmentOverlayPane
+              pane="to"
+              segmentIndex={toIndex}
+              config={toPaneConfig}
+              storyData={story}
+              items={items}
+            />
+          </>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
@@ -21,7 +21,6 @@ export interface ISpectaMobileListModeContentProps {
 
 /**
  * Mobile list story: full-viewport touch scroll on the virtual track drives
- * {@link ListStoryStageOverlay} on the map stage (via segment transition sync).
  */
 export function SpectaMobileListModeContent({
   model,

--- a/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/** Placeholder for mobile list-story scroll track (desktop: ListStoryVirtualScrollTrack). */
+export function SpectaMobileListModeContent(): JSX.Element {
+  return (
+    <div
+      id="jgis-story-segment-panel"
+      className="jgis-story-viewer-panel jgis-story-viewer-panel-specta-mod-list jgis-story-mobile-list-mode-stub"
+    >
+      <p>List story mobile view (TODO)</p>
+    </div>
+  );
+}

--- a/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
@@ -1,13 +1,75 @@
-import React from 'react';
+import { IJGISStoryMap, IJupyterGISModel } from '@jupytergis/schema';
+import React, { useLayoutEffect, useMemo, useRef } from 'react';
 
-/** Placeholder for mobile list-story scroll track (desktop: ListStoryVirtualScrollTrack). */
-export function SpectaMobileListModeContent(): JSX.Element {
+import { ListStoryVirtualScrollTrack } from '@/src/features/story/components/ListStoryVirtualScrollTrack';
+import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
+import { useListStoryScroll } from '@/src/features/story/hooks/useListStoryScroll';
+import type { IListStorySegmentTransition } from '@/src/features/story/types/types';
+import { getSpectaPresentationStyle } from '@/src/features/story/utils/spectaPresentation';
+import { buildStorySegmentViewItems } from '@/src/features/story/utils/storySegmentViewItems';
+
+export interface ISpectaMobileListModeContentProps {
+  model: IJupyterGISModel;
+  storyData: IJGISStoryMap | null;
+  currentIndex: number;
+  setIndex: (index: number) => void;
+  onSegmentTransitionChange?: (
+    payload: IListStorySegmentTransition | null,
+  ) => void;
+}
+
+/**
+ * Mobile list story: full-viewport touch scroll on the virtual track drives
+ * {@link ListStoryStageOverlay} on the map stage (via segment transition sync).
+ */
+export function SpectaMobileListModeContent({
+  model,
+  storyData,
+  currentIndex,
+  setIndex,
+  onSegmentTransitionChange,
+}: ISpectaMobileListModeContentProps): JSX.Element {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const { scrollTrackLayout, bindScrollTrackElement } =
+    useListStoryScrollTrackContext();
+
+  const segmentViewItems = useMemo(
+    () => buildStorySegmentViewItems(model, storyData),
+    [model, storyData],
+  );
+
+  const presentationStyle = getSpectaPresentationStyle(storyData);
+
+  const segmentTransitionSyncEnabled =
+    Boolean(onSegmentTransitionChange) && storyData?.storyType === 'list';
+
+  useLayoutEffect(() => {
+    bindScrollTrackElement(scrollContainerRef.current);
+    return () => {
+      bindScrollTrackElement(null);
+    };
+  }, [bindScrollTrackElement]);
+
+  useListStoryScroll({
+    enabled: segmentTransitionSyncEnabled,
+    scrollContainerRef,
+    storyData,
+    scrollTrackLayout,
+    items: segmentViewItems,
+    currentIndex,
+    setIndex,
+    onSegmentTransitionChange,
+  });
+
   return (
     <div
+      ref={scrollContainerRef}
       id="jgis-story-segment-panel"
-      className="jgis-story-viewer-panel jgis-story-viewer-panel-specta-mod-list jgis-story-mobile-list-mode-stub"
+      className="jgis-story-viewer-panel jgis-story-viewer-panel-specta-mod jgis-story-viewer-panel-specta-mod-list jgis-story-mobile-list-scroll"
+      style={presentationStyle}
     >
-      <p>List story mobile view (TODO)</p>
+      <ListStoryVirtualScrollTrack scrollTrackLayout={scrollTrackLayout} />
     </div>
   );
 }

--- a/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
@@ -7,6 +7,7 @@ import { useListStoryScroll } from '@/src/features/story/hooks/useListStoryScrol
 import type { IListStorySegmentTransition } from '@/src/features/story/types/types';
 import { getSpectaPresentationStyle } from '@/src/features/story/utils/spectaPresentation';
 import { buildStorySegmentViewItems } from '@/src/features/story/utils/storySegmentViewItems';
+import { STORY_TYPE } from '@/src/types';
 
 export interface ISpectaMobileListModeContentProps {
   model: IJupyterGISModel;
@@ -42,7 +43,8 @@ export function SpectaMobileListModeContent({
   const presentationStyle = getSpectaPresentationStyle(storyData);
 
   const segmentTransitionSyncEnabled =
-    Boolean(onSegmentTransitionChange) && storyData?.storyType === 'list';
+    Boolean(onSegmentTransitionChange) &&
+    storyData?.storyType === STORY_TYPE.list;
 
   useLayoutEffect(() => {
     bindScrollTrackElement(scrollContainerRef.current);

--- a/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
@@ -68,7 +68,7 @@ export function SpectaMobileListModeContent({
     <div
       ref={scrollContainerRef}
       id="jgis-story-segment-panel"
-      className="jgis-story-viewer-panel jgis-story-viewer-panel-specta-mod jgis-story-viewer-panel-specta-mod-list jgis-story-mobile-list-scroll"
+      className="jgis-story-viewer-panel-specta-mod-vertical-scroll jgis-story-mobile-list-scroll"
       style={presentationStyle}
     >
       <ListStoryVirtualScrollTrack scrollTrackLayout={scrollTrackLayout} />

--- a/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileListModeContent.tsx
@@ -44,7 +44,7 @@ export function SpectaMobileListModeContent({
 
   const segmentTransitionSyncEnabled =
     Boolean(onSegmentTransitionChange) &&
-    storyData?.storyType === STORY_TYPE.list;
+    storyData?.storyType === STORY_TYPE.verticalScroll;
 
   useLayoutEffect(() => {
     bindScrollTrackElement(scrollContainerRef.current);

--- a/packages/base/src/features/story/components/SpectaMobileSingleModeContent.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileSingleModeContent.tsx
@@ -1,0 +1,183 @@
+import { IJGISStoryMap, IStorySegmentLayer } from '@jupytergis/schema';
+import React, { RefObject, useEffect, useState } from 'react';
+
+import StoryViewerPanel from '@/src/features/story/StoryViewerPanel';
+import { getSpectaPresentationStyle } from '@/src/features/story/utils/spectaPresentation';
+import { Button } from '@/src/shared/components/Button';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTrigger,
+} from '@/src/shared/components/Drawer';
+
+const MAIN_ID = 'jp-main-content-panel';
+const SEGMENT_PANEL_ID = 'jgis-story-segment-panel';
+const SEGMENT_HEADER_ID = 'jgis-story-segment-header';
+
+const SNAP_FIRST_MIN = 0.3;
+const SNAP_FIRST_MAX = 0.95;
+const SNAP_FIRST_DEFAULT = 0.7;
+/** Offset (px) for segment header height: margins from p and h1 in story content */
+const SEGMENT_HEADER_OFFSET_PX = 16.8 * 2 + 18.76;
+
+export interface ISpectaMobileSingleModeContentProps {
+  segmentContainerRef: RefObject<HTMLDivElement>;
+  storyData: IJGISStoryMap | null;
+  currentIndex: number;
+  activeSlide: IStorySegmentLayer['parameters'] | undefined;
+  layerName: string;
+  handlePrev: () => void;
+  handleNext: () => void;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+/**
+ * Compute the first snap point so that vaul's --snap-point-height (the
+ * transform offset) equals #jgis-story-segment-panel height minus #jgis-story-segment-header height.
+ * For a bottom drawer, offset = mainHeight * (1 - snapPoint), so
+ * snapPoint = (mainHeight - offset) / mainHeight.
+ */
+function getFirstSnapFromSegmentHeader(
+  mainEl: HTMLElement,
+  segmentPanelEl: HTMLElement,
+  segmentHeaderEl: HTMLElement,
+): number {
+  const mainHeight = mainEl.getBoundingClientRect().height;
+  const segmentPanelHeight = segmentPanelEl.getBoundingClientRect().height;
+  const segmentHeaderHeight = segmentHeaderEl.getBoundingClientRect().height;
+  const offsetPx =
+    segmentPanelHeight - segmentHeaderHeight - SEGMENT_HEADER_OFFSET_PX;
+
+  if (mainHeight <= 0) {
+    return SNAP_FIRST_DEFAULT;
+  }
+
+  const fraction = (mainHeight - offsetPx) / mainHeight;
+  const clamped = Math.max(SNAP_FIRST_MIN, Math.min(SNAP_FIRST_MAX, fraction));
+  return clamped;
+}
+
+export function SpectaMobileSingleModeContent({
+  segmentContainerRef,
+  storyData,
+  currentIndex,
+  activeSlide,
+  layerName,
+  handlePrev,
+  handleNext,
+  hasPrev,
+  hasNext,
+}: ISpectaMobileSingleModeContentProps): JSX.Element {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [snapPoints, setSnapPoints] = useState<number[]>([
+    SNAP_FIRST_DEFAULT,
+    1,
+  ]);
+  const [snap, setSnap] = useState<number | string | null>(snapPoints[0]);
+
+  const presentationStyle = getSpectaPresentationStyle(storyData);
+
+  useEffect(() => {
+    const isInSnapPoints = snapPoints.some(
+      p =>
+        p === snap ||
+        (typeof p === 'number' &&
+          typeof snap === 'number' &&
+          Math.abs(p - snap) < 1e-9),
+    );
+    if (!isInSnapPoints && snapPoints.length > 0) {
+      setSnap(snapPoints[0]);
+    }
+  }, [snapPoints, snap]);
+
+  useEffect(() => {
+    const mainEl = document.getElementById(MAIN_ID);
+    setContainer(mainEl);
+
+    if (!mainEl) {
+      return;
+    }
+
+    const updateFirstSnap = () => {
+      const segmentPanelEl = document.getElementById(SEGMENT_PANEL_ID);
+      const segmentHeaderEl = document.getElementById(SEGMENT_HEADER_ID);
+
+      if (segmentPanelEl && segmentHeaderEl) {
+        const firstSnap = getFirstSnapFromSegmentHeader(
+          mainEl,
+          segmentPanelEl,
+          segmentHeaderEl,
+        );
+        setSnapPoints([firstSnap, 1]);
+      }
+    };
+
+    const resizeObserver = new ResizeObserver(() => updateFirstSnap());
+    let observedPanelEl: HTMLElement | null = null;
+
+    const syncHeaderObserver = () => {
+      const segmentPanelEl = document.getElementById(SEGMENT_PANEL_ID);
+      const segmentHeaderEl = document.getElementById(SEGMENT_HEADER_ID);
+
+      if (
+        !segmentPanelEl ||
+        !segmentHeaderEl ||
+        segmentPanelEl === observedPanelEl
+      ) {
+        return;
+      }
+
+      if (observedPanelEl) {
+        resizeObserver.unobserve(observedPanelEl);
+      }
+      resizeObserver.observe(segmentPanelEl);
+      observedPanelEl = segmentPanelEl;
+      updateFirstSnap();
+    };
+
+    syncHeaderObserver();
+
+    const mutationObserver = new MutationObserver(syncHeaderObserver);
+    mutationObserver.observe(mainEl, {
+      childList: true,
+      subtree: true,
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, []);
+
+  return (
+    <div className="jgis-mobile-specta-trigger-wrapper">
+      <Drawer
+        snapPoints={snapPoints}
+        activeSnapPoint={snap}
+        setActiveSnapPoint={setSnap}
+        direction="bottom"
+        container={container}
+        noBodyStyles={true}
+      >
+        <DrawerTrigger asChild>
+          <Button>Open Story Panel</Button>
+        </DrawerTrigger>
+        <DrawerContent style={presentationStyle}>
+          <div id={SEGMENT_PANEL_ID} className="jgis-story-viewer-panel">
+            <StoryViewerPanel
+              isSpecta={true}
+              isMobile={true}
+              segmentContainerRef={segmentContainerRef}
+              storyData={storyData}
+              currentIndex={currentIndex}
+              activeSlide={activeSlide}
+              layerName={layerName}
+              segmentNav={{ handlePrev, handleNext, hasPrev, hasNext }}
+            />
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+}

--- a/packages/base/src/features/story/components/SpectaMobileView.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileView.tsx
@@ -36,7 +36,7 @@ export function SpectaMobileView({
   ...singleModeProps
 }: ISpectaMobileViewProps): JSX.Element {
   const viewMode: StoryMobileViewMode =
-    singleModeProps.storyData?.storyType === STORY_TYPE.list
+    singleModeProps.storyData?.storyType === STORY_TYPE.verticalScroll
       ? 'list'
       : 'single';
 

--- a/packages/base/src/features/story/components/SpectaMobileView.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileView.tsx
@@ -1,30 +1,53 @@
-import { IJGISStoryMap, IStorySegmentLayer } from '@jupytergis/schema';
+import {
+  IJGISStoryMap,
+  IJupyterGISModel,
+  IStorySegmentLayer,
+} from '@jupytergis/schema';
 import React, { RefObject } from 'react';
 
 import { SpectaMobileListModeContent } from '@/src/features/story/components/SpectaMobileListModeContent';
 import { SpectaMobileSingleModeContent } from '@/src/features/story/components/SpectaMobileSingleModeContent';
+import type { IListStorySegmentTransition } from '@/src/features/story/types/types';
 
 type StoryMobileViewMode = 'single' | 'list';
 
 interface ISpectaMobileViewProps {
+  model: IJupyterGISModel;
   segmentContainerRef: RefObject<HTMLDivElement>;
   storyData: IJGISStoryMap | null;
   currentIndex: number;
+  setIndex: (index: number) => void;
   activeSlide: IStorySegmentLayer['parameters'] | undefined;
   layerName: string;
   handlePrev: () => void;
   handleNext: () => void;
   hasPrev: boolean;
   hasNext: boolean;
+  onSegmentTransitionChange?: (
+    payload: IListStorySegmentTransition | null,
+  ) => void;
 }
 
-export function SpectaMobileView(props: ISpectaMobileViewProps): JSX.Element {
+export function SpectaMobileView({
+  model,
+  setIndex,
+  onSegmentTransitionChange,
+  ...singleModeProps
+}: ISpectaMobileViewProps): JSX.Element {
   const viewMode: StoryMobileViewMode =
-    props.storyData?.storyType === 'list' ? 'list' : 'single';
+    singleModeProps.storyData?.storyType === 'list' ? 'list' : 'single';
 
   const renderModeContent: Record<StoryMobileViewMode, () => JSX.Element> = {
-    single: () => <SpectaMobileSingleModeContent {...props} />,
-    list: () => <SpectaMobileListModeContent />,
+    single: () => <SpectaMobileSingleModeContent {...singleModeProps} />,
+    list: () => (
+      <SpectaMobileListModeContent
+        model={model}
+        storyData={singleModeProps.storyData}
+        currentIndex={singleModeProps.currentIndex}
+        setIndex={setIndex}
+        onSegmentTransitionChange={onSegmentTransitionChange}
+      />
+    ),
   };
 
   return renderModeContent[viewMode]();

--- a/packages/base/src/features/story/components/SpectaMobileView.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileView.tsx
@@ -8,6 +8,7 @@ import React, { RefObject } from 'react';
 import { SpectaMobileListModeContent } from '@/src/features/story/components/SpectaMobileListModeContent';
 import { SpectaMobileSingleModeContent } from '@/src/features/story/components/SpectaMobileSingleModeContent';
 import type { IListStorySegmentTransition } from '@/src/features/story/types/types';
+import { STORY_TYPE } from '@/src/types';
 
 type StoryMobileViewMode = 'single' | 'list';
 
@@ -35,7 +36,9 @@ export function SpectaMobileView({
   ...singleModeProps
 }: ISpectaMobileViewProps): JSX.Element {
   const viewMode: StoryMobileViewMode =
-    singleModeProps.storyData?.storyType === 'list' ? 'list' : 'single';
+    singleModeProps.storyData?.storyType === STORY_TYPE.list
+      ? 'list'
+      : 'single';
 
   const renderModeContent: Record<StoryMobileViewMode, () => JSX.Element> = {
     single: () => <SpectaMobileSingleModeContent {...singleModeProps} />,

--- a/packages/base/src/features/story/components/SpectaMobileView.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileView.tsx
@@ -1,24 +1,10 @@
 import { IJGISStoryMap, IStorySegmentLayer } from '@jupytergis/schema';
-import React, { RefObject, useEffect, useState } from 'react';
+import React, { RefObject } from 'react';
 
-import { getSpectaPresentationStyle } from '@/src/features/story/utils/spectaPresentation';
-import { Button } from '@/src/shared/components/Button';
-import {
-  Drawer,
-  DrawerContent,
-  DrawerTrigger,
-} from '@/src/shared/components/Drawer';
-import StoryViewerPanel from '../StoryViewerPanel';
+import { SpectaMobileListModeContent } from '@/src/features/story/components/SpectaMobileListModeContent';
+import { SpectaMobileSingleModeContent } from '@/src/features/story/components/SpectaMobileSingleModeContent';
 
-const MAIN_ID = 'jp-main-content-panel';
-const SEGMENT_PANEL_ID = 'jgis-story-segment-panel';
-const SEGMENT_HEADER_ID = 'jgis-story-segment-header';
-
-const SNAP_FIRST_MIN = 0.3;
-const SNAP_FIRST_MAX = 0.95;
-const SNAP_FIRST_DEFAULT = 0.7;
-/** Offset (px) for segment header height: margins from p and h1 in story content */
-const SEGMENT_HEADER_OFFSET_PX = 16.8 * 2 + 18.76;
+type StoryMobileViewMode = 'single' | 'list';
 
 interface ISpectaMobileViewProps {
   segmentContainerRef: RefObject<HTMLDivElement>;
@@ -32,154 +18,14 @@ interface ISpectaMobileViewProps {
   hasNext: boolean;
 }
 
-/**
- * Compute the first snap point so that vaul's --snap-point-height (the
- * transform offset) equals #jgis-story-segment-panel height minus #jgis-story-segment-header height.
- * For a bottom drawer, offset = mainHeight * (1 - snapPoint), so
- * snapPoint = (mainHeight - offset) / mainHeight.
- */
-function getFirstSnapFromSegmentHeader(
-  mainEl: HTMLElement,
-  segmentPanelEl: HTMLElement,
-  segmentHeaderEl: HTMLElement,
-): number {
-  const mainHeight = mainEl.getBoundingClientRect().height;
-  const segmentPanelHeight = segmentPanelEl.getBoundingClientRect().height;
-  const segmentHeaderHeight = segmentHeaderEl.getBoundingClientRect().height;
-  const offsetPx =
-    segmentPanelHeight - segmentHeaderHeight - SEGMENT_HEADER_OFFSET_PX;
+export function SpectaMobileView(props: ISpectaMobileViewProps): JSX.Element {
+  const viewMode: StoryMobileViewMode =
+    props.storyData?.storyType === 'list' ? 'list' : 'single';
 
-  if (mainHeight <= 0) {
-    return SNAP_FIRST_DEFAULT;
-  }
+  const renderModeContent: Record<StoryMobileViewMode, () => JSX.Element> = {
+    single: () => <SpectaMobileSingleModeContent {...props} />,
+    list: () => <SpectaMobileListModeContent />,
+  };
 
-  const fraction = (mainHeight - offsetPx) / mainHeight;
-  const clamped = Math.max(SNAP_FIRST_MIN, Math.min(SNAP_FIRST_MAX, fraction));
-  return clamped;
-}
-
-export function SpectaMobileView({
-  segmentContainerRef,
-  storyData,
-  currentIndex,
-  activeSlide,
-  layerName,
-  handlePrev,
-  handleNext,
-  hasPrev,
-  hasNext,
-}: ISpectaMobileViewProps) {
-  const [container, setContainer] = useState<HTMLElement | null>(null);
-  const [snapPoints, setSnapPoints] = useState<number[]>([
-    SNAP_FIRST_DEFAULT,
-    1,
-  ]);
-  const [snap, setSnap] = useState<number | string | null>(snapPoints[0]);
-
-  const presentationStyle = getSpectaPresentationStyle(storyData);
-
-  // Keep active snap in sync with snapPoints so Vaul's --snap-point-height stays defined.
-  useEffect(() => {
-    const isInSnapPoints = snapPoints.some(
-      p =>
-        p === snap ||
-        (typeof p === 'number' &&
-          typeof snap === 'number' &&
-          Math.abs(p - snap) < 1e-9),
-    );
-    if (!isInSnapPoints && snapPoints.length > 0) {
-      setSnap(snapPoints[0]);
-    }
-  }, [snapPoints, snap]);
-
-  // Observe #jgis-story-segment-panel (and re-attach when drawer reopens).
-  useEffect(() => {
-    const mainEl = document.getElementById(MAIN_ID);
-    setContainer(mainEl);
-
-    if (!mainEl) {
-      return;
-    }
-
-    const updateFirstSnap = () => {
-      const segmentPanelEl = document.getElementById(SEGMENT_PANEL_ID);
-      const segmentHeaderEl = document.getElementById(SEGMENT_HEADER_ID);
-
-      if (segmentPanelEl && segmentHeaderEl) {
-        const firstSnap = getFirstSnapFromSegmentHeader(
-          mainEl,
-          segmentPanelEl,
-          segmentHeaderEl,
-        );
-        setSnapPoints([firstSnap, 1]);
-      }
-    };
-
-    const resizeObserver = new ResizeObserver(() => updateFirstSnap());
-    let observedPanelEl: HTMLElement | null = null;
-
-    const syncHeaderObserver = () => {
-      const segmentPanelEl = document.getElementById(SEGMENT_PANEL_ID);
-      const segmentHeaderEl = document.getElementById(SEGMENT_HEADER_ID);
-
-      if (
-        !segmentPanelEl ||
-        !segmentHeaderEl ||
-        segmentPanelEl === observedPanelEl
-      ) {
-        return;
-      }
-
-      if (observedPanelEl) {
-        resizeObserver.unobserve(observedPanelEl);
-      }
-      resizeObserver.observe(segmentPanelEl);
-      observedPanelEl = segmentPanelEl;
-      updateFirstSnap();
-    };
-
-    syncHeaderObserver();
-
-    const mutationObserver = new MutationObserver(syncHeaderObserver);
-    mutationObserver.observe(mainEl, {
-      childList: true,
-      subtree: true,
-    });
-
-    return () => {
-      resizeObserver.disconnect();
-      mutationObserver.disconnect();
-    };
-  }, []);
-
-  return (
-    <div className="jgis-mobile-specta-trigger-wrapper">
-      <Drawer
-        snapPoints={snapPoints}
-        activeSnapPoint={snap}
-        setActiveSnapPoint={setSnap}
-        direction="bottom"
-        container={container}
-        noBodyStyles={true}
-      >
-        <DrawerTrigger asChild>
-          <Button>Open Story Panel</Button>
-        </DrawerTrigger>
-        <DrawerContent style={presentationStyle}>
-          <div id={SEGMENT_PANEL_ID} className="jgis-story-viewer-panel">
-            <StoryViewerPanel
-              isSpecta={true}
-              isMobile={true}
-              segmentContainerRef={segmentContainerRef}
-              storyData={storyData}
-              currentIndex={currentIndex}
-              activeSlide={activeSlide}
-              layerName={layerName}
-              segmentNav={{ handlePrev, handleNext, hasPrev, hasNext }}
-            />
-          </div>
-        </DrawerContent>
-      </Drawer>
-    </div>
-  );
+  return renderModeContent[viewMode]();
 }

--- a/packages/base/src/features/story/components/SpectaMobileView.tsx
+++ b/packages/base/src/features/story/components/SpectaMobileView.tsx
@@ -31,22 +31,40 @@ interface ISpectaMobileViewProps {
 
 export function SpectaMobileView({
   model,
+  segmentContainerRef,
+  storyData,
+  currentIndex,
   setIndex,
+  activeSlide,
+  layerName,
+  handlePrev,
+  handleNext,
+  hasPrev,
+  hasNext,
   onSegmentTransitionChange,
-  ...singleModeProps
 }: ISpectaMobileViewProps): JSX.Element {
   const viewMode: StoryMobileViewMode =
-    singleModeProps.storyData?.storyType === STORY_TYPE.verticalScroll
-      ? 'list'
-      : 'single';
+    storyData?.storyType === STORY_TYPE.verticalScroll ? 'list' : 'single';
 
   const renderModeContent: Record<StoryMobileViewMode, () => JSX.Element> = {
-    single: () => <SpectaMobileSingleModeContent {...singleModeProps} />,
+    single: () => (
+      <SpectaMobileSingleModeContent
+        segmentContainerRef={segmentContainerRef}
+        storyData={storyData}
+        currentIndex={currentIndex}
+        activeSlide={activeSlide}
+        layerName={layerName}
+        handlePrev={handlePrev}
+        handleNext={handleNext}
+        hasPrev={hasPrev}
+        hasNext={hasNext}
+      />
+    ),
     list: () => (
       <SpectaMobileListModeContent
         model={model}
-        storyData={singleModeProps.storyData}
-        currentIndex={singleModeProps.currentIndex}
+        storyData={storyData}
+        currentIndex={currentIndex}
         setIndex={setIndex}
         onSegmentTransitionChange={onSegmentTransitionChange}
       />

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -21,6 +21,7 @@ import {
 
 interface IListStoryScrollTrackContextValue {
   scrollTrackLayout: IListStoryScrollTrackLayout | null;
+  scrollTop: number;
   bindScrollTrackElement: (element: HTMLDivElement | null) => void;
 }
 
@@ -42,9 +43,12 @@ export function ListStoryScrollTrackProvider({
   const [heightsById, setHeightsById] = useState<Record<string, number>>({});
   const [viewportHeight, setViewportHeight] = useState(0);
   const [mapViewportHeight, setMapViewportHeight] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
 
   const currentSegmentIndex = useCurrentSegmentIndex(model);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTrackElement, setScrollTrackElement] =
+    useState<HTMLDivElement | null>(null);
 
   useLayoutEffect(() => {
     const bump = (): void => {
@@ -91,17 +95,24 @@ export function ListStoryScrollTrackProvider({
     [items, viewportHeight, mapViewportHeightOption],
   );
 
+  const syncScrollerMetrics = useCallback((scroller: HTMLDivElement): void => {
+    setViewportHeight(scroller.clientHeight);
+    setScrollTop(scroller.scrollTop);
+  }, []);
+
   const bindScrollTrackElement = useCallback(
     (element: HTMLDivElement | null) => {
       scrollerRef.current = element;
+      setScrollTrackElement(element);
       if (!element) {
         setViewportHeight(0);
+        setScrollTop(0);
         return;
       }
 
-      setViewportHeight(element.clientHeight);
+      syncScrollerMetrics(element);
     },
-    [],
+    [syncScrollerMetrics],
   );
 
   const observeElementHeight = useCallback(
@@ -125,17 +136,36 @@ export function ListStoryScrollTrackProvider({
   );
 
   useLayoutEffect(() => {
-    const scroller = scrollerRef.current;
+    const scroller = scrollTrackElement;
     if (!scroller || !enabled) {
       return;
     }
 
     const update = (): void => {
-      setViewportHeight(scroller.clientHeight);
+      syncScrollerMetrics(scroller);
     };
 
     return observeElementHeight(scroller, update);
-  }, [enabled, storyRevision, observeElementHeight]);
+  }, [enabled, scrollTrackElement, observeElementHeight, syncScrollerMetrics]);
+
+  useLayoutEffect(() => {
+    const scroller = scrollTrackElement;
+    if (!scroller || !enabled) {
+      return;
+    }
+
+    const onScroll = (): void => {
+      setScrollTop(scroller.scrollTop);
+      setViewportHeight(scroller.clientHeight);
+    };
+
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+
+    return () => {
+      scroller.removeEventListener('scroll', onScroll);
+    };
+  }, [enabled, scrollTrackElement]);
 
   useLayoutEffect(() => {
     if (!enabled) {
@@ -219,9 +249,10 @@ export function ListStoryScrollTrackProvider({
   const value = useMemo(
     (): IListStoryScrollTrackContextValue => ({
       scrollTrackLayout,
+      scrollTop,
       bindScrollTrackElement,
     }),
-    [scrollTrackLayout, bindScrollTrackElement],
+    [scrollTrackLayout, scrollTop, bindScrollTrackElement],
   );
 
   return (

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -19,6 +19,24 @@ import {
   getListStoryMarkdownSegmentsFromItems,
 } from '@/src/features/story/utils/storySegmentViewItems';
 
+const LIST_STORY_VIRTUAL_TRACK_DEBUG = true;
+
+function logVirtualTrackDebug(
+  event: string,
+  payload?: Record<string, unknown>,
+): void {
+  if (!LIST_STORY_VIRTUAL_TRACK_DEBUG) {
+    return;
+  }
+
+  if (payload) {
+    console.log(`[list-story-virtual-track] ${event}`, payload);
+    return;
+  }
+
+  console.log(`[list-story-virtual-track] ${event}`);
+}
+
 interface IListStoryScrollTrackContextValue {
   scrollTrackLayout: IListStoryScrollTrackLayout | null;
   scrollTop: number;
@@ -44,6 +62,7 @@ export function ListStoryScrollTrackProvider({
   const [viewportHeight, setViewportHeight] = useState(0);
   const [mapViewportHeight, setMapViewportHeight] = useState(0);
   const [scrollTop, setScrollTop] = useState(0);
+  const lastScrollLogAtRef = useRef(0);
 
   const currentSegmentIndex = useCurrentSegmentIndex(model);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
@@ -105,11 +124,17 @@ export function ListStoryScrollTrackProvider({
       scrollerRef.current = element;
       setScrollTrackElement(element);
       if (!element) {
+        logVirtualTrackDebug('scroller unbound');
         setViewportHeight(0);
         setScrollTop(0);
         return;
       }
 
+      logVirtualTrackDebug('scroller bound', {
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
+        scrollTop: element.scrollTop,
+      });
       syncScrollerMetrics(element);
     },
     [syncScrollerMetrics],
@@ -157,6 +182,22 @@ export function ListStoryScrollTrackProvider({
     const onScroll = (): void => {
       setScrollTop(scroller.scrollTop);
       setViewportHeight(scroller.clientHeight);
+
+      const now = Date.now();
+      if (now - lastScrollLogAtRef.current >= 250) {
+        lastScrollLogAtRef.current = now;
+        const maxScrollTop = Math.max(
+          0,
+          scroller.scrollHeight - scroller.clientHeight,
+        );
+        logVirtualTrackDebug('scroller scroll', {
+          scrollTop: scroller.scrollTop,
+          maxScrollTop,
+          atEnd: scroller.scrollTop >= maxScrollTop - 1,
+          clientHeight: scroller.clientHeight,
+          scrollHeight: scroller.scrollHeight,
+        });
+      }
     };
 
     scroller.addEventListener('scroll', onScroll, { passive: true });
@@ -245,6 +286,60 @@ export function ListStoryScrollTrackProvider({
 
     return buildScrollTrackLayout(heightsById);
   }, [enabled, items, viewportHeight, heightsById, buildScrollTrackLayout]);
+
+  useLayoutEffect(() => {
+    if (!scrollTrackLayout) {
+      logVirtualTrackDebug('layout cleared');
+      return;
+    }
+
+    const scroller = scrollerRef.current;
+    const virtualTrack = scroller?.querySelector('.jgis-story-virtual-track');
+    const virtualTrackEl =
+      virtualTrack instanceof HTMLElement ? virtualTrack : null;
+    const maxScrollTopEstimate = Math.max(
+      0,
+      scrollTrackLayout.scrollTrackHeight - viewportHeight,
+    );
+    const unreachableStarts = scrollTrackLayout.segments
+      .filter(segment => segment.start > maxScrollTopEstimate)
+      .map(segment => ({
+        index: segment.index,
+        id: segment.id,
+        start: segment.start,
+      }));
+
+    logVirtualTrackDebug('layout updated', {
+      scrollTrackHeight: scrollTrackLayout.scrollTrackHeight,
+      viewportHeight,
+      mapViewportHeight,
+      scrollTop,
+      maxScrollTopEstimate,
+      domScrollHeight: scroller?.scrollHeight ?? null,
+      domClientHeight: scroller?.clientHeight ?? null,
+      domMaxScrollTop:
+        scroller
+          ? Math.max(0, scroller.scrollHeight - scroller.clientHeight)
+          : null,
+      virtualTrackOffsetHeight: virtualTrackEl?.offsetHeight ?? null,
+      virtualTrackStyleHeight: virtualTrackEl?.style.height ?? null,
+      virtualTrackComputedHeight: virtualTrackEl
+        ? getComputedStyle(virtualTrackEl).height
+        : null,
+      unreachableStarts,
+      segments: scrollTrackLayout.segments.map((segment, i) => ({
+        index: segment.index,
+        id: segment.id,
+        mode: segment.contentMode,
+        height: segment.height,
+        measured: segment.measured,
+        start: segment.start,
+        end: segment.end,
+        gapAfter: segment.end - segment.start - segment.height,
+        isLast: i === scrollTrackLayout.segments.length - 1,
+      })),
+    });
+  }, [scrollTrackLayout, viewportHeight, mapViewportHeight, scrollTop]);
 
   const value = useMemo(
     (): IListStoryScrollTrackContextValue => ({

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -19,24 +19,6 @@ import {
   getListStoryMarkdownSegmentsFromItems,
 } from '@/src/features/story/utils/storySegmentViewItems';
 
-const LIST_STORY_VIRTUAL_TRACK_DEBUG = true;
-
-function logVirtualTrackDebug(
-  event: string,
-  payload?: Record<string, unknown>,
-): void {
-  if (!LIST_STORY_VIRTUAL_TRACK_DEBUG) {
-    return;
-  }
-
-  if (payload) {
-    console.log(`[list-story-virtual-track] ${event}`, payload);
-    return;
-  }
-
-  console.log(`[list-story-virtual-track] ${event}`);
-}
-
 interface IListStoryScrollTrackContextValue {
   scrollTrackLayout: IListStoryScrollTrackLayout | null;
   scrollTop: number;
@@ -62,7 +44,6 @@ export function ListStoryScrollTrackProvider({
   const [viewportHeight, setViewportHeight] = useState(0);
   const [mapViewportHeight, setMapViewportHeight] = useState(0);
   const [scrollTop, setScrollTop] = useState(0);
-  const lastScrollLogAtRef = useRef(0);
 
   const currentSegmentIndex = useCurrentSegmentIndex(model);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
@@ -124,17 +105,11 @@ export function ListStoryScrollTrackProvider({
       scrollerRef.current = element;
       setScrollTrackElement(element);
       if (!element) {
-        logVirtualTrackDebug('scroller unbound');
         setViewportHeight(0);
         setScrollTop(0);
         return;
       }
 
-      logVirtualTrackDebug('scroller bound', {
-        clientHeight: element.clientHeight,
-        scrollHeight: element.scrollHeight,
-        scrollTop: element.scrollTop,
-      });
       syncScrollerMetrics(element);
     },
     [syncScrollerMetrics],
@@ -182,22 +157,6 @@ export function ListStoryScrollTrackProvider({
     const onScroll = (): void => {
       setScrollTop(scroller.scrollTop);
       setViewportHeight(scroller.clientHeight);
-
-      const now = Date.now();
-      if (now - lastScrollLogAtRef.current >= 250) {
-        lastScrollLogAtRef.current = now;
-        const maxScrollTop = Math.max(
-          0,
-          scroller.scrollHeight - scroller.clientHeight,
-        );
-        logVirtualTrackDebug('scroller scroll', {
-          scrollTop: scroller.scrollTop,
-          maxScrollTop,
-          atEnd: scroller.scrollTop >= maxScrollTop - 1,
-          clientHeight: scroller.clientHeight,
-          scrollHeight: scroller.scrollHeight,
-        });
-      }
     };
 
     scroller.addEventListener('scroll', onScroll, { passive: true });
@@ -286,60 +245,6 @@ export function ListStoryScrollTrackProvider({
 
     return buildScrollTrackLayout(heightsById);
   }, [enabled, items, viewportHeight, heightsById, buildScrollTrackLayout]);
-
-  useLayoutEffect(() => {
-    if (!scrollTrackLayout) {
-      logVirtualTrackDebug('layout cleared');
-      return;
-    }
-
-    const scroller = scrollerRef.current;
-    const virtualTrack = scroller?.querySelector('.jgis-story-virtual-track');
-    const virtualTrackEl =
-      virtualTrack instanceof HTMLElement ? virtualTrack : null;
-    const maxScrollTopEstimate = Math.max(
-      0,
-      scrollTrackLayout.scrollTrackHeight - viewportHeight,
-    );
-    const unreachableStarts = scrollTrackLayout.segments
-      .filter(segment => segment.start > maxScrollTopEstimate)
-      .map(segment => ({
-        index: segment.index,
-        id: segment.id,
-        start: segment.start,
-      }));
-
-    logVirtualTrackDebug('layout updated', {
-      scrollTrackHeight: scrollTrackLayout.scrollTrackHeight,
-      viewportHeight,
-      mapViewportHeight,
-      scrollTop,
-      maxScrollTopEstimate,
-      domScrollHeight: scroller?.scrollHeight ?? null,
-      domClientHeight: scroller?.clientHeight ?? null,
-      domMaxScrollTop:
-        scroller
-          ? Math.max(0, scroller.scrollHeight - scroller.clientHeight)
-          : null,
-      virtualTrackOffsetHeight: virtualTrackEl?.offsetHeight ?? null,
-      virtualTrackStyleHeight: virtualTrackEl?.style.height ?? null,
-      virtualTrackComputedHeight: virtualTrackEl
-        ? getComputedStyle(virtualTrackEl).height
-        : null,
-      unreachableStarts,
-      segments: scrollTrackLayout.segments.map((segment, i) => ({
-        index: segment.index,
-        id: segment.id,
-        mode: segment.contentMode,
-        height: segment.height,
-        measured: segment.measured,
-        start: segment.start,
-        end: segment.end,
-        gapAfter: segment.end - segment.start - segment.height,
-        isLast: i === scrollTrackLayout.segments.length - 1,
-      })),
-    });
-  }, [scrollTrackLayout, viewportHeight, mapViewportHeight, scrollTop]);
 
   const value = useMemo(
     (): IListStoryScrollTrackContextValue => ({

--- a/packages/base/src/features/story/utils/computeListStoryScrollState.ts
+++ b/packages/base/src/features/story/utils/computeListStoryScrollState.ts
@@ -23,21 +23,47 @@ function clamp01(value: number): number {
   return Math.min(1, Math.max(0, value));
 }
 
-function findSegmentAtScrollCenter(
-  scrollCenter: number,
+/** Same-segment scroll (from and to pane share content; to pane is the stack tail). */
+export function isIntraSegmentScroll(
+  transition: IListStorySegmentTransition | null,
+): boolean {
+  return transition !== null && transition.fromIndex === transition.toIndex;
+}
+
+function findSegmentAtScrollTop(
+  scrollTop: number,
   segments: IListStoryScrollTrackSegment[],
 ): IListStoryScrollTrackSegment {
-  if (scrollCenter < segments[0].start) {
+  if (scrollTop < segments[0].start) {
     return segments[0];
   }
 
   for (const segment of segments) {
-    if (scrollCenter >= segment.start && scrollCenter < segment.end) {
+    if (scrollTop >= segment.start && scrollTop < segment.end) {
       return segment;
     }
   }
 
   return segments[segments.length - 1];
+}
+
+function buildIntraSegmentScrollState(
+  segment: IListStoryScrollTrackSegment,
+  scrollTop: number,
+): IListStoryScrollState {
+  const span = segment.end - segment.start;
+  const progress = span > 0 ? clamp01((scrollTop - segment.start) / span) : 0;
+
+  return {
+    activeIndex: segment.index,
+    segmentTransition: {
+      progress,
+      fromIndex: segment.index,
+      toIndex: segment.index,
+      fromMode: segment.contentMode,
+      toMode: segment.contentMode,
+    },
+  };
 }
 
 function computePairTransition(
@@ -90,41 +116,34 @@ export function computeListStoryScrollState({
     return null;
   }
 
-  if (segments.length === 1) {
-    return {
-      activeIndex: segments[0].index,
-      segmentTransition: null,
-    };
-  }
+  if (segments.length > 1) {
+    for (let i = 0; i < segments.length - 1; i++) {
+      const fromSegment = segments[i];
+      const toSegment = segments[i + 1];
 
-  for (let i = 0; i < segments.length - 1; i++) {
-    const fromSegment = segments[i];
-    const toSegment = segments[i + 1];
-
-    const pairTransition = computePairTransition(
-      scrollTop,
-      fromSegment,
-      toSegment,
-    );
-    if (!pairTransition) {
-      continue;
-    }
-
-    return {
-      activeIndex: pairTransition.activeIndex,
-      segmentTransition: buildSegmentTransitionPayload(
+      const pairTransition = computePairTransition(
+        scrollTop,
         fromSegment,
         toSegment,
-        pairTransition.progress,
-      ),
-    };
+      );
+
+      if (!pairTransition) {
+        continue;
+      }
+
+      return {
+        activeIndex: pairTransition.activeIndex,
+        segmentTransition: buildSegmentTransitionPayload(
+          fromSegment,
+          toSegment,
+          pairTransition.progress,
+        ),
+      };
+    }
   }
 
-  const scrollCenter = scrollTop + viewportHeight / 2;
-  const activeSegment = findSegmentAtScrollCenter(scrollCenter, segments);
-
-  return {
-    activeIndex: activeSegment.index,
-    segmentTransition: null,
-  };
+  return buildIntraSegmentScrollState(
+    findSegmentAtScrollTop(scrollTop, segments),
+    scrollTop,
+  );
 }

--- a/packages/base/src/mainview/components/MainViewMapSurface.tsx
+++ b/packages/base/src/mainview/components/MainViewMapSurface.tsx
@@ -1,0 +1,49 @@
+import { IDict } from '@jupytergis/schema';
+import { User } from '@jupyterlab/services';
+import React, { RefObject } from 'react';
+
+import CollaboratorPointers, {
+  ClientPointer,
+} from '@/src/mainview/CollaboratorPointers';
+import { FollowIndicator } from '@/src/mainview/FollowIndicator';
+import { LoadingOverlay } from '@/src/shared/components/loading';
+
+export interface IMainViewMapSurfaceProps {
+  mainViewRef: RefObject<HTMLDivElement>;
+  loading: boolean;
+  remoteUser?: User.IIdentity | null;
+  clientPointers: IDict<ClientPointer>;
+  spectaMobileTouch: boolean;
+  onTouchStart?: (event: React.TouchEvent) => void;
+  onTouchEnd?: (event: React.TouchEvent) => void;
+  children: React.ReactNode;
+}
+
+export function MainViewMapSurface({
+  mainViewRef,
+  loading,
+  remoteUser,
+  clientPointers,
+  spectaMobileTouch,
+  onTouchStart,
+  onTouchEnd,
+  children,
+}: IMainViewMapSurfaceProps): JSX.Element {
+  return (
+    <div
+      ref={mainViewRef}
+      className="jGIS-Mainview data-jgis-keybinding"
+      tabIndex={0}
+      style={{
+        border: remoteUser ? `solid 3px ${remoteUser.color}` : 'unset',
+      }}
+      onTouchStart={spectaMobileTouch ? onTouchStart : undefined}
+      onTouchEnd={spectaMobileTouch ? onTouchEnd : undefined}
+    >
+      <LoadingOverlay loading={loading} />
+      <FollowIndicator remoteUser={remoteUser} />
+      <CollaboratorPointers clients={clientPointers} />
+      {children}
+    </div>
+  );
+}

--- a/packages/base/src/mainview/components/MainViewOverlayLayer.tsx
+++ b/packages/base/src/mainview/components/MainViewOverlayLayer.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+const DRAW_GEOMETRIES = ['Point', 'LineString', 'Polygon'] as const;
+
+export interface IMainViewOverlayLayerProps {
+  annotationFloaters: React.ReactNode;
+  featureFloaters: React.ReactNode;
+  editingVectorLayer: boolean;
+  drawGeometryLabel: string | undefined;
+  onDrawGeometryTypeChange: (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => void;
+}
+
+export function MainViewOverlayLayer({
+  annotationFloaters,
+  featureFloaters,
+  editingVectorLayer,
+  drawGeometryLabel,
+  onDrawGeometryTypeChange,
+}: IMainViewOverlayLayerProps): JSX.Element {
+  return (
+    <>
+      {annotationFloaters}
+      {featureFloaters}
+      {editingVectorLayer ? (
+        <div className="jgis-geometry-type-selector-overlay">
+          <select
+            className="geometry-type-selector"
+            id="geometry-type-selector"
+            value={drawGeometryLabel ?? ''}
+            onChange={onDrawGeometryTypeChange}
+          >
+            <option value="" disabled hidden>
+              Geometry type
+            </option>
+            {DRAW_GEOMETRIES.map(geometryType => (
+              <option key={geometryType} value={geometryType}>
+                {geometryType}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/packages/base/src/mainview/components/MainViewSidePanels.tsx
+++ b/packages/base/src/mainview/components/MainViewSidePanels.tsx
@@ -1,0 +1,79 @@
+import {
+  IAnnotationModel,
+  IJGISFormSchemaRegistry,
+  IJGISLayer,
+  IJupyterGISModel,
+  IJupyterGISSettings,
+} from '@jupytergis/schema';
+import { IStateDB } from '@jupyterlab/statedb';
+import { CommandRegistry } from '@lumino/commands';
+import React from 'react';
+
+import type { PatchGeoJSONFeatureProperties } from '@/src/mainview/geoJsonFeaturePatch';
+import { LeftPanel, MergedPanel, RightPanel } from '@/src/workspace/panels';
+
+export interface IMainViewSidePanelsProps {
+  model: IJupyterGISModel;
+  commands: CommandRegistry;
+  settings: IJupyterGISSettings;
+  showMergedMobilePanel: boolean;
+  state?: IStateDB;
+  formSchemaRegistry?: IJGISFormSchemaRegistry;
+  annotationModel?: IAnnotationModel;
+  addLayer: (id: string, layer: IJGISLayer, index: number) => Promise<void>;
+  removeLayer: (id: string) => void;
+  patchGeoJSONFeatureProperties: PatchGeoJSONFeatureProperties;
+}
+
+export function MainViewSidePanels({
+  model,
+  commands,
+  settings,
+  showMergedMobilePanel,
+  state,
+  formSchemaRegistry,
+  annotationModel,
+  addLayer,
+  removeLayer,
+  patchGeoJSONFeatureProperties,
+}: IMainViewSidePanelsProps): JSX.Element {
+  if (showMergedMobilePanel) {
+    return (
+      <MergedPanel
+        model={model}
+        commands={commands}
+        state={state!}
+        settings={settings}
+        formSchemaRegistry={formSchemaRegistry!}
+        annotationModel={annotationModel!}
+        addLayer={addLayer}
+        removeLayer={removeLayer}
+      />
+    );
+  }
+
+  return (
+    <>
+      {state ? (
+        <LeftPanel
+          model={model}
+          commands={commands}
+          state={state}
+          settings={settings}
+        />
+      ) : null}
+      {formSchemaRegistry && annotationModel ? (
+        <RightPanel
+          model={model}
+          commands={commands}
+          formSchemaRegistry={formSchemaRegistry}
+          annotationModel={annotationModel}
+          addLayer={addLayer}
+          removeLayer={removeLayer}
+          settings={settings}
+          patchGeoJSONFeatureProperties={patchGeoJSONFeatureProperties}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/packages/base/src/mainview/components/MainViewSpectaPanel.tsx
+++ b/packages/base/src/mainview/components/MainViewSpectaPanel.tsx
@@ -1,0 +1,52 @@
+import { IJGISLayer, IJupyterGISModel } from '@jupytergis/schema';
+import React, { RefObject } from 'react';
+
+import { SpectaPanel } from '@/src/features/story/SpectaPanel';
+import type { IStoryViewerPanelHandle } from '@/src/features/story/StoryViewerPanel';
+import type { IListStorySegmentTransition } from '@/src/features/story/types/types';
+
+export interface IMainViewSpectaPanelProps {
+  model: IJupyterGISModel;
+  isSpecta: boolean;
+  isMobile: boolean;
+  initialLayersReady: boolean;
+  containerRef: RefObject<HTMLDivElement>;
+  storyViewerPanelRef: RefObject<IStoryViewerPanelHandle>;
+  addLayer: (id: string, layer: IJGISLayer, index: number) => Promise<void>;
+  removeLayer: (id: string) => void;
+  onSegmentTransitionEnd: () => void;
+  onSegmentTransitionChange: (
+    payload: IListStorySegmentTransition | null,
+  ) => void;
+}
+
+export function MainViewSpectaPanel({
+  model,
+  isSpecta,
+  isMobile,
+  initialLayersReady,
+  containerRef,
+  storyViewerPanelRef,
+  addLayer,
+  removeLayer,
+  onSegmentTransitionEnd,
+  onSegmentTransitionChange,
+}: IMainViewSpectaPanelProps): JSX.Element | null {
+  if (!initialLayersReady) {
+    return null;
+  }
+
+  return (
+    <SpectaPanel
+      model={model}
+      isSpecta={isSpecta}
+      isMobile={isMobile}
+      onSegmentTransitionEnd={onSegmentTransitionEnd}
+      containerRef={containerRef}
+      storyViewerPanelRef={storyViewerPanelRef}
+      addLayer={addLayer}
+      removeLayer={removeLayer}
+      onSegmentTransitionChange={onSegmentTransitionChange}
+    />
+  );
+}

--- a/packages/base/src/mainview/components/MainViewStoryStage.tsx
+++ b/packages/base/src/mainview/components/MainViewStoryStage.tsx
@@ -1,0 +1,47 @@
+import { IJupyterGISModel } from '@jupytergis/schema';
+import React, { RefObject } from 'react';
+
+import { ListStoryStageOverlay } from '@/src/features/story/components/ListStoryStageOverlay';
+import { ListStoryScrollTrackProvider } from '@/src/features/story/context/ListStoryScrollTrackContext';
+import type { IListStorySegmentTransition } from '@/src/features/story/types/types';
+
+export interface IMainViewStoryStageProps {
+  model: IJupyterGISModel;
+  isListStory: boolean;
+  segmentTransition: IListStorySegmentTransition | null;
+  stageRef: RefObject<HTMLDivElement>;
+  controlsToolbarRef: RefObject<HTMLDivElement>;
+  panels: React.ReactNode;
+}
+
+export function MainViewStoryStage({
+  model,
+  isListStory,
+  segmentTransition,
+  stageRef,
+  controlsToolbarRef,
+  panels,
+}: IMainViewStoryStageProps): JSX.Element {
+  return (
+    <div
+      ref={stageRef}
+      className="jgis-mainview-stage"
+      style={{
+        width: '100%',
+        height: '100%',
+        position: 'relative',
+      }}
+    >
+      <ListStoryScrollTrackProvider model={model} enabled={isListStory}>
+        {isListStory ? (
+          <ListStoryStageOverlay
+            model={model}
+            segmentTransition={segmentTransition}
+          />
+        ) : null}
+        <div className="jgis-panels-wrapper">{panels}</div>
+        <div ref={controlsToolbarRef} className="jgis-controls-toolbar"></div>
+      </ListStoryScrollTrackProvider>
+    </div>
+  );
+}

--- a/packages/base/src/mainview/components/PositionedFloater.tsx
+++ b/packages/base/src/mainview/components/PositionedFloater.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface IPositionedFloaterProps {
+  id: string;
+  className: string;
+  left: number;
+  top: number;
+  children: React.ReactNode;
+}
+
+export function PositionedFloater({
+  id,
+  className,
+  left,
+  top,
+  children,
+}: IPositionedFloaterProps): JSX.Element {
+  return (
+    <div
+      id={id}
+      className={className}
+      style={{
+        left,
+        top,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -131,7 +131,6 @@ import { CommandIDs } from '@/src/constants';
 import AnnotationFloater from '@/src/features/annotations/components/AnnotationFloater';
 import FeatureFloater from '@/src/features/identify/components/FeatureFloater';
 import { getFeatureIdentifier } from '@/src/features/identify/utils/getFeatureIdentifier';
-import { LoadingOverlay } from '@/src/shared/components/loading';
 import useMediaQuery from '@/src/shared/hooks/useMediaQuery';
 import { markerIcon } from '@/src/shared/icons';
 import {
@@ -143,8 +142,13 @@ import {
   throttle,
 } from '@/src/tools';
 import StatusBar from '@/src/workspace/statusbar/StatusBar';
-import CollaboratorPointers, { ClientPointer } from './CollaboratorPointers';
-import { FollowIndicator } from './FollowIndicator';
+import { ClientPointer } from './CollaboratorPointers';
+import { MainViewSidePanels } from './components/MainViewSidePanels';
+import { MainViewMapSurface } from './components/MainViewMapSurface';
+import { MainViewOverlayLayer } from './components/MainViewOverlayLayer';
+import { PositionedFloater } from './components/PositionedFloater';
+import { MainViewSpectaPanel } from './components/MainViewSpectaPanel';
+import { MainViewStoryStage } from './components/MainViewStoryStage';
 import { OpenEOTileLayer, OpenEOTileSource } from './OpenEOTileLayer';
 import TemporalSlider from './TemporalSlider';
 import {
@@ -160,13 +164,8 @@ import {
   grammarToOLStyle,
 } from '../features/layers/symbology/grammarToOLStyle';
 import { DEFAULT_FLAT_STYLE } from '../features/layers/symbology/styleBuilder';
-import { SpectaPanel } from '../features/story/SpectaPanel';
 import type { IStoryViewerPanelHandle } from '../features/story/StoryViewerPanel';
-import { ListStoryStageOverlay } from '../features/story/components/ListStoryStageOverlay';
-import { ListStoryScrollTrackProvider } from '../features/story/context/ListStoryScrollTrackContext';
 import type { IListStorySegmentTransition } from '../features/story/types/types';
-import { STORY_TYPE } from '../types';
-import { LeftPanel, MergedPanel, RightPanel } from '../workspace/panels';
 
 type OlLayerTypes =
   | TileLayer
@@ -178,8 +177,6 @@ type OlLayerTypes =
   | StacLayer
   | ImageLayer<any>
   | LayerGroup;
-
-const DRAW_GEOMETRIES = ['Point', 'LineString', 'Polygon'] as const;
 
 const drawInteractionStyle = new Style({
   fill: new Fill({
@@ -3759,212 +3756,157 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     await this.updateSource(id, source);
   };
 
+  private _renderAnnotationFloaters(): React.ReactNode {
+    const annotationModel = this._model.annotationModel;
+    if (!annotationModel) {
+      return null;
+    }
+
+    return Object.entries(this.state.annotations).map(([key, annotation]) => {
+      const screenPosition = this._computeAnnotationPosition(annotation);
+      if (!screenPosition) {
+        return null;
+      }
+
+      return (
+        <PositionedFloater
+          key={key}
+          id={key}
+          className="jGIS-Popup-Wrapper"
+          left={screenPosition.x}
+          top={screenPosition.y}
+        >
+          <AnnotationFloater itemId={key} annotationModel={annotationModel} />
+        </PositionedFloater>
+      );
+    });
+  }
+
+  private _renderFeatureFloaters(): React.ReactNode {
+    return this._getVisibleDrawIdentifiedFeatures().map(
+      ([floaterKey, feature]) => {
+        const screenPosition = this._computeFeatureFloaterPosition(feature);
+        if (!screenPosition) {
+          return null;
+        }
+
+        const id = `feature-floater-${floaterKey}`;
+        return (
+          <PositionedFloater
+            key={id}
+            id={id}
+            className="jGIS-Popup-Wrapper jGIS-FeatureFloater-Wrapper"
+            left={screenPosition.x}
+            top={screenPosition.y}
+          >
+            <FeatureFloater feature={feature} />
+          </PositionedFloater>
+        );
+      },
+    );
+  }
+
   render(): JSX.Element {
+    const {
+      clientPointers,
+      displayTemporalController,
+      drawGeometryLabel,
+      editingVectorLayer,
+      filterStates,
+      initialLayersReady,
+      isSpectaPresentation,
+      jgisSettings,
+      loading,
+      loadingLayer,
+      remoteUser,
+      scale,
+      segmentTransition,
+      viewProjection,
+    } = this.state;
+    const { isMobile } = this.props;
+    const selectedStory = this._model.getSelectedStory().story;
+    const isListStory =
+      isSpectaPresentation && selectedStory?.storyType === 'list';
+    const showSidePanels = !isSpectaPresentation;
+    const showMergedMobilePanel =
+      isMobile &&
+      Boolean(this._state) &&
+      Boolean(this._formSchemaRegistry) &&
+      Boolean(this._annotationModel);
+    const spectaMobileTouch = isSpectaPresentation && isMobile;
+
     return (
       <>
-        {Object.entries(this.state.annotations).map(([key, annotation]) => {
-          if (!this._model.annotationModel) {
-            return null;
-          }
-          const screenPosition = this._computeAnnotationPosition(annotation);
-          return (
-            screenPosition && (
-              <div
-                key={key}
-                id={key}
-                style={{
-                  left: screenPosition.x,
-                  top: screenPosition.y,
-                }}
-                className={'jGIS-Popup-Wrapper'}
-              >
-                <AnnotationFloater
-                  itemId={key}
-                  annotationModel={this._model.annotationModel}
-                />
-              </div>
-            )
-          );
-        })}
-        {this._getVisibleDrawIdentifiedFeatures().map(
-          ([floaterKey, feature]) => {
-            const screenPosition = this._computeFeatureFloaterPosition(feature);
-            if (!screenPosition) {
-              return null;
-            }
-
-            return (
-              <div
-                key={`feature-floater-${floaterKey}`}
-                id={`feature-floater-${floaterKey}`}
-                style={{
-                  left: screenPosition.x,
-                  top: screenPosition.y,
-                }}
-                className="jGIS-Popup-Wrapper jGIS-FeatureFloater-Wrapper"
-              >
-                <FeatureFloater feature={feature} />
-              </div>
-            );
-          },
-        )}
-
-        {this.state.editingVectorLayer && (
-          <div className="jgis-geometry-type-selector-overlay">
-            <select
-              className="geometry-type-selector"
-              id="geometry-type-selector"
-              value={this.state.drawGeometryLabel ?? ''}
-              onChange={this._handleDrawGeometryTypeChange}
-            >
-              <option value="" disabled hidden>
-                Geometry type
-              </option>
-              {DRAW_GEOMETRIES.map(geometryType => (
-                <option key={geometryType} value={geometryType}>
-                  {geometryType}
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
+        <MainViewOverlayLayer
+          annotationFloaters={this._renderAnnotationFloaters()}
+          featureFloaters={this._renderFeatureFloaters()}
+          editingVectorLayer={editingVectorLayer}
+          drawGeometryLabel={drawGeometryLabel}
+          onDrawGeometryTypeChange={this._handleDrawGeometryTypeChange}
+        />
 
         <div className="jGIS-Mainview-Container">
-          {this.state.displayTemporalController && (
-            <TemporalSlider
-              model={this._model}
-              filterStates={this.state.filterStates}
-            />
-          )}
-          <div
-            ref={this.mainViewRef}
-            className="jGIS-Mainview data-jgis-keybinding"
-            tabIndex={0}
-            style={{
-              border: this.state.remoteUser
-                ? `solid 3px ${this.state.remoteUser.color}`
-                : 'unset',
-            }}
-            onTouchStart={
-              this.state.isSpectaPresentation && this.props.isMobile
-                ? this._handleSpectaTouchStart
-                : undefined
-            }
-            onTouchEnd={
-              this.state.isSpectaPresentation && this.props.isMobile
-                ? this._handleSpectaTouchEnd
-                : undefined
-            }
+          {displayTemporalController ? (
+            <TemporalSlider model={this._model} filterStates={filterStates} />
+          ) : null}
+          <MainViewMapSurface
+            mainViewRef={this.mainViewRef}
+            loading={loading}
+            remoteUser={remoteUser}
+            clientPointers={clientPointers}
+            spectaMobileTouch={spectaMobileTouch}
+            onTouchStart={this._handleSpectaTouchStart}
+            onTouchEnd={this._handleSpectaTouchEnd}
           >
-            <LoadingOverlay loading={this.state.loading} />
-            <FollowIndicator remoteUser={this.state.remoteUser} />
-            <CollaboratorPointers clients={this.state.clientPointers} />
-
-            <div
-              ref={this.divRef}
-              className="jgis-mainview-stage"
-              style={{
-                width: '100%',
-                height: '100%',
-                position: 'relative',
-              }}
-            >
-              <ListStoryScrollTrackProvider
-                model={this._model}
-                enabled={
-                  this.state.isSpectaPresentation &&
-                  this._model.getSelectedStory().story?.storyType ===
-                    STORY_TYPE.verticalScroll
-                }
-              >
-                {this.state.isSpectaPresentation &&
-                this._model.getSelectedStory().story?.storyType ===
-                  STORY_TYPE.verticalScroll ? (
-                  <ListStoryStageOverlay
+            <MainViewStoryStage
+              model={this._model}
+              isListStory={isListStory}
+              segmentTransition={segmentTransition}
+              stageRef={this.divRef}
+              controlsToolbarRef={this.controlsToolbarRef}
+              panels={
+                showSidePanels ? (
+                  <MainViewSidePanels
                     model={this._model}
-                    segmentTransition={this.state.segmentTransition}
+                    commands={this._mainViewModel.commands}
+                    settings={jgisSettings}
+                    showMergedMobilePanel={showMergedMobilePanel}
+                    state={this._state}
+                    formSchemaRegistry={this._formSchemaRegistry}
+                    annotationModel={this._annotationModel}
+                    addLayer={this.addLayer.bind(this)}
+                    removeLayer={this.removeLayer.bind(this)}
+                    patchGeoJSONFeatureProperties={
+                      this._patchGeoJSONFeatureProperties
+                    }
                   />
-                ) : null}
-                <div className="jgis-panels-wrapper">
-                  {!this.state.isSpectaPresentation ? (
-                    <>
-                      {this.props.isMobile &&
-                      this._state &&
-                      this._formSchemaRegistry &&
-                      this._annotationModel ? (
-                        <MergedPanel
-                          model={this._model}
-                          commands={this._mainViewModel.commands}
-                          state={this._state}
-                          settings={this.state.jgisSettings}
-                          formSchemaRegistry={this._formSchemaRegistry}
-                          annotationModel={this._annotationModel}
-                          addLayer={this.addLayer.bind(this)}
-                          removeLayer={this.removeLayer.bind(this)}
-                        />
-                      ) : (
-                        <>
-                          {this._state && (
-                            <LeftPanel
-                              model={this._model}
-                              commands={this._mainViewModel.commands}
-                              state={this._state}
-                              settings={this.state.jgisSettings}
-                            />
-                          )}
-                          {this._formSchemaRegistry &&
-                            this._annotationModel && (
-                              <RightPanel
-                                model={this._model}
-                                commands={this._mainViewModel.commands}
-                                formSchemaRegistry={this._formSchemaRegistry}
-                                annotationModel={this._annotationModel}
-                                addLayer={this.addLayer.bind(this)}
-                                removeLayer={this.removeLayer.bind(this)}
-                                settings={this.state.jgisSettings}
-                                patchGeoJSONFeatureProperties={
-                                  this._patchGeoJSONFeatureProperties
-                                }
-                              />
-                            )}
-                        </>
-                      )}
-                    </>
-                  ) : (
-                    this.state.initialLayersReady && (
-                      <SpectaPanel
-                        model={this._model}
-                        isSpecta={this.state.isSpectaPresentation}
-                        isMobile={this.props.isMobile}
-                        onSegmentTransitionEnd={() =>
-                          this._clearStoryScrollGuard()
-                        }
-                        containerRef={this.spectaContainerRef}
-                        storyViewerPanelRef={this.storyViewerPanelRef}
-                        addLayer={this._addLayerForPanels}
-                        removeLayer={this._removeLayerForPanels}
-                        onSegmentTransitionChange={
-                          this._handleSegmentTransitionChange
-                        }
-                      />
-                    )
-                  )}
-                </div>
-                <div
-                  ref={this.controlsToolbarRef}
-                  className="jgis-controls-toolbar"
-                ></div>
-              </ListStoryScrollTrackProvider>
-            </div>
-          </div>
-          {!this.state.isSpectaPresentation && (
+                ) : (
+                  <MainViewSpectaPanel
+                    model={this._model}
+                    isSpecta={isSpectaPresentation}
+                    isMobile={isMobile}
+                    initialLayersReady={initialLayersReady}
+                    containerRef={this.spectaContainerRef}
+                    storyViewerPanelRef={this.storyViewerPanelRef}
+                    addLayer={this._addLayerForPanels}
+                    removeLayer={this._removeLayerForPanels}
+                    onSegmentTransitionEnd={this._clearStoryScrollGuard}
+                    onSegmentTransitionChange={
+                      this._handleSegmentTransitionChange
+                    }
+                  />
+                )
+              }
+            />
+          </MainViewMapSurface>
+          {!isSpectaPresentation ? (
             <StatusBar
               jgisModel={this._model}
-              loading={this.state.loadingLayer}
-              projection={this.state.viewProjection}
-              scale={this.state.scale}
+              loading={loadingLayer}
+              projection={viewProjection}
+              scale={scale}
             />
-          )}
+          ) : null}
         </div>
       </>
     );

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -3827,7 +3827,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const { isMobile } = this.props;
     const selectedStory = this._model.getSelectedStory().story;
     const isListStory =
-      isSpectaPresentation && selectedStory?.storyType === STORY_TYPE.list;
+      isSpectaPresentation &&
+      selectedStory?.storyType === STORY_TYPE.verticalScroll;
     const showSidePanels = !isSpectaPresentation;
     const showMergedMobilePanel =
       isMobile &&

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -143,14 +143,14 @@ import {
 } from '@/src/tools';
 import StatusBar from '@/src/workspace/statusbar/StatusBar';
 import { ClientPointer } from './CollaboratorPointers';
-import { MainViewSidePanels } from './components/MainViewSidePanels';
-import { MainViewMapSurface } from './components/MainViewMapSurface';
-import { MainViewOverlayLayer } from './components/MainViewOverlayLayer';
-import { PositionedFloater } from './components/PositionedFloater';
-import { MainViewSpectaPanel } from './components/MainViewSpectaPanel';
-import { MainViewStoryStage } from './components/MainViewStoryStage';
 import { OpenEOTileLayer, OpenEOTileSource } from './OpenEOTileLayer';
 import TemporalSlider from './TemporalSlider';
+import { MainViewMapSurface } from './components/MainViewMapSurface';
+import { MainViewOverlayLayer } from './components/MainViewOverlayLayer';
+import { MainViewSidePanels } from './components/MainViewSidePanels';
+import { MainViewSpectaPanel } from './components/MainViewSpectaPanel';
+import { MainViewStoryStage } from './components/MainViewStoryStage';
+import { PositionedFloater } from './components/PositionedFloater';
 import {
   createGeoJSONFeaturePatcher,
   type PatchGeoJSONFeatureProperties,
@@ -166,6 +166,7 @@ import {
 import { DEFAULT_FLAT_STYLE } from '../features/layers/symbology/styleBuilder';
 import type { IStoryViewerPanelHandle } from '../features/story/StoryViewerPanel';
 import type { IListStorySegmentTransition } from '../features/story/types/types';
+import { STORY_TYPE } from '../types';
 
 type OlLayerTypes =
   | TileLayer
@@ -3826,7 +3827,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const { isMobile } = this.props;
     const selectedStory = this._model.getSelectedStory().story;
     const isListStory =
-      isSpectaPresentation && selectedStory?.storyType === 'list';
+      isSpectaPresentation && selectedStory?.storyType === STORY_TYPE.list;
     const showSidePanels = !isSpectaPresentation;
     const showMergedMobilePanel =
       isMobile &&

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -352,6 +352,30 @@
   right: 0.125rem;
 }
 
+/* Full-viewport touch scroll driver; segment UI is on ListStoryStageOverlay. */
+.jgis-story-mobile-list-scroll {
+  position: fixed;
+  inset: 0;
+  z-index: 6;
+  width: 100%;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+  background: transparent;
+}
+
+/* Mobile list only (scroll driver mounted); desktop list keeps 25% map cards. */
+.jgis-mainview-stage:has(.jgis-story-mobile-list-scroll)
+  .jgis-story-map-scroll-pane {
+  padding-left: 1rem;
+}
+
+.jgis-mainview-stage:has(.jgis-story-mobile-list-scroll)
+  .jgis-story-map-overlay-content {
+  width: fit-content;
+}
+
 /* Hierarchy: .form-group > .jp-FormGroup-content > .jp-objectFieldWrapper > #jgis-source-properties-field */
 .form-group:has(
   .jp-FormGroup-content .jp-objectFieldWrapper #jgis-source-properties-field

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -308,7 +308,6 @@
   )
   .jgis-story-stage-overlay-content {
   box-sizing: border-box;
-  overflow: auto;
 }
 
 .jgis-story-markdown-measure-host {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -374,6 +374,16 @@
 .jgis-mainview-stage:has(.jgis-story-mobile-list-scroll)
   .jgis-story-map-overlay-content {
   width: fit-content;
+  background-color: color-mix(
+    in srgb,
+    var(--jgis-specta-bg-color, var(--jp-layout-color0)) 90%,
+    transparent
+  );
+}
+
+.jgis-mainview-stage:has(.jgis-story-mobile-list-scroll)
+  .jgis-story-viewer-image-section {
+  opacity: 0.9;
 }
 
 /* Hierarchy: .form-group > .jp-FormGroup-content > .jp-objectFieldWrapper > #jgis-source-properties-field */


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Adds mobile view for the vertical scroll presentation mode in specta. 

Also throws in a little refactor of `mainView`s `render` function because that thing was a mess. 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1463.org.readthedocs.build/en/1463/
💡 JupyterLite preview: https://jupytergis--1463.org.readthedocs.build/en/1463/lite
💡 Specta preview: https://jupytergis--1463.org.readthedocs.build/en/1463/lite/specta

<!-- readthedocs-preview jupytergis end -->