### PR TITLE
Fix About page comparison accuracy

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -46,6 +46,11 @@ for server-side raster processing at scale.
 
 ## Architecture
 
+JupyterGIS is built on top of the [Jupyter](https://jupyter.org/) ecosystem.
+This gives it browser-based UI, kernel integration for server-side computation, real-time collaboration infrastructure, AI integration (via [Jupyter AI](https://github.com/jupyterlab/jupyter-ai) / [JupyterLite AI](https://github.com/jupyterlite/jupyterlite-ai)), and deployment options ranging from zero-install browser links ([JupyterLite](https://jupyterlite.readthedocs.io/)) to multi-user servers ([JupyterHub](https://jupyterhub.readthedocs.io/)).
+However, JupyterGIS can also be used independently — as a standalone web application or an embeddable map widget — without requiring a full Jupyter environment.
+The following sections illustrate the key architectural choices that follow from this foundation.
+
 ### Browser-first
 
 JupyterGIS is browser-native by default, using WebAssembly to run tools like [GDAL](https://gdal.org) client-side, and it can be deployed as a zero-server JupyterLite site with full Python capabilities.

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -47,7 +47,7 @@ for server-side raster processing at scale.
 ## Architecture
 
 JupyterGIS is built on top of the [Jupyter](https://jupyter.org/) ecosystem.
-This gives it browser-based UI, kernel integration for server-side computation, real-time collaboration infrastructure, AI integration (via [Jupyter AI](https://github.com/jupyterlab/jupyter-ai) / [JupyterLite AI](https://github.com/jupyterlite/jupyterlite-ai)), and deployment options ranging from zero-install browser links ([JupyterLite](https://jupyterlite.readthedocs.io/)) to multi-user servers ([JupyterHub](https://jupyterhub.readthedocs.io/)).
+This gives it browser-based UI, kernel integration for server-side computation, real-time collaboration infrastructure, AI integration (via [Jupyter AI](https://github.com/jupyterlab/jupyter-ai) / [JupyterLite AI](https://github.com/jupyterlite/ai)), and deployment options ranging from zero-install browser links ([JupyterLite](https://jupyterlite.readthedocs.io/)) to multi-user servers ([JupyterHub](https://jupyterhub.readthedocs.io/)).
 However, JupyterGIS can also be used independently — as a standalone web application or an embeddable map widget — without requiring a full Jupyter environment.
 The following sections illustrate the key architectural choices that follow from this foundation.
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -133,18 +133,6 @@ Felt does not support scripting or integration with computational workflows.
 **JupyterGIS** shares the browser-first collaborative approach but is fully open source, community-driven with multiple organizational stakeholders, self-hostable on any infrastructure, and scriptable.
 It adds integration with Jupyter kernels for server-side processing and deep ties to the scientific Python ecosystem.
 
-### GeoLibre
-
-[GeoLibre](https://geolibre.app/) is a lightweight, open-source desktop GIS built with Tauri, React, and MapLibre GL JS.
-It uses DuckDB-WASM for client-side geospatial processing and supports a wide range of formats including GeoParquet, PMTiles, and Cloud-Optimized GeoTIFFs.
-
-**GeoLibre** is desktop-first and single-user — a standalone application focused on local data exploration and visualization.
-It does not support real-time collaboration or integration with computational notebooks.
-
-**JupyterGIS** is browser-first, collaborative, and deeply integrated with the Jupyter ecosystem.
-Where GeoLibre focuses on lightweight local exploration, JupyterGIS is designed for team workflows that combine map visualization with computational analysis in notebooks.
-Both projects are open source and share a commitment to modern web technologies and open formats.
-
 ### Rendering libraries (MapLibre, OpenLayers, Leaflet, ...)
 
 [MapLibre](https://maplibre.org/), [OpenLayers](https://openlayers.org/), [Leaflet](https://leafletjs.com/), and similar projects are map rendering libraries — they draw maps, not build GIS environments.

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -82,6 +82,7 @@ This design allows modification, adaptation, and integration into other systems 
 ## Comparison with other GIS tools
 
 These architectural choices place JupyterGIS in a unique position in the GIS landscape — at the intersection of collaborative editing, computational notebooks, and cloud-native geospatial.
+If you believe any of these comparisons is inaccurate, please [open an issue](https://github.com/geojupyter/jupytergis/issues/new) so we can correct it.
 
 ### QGIS
 
@@ -100,10 +101,10 @@ It is highly scriptable — via Python and natural-language prompts (Jupyter AI 
 
 [ArcGIS](https://www.esri.com/en-us/arcgis/about-arcgis/overview) (Esri) is the industry-standard commercial GIS platform — powerful, feature-complete, and mature.
 
-**ArcGIS** is proprietary with per-seat licensing and a deep ecosystem (Living Atlas, ArcGIS Online).
-It is the proprietary default choice for many organizations already invested in Esri infrastructure.
+**ArcGIS** is proprietary and closed-source with per-seat licensing and a deep ecosystem (Living Atlas, ArcGIS Online).
+It is the default choice for many organizations already invested in Esri infrastructure, but it cannot be inspected, modified, or independently audited, and it is governed by a single company.
 
-**JupyterGIS**, in contrast, is free, open source, built for modification and integration.
+**JupyterGIS**, in contrast, is free, open source, community-driven with multiple organizational stakeholders, and built for modification and integration.
 It is also browser-first, scriptable, cloud-native, and can connect to powerful backend kernels.
 Due to its open nature, JupyterGIS excels when you need tight integration with other systems, browser-first access, customization and sovereign infrastructure that you control.
 
@@ -111,7 +112,7 @@ Due to its open nature, JupyterGIS excels when you need tight integration with o
 
 [Google Earth Engine](https://earthengine.google.com/) (GEE) is a cloud platform for planetary-scale geospatial analysis, backed by Google's data catalog and compute infrastructure.
 
-**GEE** is proprietary and tightly coupled to Google's infrastructure. It offers an unmatched data catalog but is difficult to integrate with external systems, difficult to customize, and cannot be self-hosted.
+**GEE** is proprietary, closed-source, and tightly coupled to Google's infrastructure. It offers an unmatched data catalog but cannot be inspected or modified, is difficult to integrate with external systems, and cannot be self-hosted. It is governed by a single company.
 
 **JupyterGIS** integrates with open-source tools for compute-heavy workloads: Jupyter kernels for arbitrary server-side processing, [OpenEO](https://openeo.org/) for cloud processing, and [TiTiler](https://developmentseed.org/titiler/) for dynamic raster tile serving backed by the Pangeo stack.
 JupyterGIS is open source, self-hostable, and built for integration — offering cloud-native processing via open standards rather than a single vendor's infrastructure.
@@ -120,9 +121,24 @@ JupyterGIS is open source, self-hostable, and built for integration — offering
 
 [Felt](https://felt.com) is a modern, collaborative web-based mapping tool focused on ease of use for non-technical users.
 
-**Felt** is a proprietary SaaS with a polished, Miro-like experience for visual collaboration. It does not support scripting, self-hosting, or integration with computational workflows.
+**Felt** is a proprietary SaaS with a polished, Miro-like experience for visual collaboration.
+It offers enterprise VPC deployment for regulated industries, but the source code is closed — it cannot be inspected, modified, or independently audited, and it is governed by a single company.
+Felt does not support scripting or integration with computational workflows.
 
-**JupyterGIS** shares the browser-first collaborative approach but is open source, self-hostable, and scriptable. It adds integration with Jupyter kernels for server-side processing and deep ties to the scientific Python ecosystem.
+**JupyterGIS** shares the browser-first collaborative approach but is fully open source, community-driven with multiple organizational stakeholders, self-hostable on any infrastructure, and scriptable.
+It adds integration with Jupyter kernels for server-side processing and deep ties to the scientific Python ecosystem.
+
+### GeoLibre
+
+[GeoLibre](https://geolibre.app/) is a lightweight, open-source desktop GIS built with Tauri, React, and MapLibre GL JS.
+It uses DuckDB-WASM for client-side geospatial processing and supports a wide range of formats including GeoParquet, PMTiles, and Cloud-Optimized GeoTIFFs.
+
+**GeoLibre** is desktop-first and single-user — a standalone application focused on local data exploration and visualization.
+It does not support real-time collaboration or integration with computational notebooks.
+
+**JupyterGIS** is browser-first, collaborative, and deeply integrated with the Jupyter ecosystem.
+Where GeoLibre focuses on lightweight local exploration, JupyterGIS is designed for team workflows that combine map visualization with computational analysis in notebooks.
+Both projects are open source and share a commitment to modern web technologies and open formats.
 
 ### Rendering libraries (MapLibre, OpenLayers, Leaflet, ...)
 


### PR DESCRIPTION
## Summary
- Fix inaccurate claims in GIS tool comparisons (Felt, ArcGIS, GEE): add closed-source/governance notes
- Add invitation to open issues for inaccurate comparisons
- Add Jupyter foundation paragraph to Architecture section

## Test plan
- [ ] Verify docs build cleanly
- [ ] Review comparison claims for accuracy

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1468.org.readthedocs.build/en/1468/
💡 JupyterLite preview: https://jupytergis--1468.org.readthedocs.build/en/1468/lite
💡 Specta preview: https://jupytergis--1468.org.readthedocs.build/en/1468/lite/specta

<!-- readthedocs-preview jupytergis end -->