### PR TITLE
Symbology panel UI update

### DIFF
--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -35,11 +35,11 @@ import {
   saveSymbology,
   VectorSymbologyParams,
 } from '@/src/features/layers/symbology/symbologyUtils';
+import { Button } from '@/src/shared/components/Button';
 import {
   NativeSelect,
   NativeSelectOption,
 } from '@/src/shared/components/NativeSelect';
-import { Button } from '@/src/shared/components/Button';
 
 const DEFAULT_CHANNELS: StyleChannel[] = ['fill-color', 'circle-fill-color'];
 const DEFAULT_RGBA: RGBA = [128, 128, 128, 1];

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -17,7 +17,6 @@ import {
   StyleChannel,
   RGBA,
 } from '@jupytergis/schema';
-import { Button } from '@jupyterlab/ui-components';
 import { UUID } from '@lumino/coreutils';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -36,6 +35,11 @@ import {
   saveSymbology,
   VectorSymbologyParams,
 } from '@/src/features/layers/symbology/symbologyUtils';
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from '@/src/shared/components/NativeSelect';
+import { Button } from '@/src/shared/components/Button';
 
 const DEFAULT_CHANNELS: StyleChannel[] = ['fill-color', 'circle-fill-color'];
 const DEFAULT_RGBA: RGBA = [128, 128, 128, 1];
@@ -94,57 +98,49 @@ const TransformRow: React.FC<ITransformRowProps> = ({
   return (
     <div className="jp-gis-grammar-transform-row">
       {/* Type selector */}
-      <div className="jp-select-wrapper" style={{ flex: '0 0 120px' }}>
-        <select
-          className="jp-mod-styled"
-          value={transform.type}
-          onChange={e => handleTypeChange(e.target.value as ITransform['type'])}
-        >
-          {TRANSFORM_TYPES.map(({ value, label }) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </div>
+      <NativeSelect
+        value={transform.type}
+        onChange={e => handleTypeChange(e.target.value as ITransform['type'])}
+      >
+        {TRANSFORM_TYPES.map(({ value, label }) => (
+          <NativeSelectOption key={value} value={value}>
+            {label}
+          </NativeSelectOption>
+        ))}
+      </NativeSelect>
 
       {/* KDE params */}
       {transform.type === 'kde' && (
         <>
           <label>radius</label>
           <NumericInput
-            className="jp-mod-styled"
             style={{ width: 52 }}
             value={transform.radius}
             onChange={v => onChange({ ...transform, radius: v })}
           />
           <label>blur</label>
           <NumericInput
-            className="jp-mod-styled"
             style={{ width: 52 }}
             value={transform.blur}
             onChange={v => onChange({ ...transform, blur: v })}
           />
           <label>weight</label>
-          <div className="jp-select-wrapper" style={{ flex: '0 0 90px' }}>
-            <select
-              className="jp-mod-styled"
-              value={transform.weightField ?? ''}
-              onChange={e =>
-                onChange({
-                  ...transform,
-                  weightField: e.target.value || undefined,
-                })
-              }
-            >
-              <option value="">(none)</option>
-              {availableFields.map(f => (
-                <option key={f} value={f}>
-                  {f}
-                </option>
-              ))}
-            </select>
-          </div>
+          <NativeSelect
+            value={transform.weightField ?? ''}
+            onChange={e =>
+              onChange({
+                ...transform,
+                weightField: e.target.value || undefined,
+              })
+            }
+          >
+            <NativeSelectOption value="">(none)</NativeSelectOption>
+            {availableFields.map(field => (
+              <NativeSelectOption key={field} value={field}>
+                {field}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
         </>
       )}
 
@@ -153,7 +149,6 @@ const TransformRow: React.FC<ITransformRowProps> = ({
         <>
           <label>radius</label>
           <NumericInput
-            className="jp-mod-styled"
             style={{ width: 52 }}
             value={transform.radius}
             onChange={v => onChange({ ...transform, radius: v })}
@@ -161,7 +156,7 @@ const TransformRow: React.FC<ITransformRowProps> = ({
         </>
       )}
 
-      <button
+      <Button
         type="button"
         className="jp-gis-grammar-delete-btn"
         onClick={onDelete}
@@ -169,7 +164,7 @@ const TransformRow: React.FC<ITransformRowProps> = ({
         style={{ marginLeft: 'auto' }}
       >
         <FontAwesomeIcon icon={faTrash} />
-      </button>
+      </Button>
     </div>
   );
 };
@@ -290,23 +285,26 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         <span className="jp-gis-grammar-layer-label">
           Layer {layerIndex + 1}
         </span>
-        <button
+        <Button
           type="button"
-          className="jp-gis-grammar-when-add-btn"
+          variant="outline"
           onClick={addTransform}
           title="Add transform"
         >
-          <FontAwesomeIcon icon={faPlus} /> transform
-        </button>
+          <FontAwesomeIcon data-icon="inline-start" icon={faPlus} />
+          Transform
+        </Button>
+
         {totalLayers > 1 && (
-          <button
+          <Button
             type="button"
-            className="jp-gis-grammar-delete-btn"
+            variant="outline"
+            style={{ height: 32, width: 32 }}
             onClick={onDelete}
             title="Remove layer"
           >
             <FontAwesomeIcon icon={faTrash} />
-          </button>
+          </Button>
         )}
       </div>
 
@@ -314,7 +312,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
       <div className="jp-gis-grammar-when-row">
         <span className="jp-gis-grammar-when-label">when</span>
         {(layer.when?.length ?? 0) > 1 && (
-          <button
+          <Button
             type="button"
             className="jp-gis-grammar-when-op"
             onClick={() =>
@@ -325,18 +323,18 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
             }
           >
             {layer.whenOp ?? 'all'}
-          </button>
+          </Button>
         )}
         {layer.when?.map((pred, i) => (
           <span key={i} className="jp-gis-grammar-when-chip">
             {formatPredicate(pred)}
-            <button
+            <Button
               type="button"
               onClick={() => removeLayerPredicate(i)}
               title="Remove condition"
             >
               <FontAwesomeIcon icon={faXmark} />
-            </button>
+            </Button>
           </span>
         ))}
         {addingLayerWhen ? (
@@ -346,13 +344,13 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
             onCancel={() => setAddingLayerWhen(false)}
           />
         ) : (
-          <button
+          <Button
             type="button"
             className="jp-gis-grammar-when-add-btn"
             onClick={() => setAddingLayerWhen(true)}
           >
             <FontAwesomeIcon icon={faPlus} />
-          </button>
+          </Button>
         )}
       </div>
 
@@ -383,6 +381,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
       <div className="jp-gis-symbology-button-container">
         <Button
           className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+          style={{ margin: '0 0 0.5rem 1rem' }}
           onClick={addRow}
         >
           Add Mapping

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -28,19 +28,18 @@ import {
   drawColorRamp,
   getColorMap,
 } from '@/src/features/layers/symbology/colorRampUtils';
+import { Button } from '@/src/shared/components/Button';
+import { Input } from '@/src/shared/components/Input';
 import {
   NativeSelect,
   NativeSelectOption,
 } from '@/src/shared/components/NativeSelect';
-import { type ISelectItem, Select } from '@/src/shared/components/Select';
 import {
   CategoricalEditor,
   ColorRampEditor,
   ConstantEditor,
   ScalarEditor,
 } from './ScaleEditor';
-import { Input } from '@/src/shared/components/Input';
-import { Button } from '@/src/shared/components/Button';
 
 // ---------------------------------------------------------------------------
 // Channel taxonomy

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -29,11 +29,18 @@ import {
   getColorMap,
 } from '@/src/features/layers/symbology/colorRampUtils';
 import {
+  NativeSelect,
+  NativeSelectOption,
+} from '@/src/shared/components/NativeSelect';
+import { type ISelectItem, Select } from '@/src/shared/components/Select';
+import {
   CategoricalEditor,
   ColorRampEditor,
   ConstantEditor,
   ScalarEditor,
 } from './ScaleEditor';
+import { Input } from '@/src/shared/components/Input';
+import { Button } from '@/src/shared/components/Button';
 
 // ---------------------------------------------------------------------------
 // Channel taxonomy
@@ -397,77 +404,70 @@ export const WhenAddForm: React.FC<IWhenAddFormProps> = ({
 
   return (
     <span className="jp-gis-grammar-when-form">
-      <div className="jp-select-wrapper" style={{ flex: '0 0 auto' }}>
-        <select
-          className="jp-mod-styled"
-          value={draft.type}
-          onChange={e => patch({ type: e.target.value as PredicateType })}
-        >
-          <option value="geometryType">geometry type</option>
-          <option value="hasField">has field</option>
-          <option value="fieldEquals">field equals</option>
-          <option value="fieldCompare">field compare</option>
-          <option value="between">between</option>
-        </select>
-      </div>
+      <NativeSelect
+        value={draft.type}
+        onChange={e => patch({ type: e.target.value as PredicateType })}
+      >
+        <NativeSelectOption value="geometryType">
+          Geometry Type
+        </NativeSelectOption>
+        <NativeSelectOption value="hasField">Has Field</NativeSelectOption>
+        <NativeSelectOption value="fieldEquals">
+          Field Equals
+        </NativeSelectOption>
+        <NativeSelectOption value="fieldCompare">
+          Field Compare
+        </NativeSelectOption>
+        <NativeSelectOption value="between">Between</NativeSelectOption>
+      </NativeSelect>
 
       {draft.type === 'geometryType' && (
-        <div className="jp-select-wrapper" style={{ flex: '0 0 auto' }}>
-          <select
-            className="jp-mod-styled"
-            value={draft.geomValue}
-            onChange={e =>
-              patch({
-                geomValue: e.target.value as INewPredicate['geomValue'],
-              })
-            }
-          >
-            <option value="Point">Point</option>
-            <option value="LineString">LineString</option>
-            <option value="Polygon">Polygon</option>
-          </select>
-        </div>
+        <NativeSelect
+          value={draft.geomValue}
+          onChange={e =>
+            patch({
+              geomValue: e.target.value as INewPredicate['geomValue'],
+            })
+          }
+        >
+          <NativeSelectOption value="Point">Point</NativeSelectOption>
+          <NativeSelectOption value="LineString">LineString</NativeSelectOption>
+          <NativeSelectOption value="Polygon">Polygon</NativeSelectOption>
+        </NativeSelect>
       )}
 
       {(draft.type === 'hasField' ||
         draft.type === 'fieldEquals' ||
         draft.type === 'fieldCompare' ||
         draft.type === 'between') && (
-        <div className="jp-select-wrapper" style={{ flex: '0 0 auto' }}>
-          <select
-            className="jp-mod-styled"
-            value={draft.field}
-            onChange={e => patch({ field: e.target.value })}
-          >
-            <option value="">(field)</option>
-            {availableFields.map(f => (
-              <option key={f} value={f}>
-                {f}
-              </option>
-            ))}
-          </select>
-        </div>
+        <NativeSelect
+          value={draft.field}
+          onChange={e => patch({ field: e.target.value })}
+        >
+          <NativeSelectOption value="">(field)</NativeSelectOption>
+          {availableFields.map(field => (
+            <NativeSelectOption key={field} value={field}>
+              {field}
+            </NativeSelectOption>
+          ))}
+        </NativeSelect>
       )}
 
       {draft.type === 'fieldCompare' && (
-        <div className="jp-select-wrapper" style={{ flex: '0 0 auto' }}>
-          <select
-            className="jp-mod-styled"
-            value={draft.compareOp}
-            onChange={e => patch({ compareOp: e.target.value as ICompareOp })}
-          >
-            {COMPARE_OPS.map(op => (
-              <option key={op} value={op}>
-                {op}
-              </option>
-            ))}
-          </select>
-        </div>
+        <NativeSelect
+          value={draft.compareOp}
+          onChange={e => patch({ compareOp: e.target.value as ICompareOp })}
+        >
+          {COMPARE_OPS.map(op => (
+            <NativeSelectOption key={op} value={op}>
+              {op}
+            </NativeSelectOption>
+          ))}
+        </NativeSelect>
       )}
 
       {(draft.type === 'fieldEquals' || draft.type === 'fieldCompare') && (
-        <input
-          className="jp-mod-styled"
+        <Input
           style={{ flex: '0 0 80px', minWidth: 0 }}
           type={draft.type === 'fieldCompare' ? 'number' : 'text'}
           placeholder="value"
@@ -478,8 +478,7 @@ export const WhenAddForm: React.FC<IWhenAddFormProps> = ({
 
       {draft.type === 'between' && (
         <>
-          <input
-            className="jp-mod-styled"
+          <Input
             style={{ flex: '0 0 60px', minWidth: 0 }}
             type="number"
             placeholder="min"
@@ -491,8 +490,7 @@ export const WhenAddForm: React.FC<IWhenAddFormProps> = ({
           >
             –
           </span>
-          <input
-            className="jp-mod-styled"
+          <Input
             style={{ flex: '0 0 60px', minWidth: 0 }}
             type="number"
             placeholder="max"
@@ -502,23 +500,26 @@ export const WhenAddForm: React.FC<IWhenAddFormProps> = ({
         </>
       )}
 
-      <button
+      <Button
         type="button"
-        className="jp-gis-grammar-when-ok"
+        variant="icon"
+        size="icon-md"
         disabled={!built}
         onClick={() => built && onAdd(built)}
         title="Add predicate"
       >
         <FontAwesomeIcon icon={faCheck} />
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
-        className="jp-gis-grammar-when-cancel"
+        variant="icon"
+        size="icon-md"
+        className="jp-gis-grammar-when-form-cancel"
         onClick={onCancel}
         title="Cancel"
       >
         <FontAwesomeIcon icon={faXmark} />
-      </button>
+      </Button>
     </span>
   );
 };
@@ -567,20 +568,20 @@ const FieldSelector: React.FC<IFieldSelectorProps> = ({
   }
 
   if (fieldCount === 1) {
+    const selectedField = fields[0] ?? '';
     return (
-      <div className="jp-select-wrapper" style={{ gridRow: 1, gridColumn: 1 }}>
-        <select
-          className="jp-mod-styled"
-          value={fields[0] ?? ''}
+      <div style={{ gridRow: 1, gridColumn: 1 }}>
+        <NativeSelect
+          value={selectedField}
           onChange={e => onFieldChange(0, e.target.value)}
         >
-          <option value="">(none)</option>
+          <NativeSelectOption value="">(none)</NativeSelectOption>
           {availableFields.map(f => (
-            <option key={f} value={f}>
+            <NativeSelectOption key={f} value={f}>
               {f}
-            </option>
+            </NativeSelectOption>
           ))}
-        </select>
+        </NativeSelect>
       </div>
     );
   }
@@ -600,34 +601,34 @@ const FieldSelector: React.FC<IFieldSelectorProps> = ({
       {fields.map((f, i) => (
         <span key={i} className="jp-gis-grammar-when-chip">
           {f}
-          <button
+          <Button
             type="button"
             className="jp-gis-grammar-when-cancel"
             onClick={() => onFieldChange(i, '')}
             title="Remove field"
           >
             <FontAwesomeIcon icon={faXmark} />
-          </button>
+          </Button>
         </span>
       ))}
-      <div
-        className="jp-select-wrapper"
-        style={{ minWidth: 60, flex: '0 0 auto' }}
-      >
-        <select
-          className="jp-mod-styled"
+      <div style={{ minWidth: 60, flex: '0 0 auto' }}>
+        <NativeSelect
           value=""
-          onChange={e => onAddField(e.target.value)}
+          onChange={e => {
+            if (e.target.value) {
+              onAddField(e.target.value);
+            }
+          }}
         >
-          <option value="">+field</option>
+          <NativeSelectOption value="">+field</NativeSelectOption>
           {availableFields
             .filter(f => !fields.includes(f))
             .map(f => (
-              <option key={f} value={f}>
+              <NativeSelectOption key={f} value={f}>
                 {f}
-              </option>
+              </NativeSelectOption>
             ))}
-        </select>
+        </NativeSelect>
       </div>
     </div>
   );
@@ -803,23 +804,21 @@ const MappingRow: React.FC<IMappingRowProps> = ({
         />
 
         {/* Scheme — row 1 */}
-        <div
-          className="jp-select-wrapper"
-          style={{ gridRow: 1, gridColumn: 2 }}
-        >
-          <select
-            className="jp-mod-styled"
+        <div style={{ gridRow: 1, gridColumn: 2 }}>
+          <NativeSelect
             value={row.scale.scheme}
             onChange={e =>
               handleSchemeChange(e.target.value as IScale['scheme'])
             }
           >
-            {SCHEME_OPTIONS.map(({ value, label, disabled }) => (
-              <option key={value} value={value} disabled={disabled}>
-                {label}
-              </option>
-            ))}
-          </select>
+            {SCHEME_OPTIONS.filter(({ disabled }) => !disabled).map(
+              ({ value, label }) => (
+                <NativeSelectOption key={value} value={value}>
+                  {label}
+                </NativeSelectOption>
+              ),
+            )}
+          </NativeSelect>
         </div>
 
         {/* Scale preview — spans all channel rows + optional add-channel row */}
@@ -843,26 +842,27 @@ const MappingRow: React.FC<IMappingRowProps> = ({
               →
             </span>
             <div
-              className="jp-select-wrapper"
+              className="jp-gis-grammar-channel-select"
               style={{ gridRow: i + 1, gridColumn: 5 }}
             >
-              <select
-                className="jp-mod-styled"
+              <NativeSelect
                 value={ch}
                 onChange={e =>
                   handleChannelChange(i, e.target.value as StyleChannel)
                 }
               >
                 {compat.map(c => (
-                  <option key={c} value={c}>
+                  <NativeSelectOption key={c} value={c}>
                     {CHANNEL_LABELS[c] ?? c}
-                  </option>
+                  </NativeSelectOption>
                 ))}
-              </select>
+              </NativeSelect>
             </div>
-            <button
+            <Button
               type="button"
-              className="jp-gis-grammar-delete-btn"
+              variant="outline"
+              size="icon-md"
+              className="jp-mod-styled"
               style={{ gridRow: i + 1, gridColumn: 6 }}
               onClick={() => removeChannel(ch)}
               title={
@@ -870,7 +870,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
               }
             >
               <FontAwesomeIcon icon={faTrash} />
-            </button>
+            </Button>
           </React.Fragment>
         ))}
 
@@ -884,11 +884,10 @@ const MappingRow: React.FC<IMappingRowProps> = ({
               +
             </span>
             <div
-              className="jp-select-wrapper"
+              className="jp-gis-grammar-channel-select"
               style={{ gridRow: row.channels.length + 1, gridColumn: 5 }}
             >
-              <select
-                className="jp-mod-styled"
+              <NativeSelect
                 value=""
                 onChange={e => {
                   if (e.target.value) {
@@ -896,13 +895,13 @@ const MappingRow: React.FC<IMappingRowProps> = ({
                   }
                 }}
               >
-                <option value="">(add channel)</option>
+                <NativeSelectOption value="">(add channel)</NativeSelectOption>
                 {availableToAdd.map(ch => (
-                  <option key={ch} value={ch}>
+                  <NativeSelectOption key={ch} value={ch}>
                     {CHANNEL_LABELS[ch] ?? ch}
-                  </option>
+                  </NativeSelectOption>
                 ))}
-              </select>
+              </NativeSelect>
             </div>
           </React.Fragment>
         )}
@@ -912,7 +911,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
       <div className="jp-gis-grammar-when-row">
         <span className="jp-gis-grammar-when-label">when</span>
         {(row.when?.length ?? 0) > 1 && (
-          <button
+          <Button
             type="button"
             className="jp-gis-grammar-when-op"
             onClick={() =>
@@ -923,18 +922,18 @@ const MappingRow: React.FC<IMappingRowProps> = ({
             }
           >
             {row.whenOp ?? 'all'}
-          </button>
+          </Button>
         )}
         {row.when?.map((pred, i) => (
           <span key={i} className="jp-gis-grammar-when-chip">
             {formatPredicate(pred)}
-            <button
+            <Button
               type="button"
               onClick={() => removePredicate(i)}
               title="Remove condition"
             >
               <FontAwesomeIcon icon={faXmark} />
-            </button>
+            </Button>
           </span>
         ))}
         {addingWhen ? (
@@ -944,13 +943,13 @@ const MappingRow: React.FC<IMappingRowProps> = ({
             onCancel={() => setAddingWhen(false)}
           />
         ) : (
-          <button
+          <Button
             type="button"
             className="jp-gis-grammar-when-add-btn"
             onClick={() => setAddingWhen(true)}
           >
             <FontAwesomeIcon icon={faPlus} />
-          </button>
+          </Button>
         )}
       </div>
 

--- a/packages/base/src/features/layers/symbology/components/NumericInput.tsx
+++ b/packages/base/src/features/layers/symbology/components/NumericInput.tsx
@@ -11,6 +11,8 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 
+import { Input } from '@/src/shared/components/Input';
+
 interface INumericInputProps {
   value: number;
   onChange: (v: number) => void;
@@ -58,20 +60,13 @@ export const NumericInput: React.FC<INumericInputProps> = ({
     trimmed === '' || trimmed === '-' || Number.isFinite(Number(trimmed));
 
   return (
-    <input
+    <Input
       className={className}
-      style={
-        isValid
-          ? style
-          : {
-              ...style,
-              outline: '2px solid var(--jp-error-color1, #d32f2f)',
-              outlineOffset: '-1px',
-            }
-      }
+      style={style}
       type="text"
       placeholder={placeholder}
       value={raw}
+      aria-invalid={!isValid}
       onChange={e => setRaw(e.target.value)}
       onFocus={() => {
         focused.current = true;

--- a/packages/base/src/shared/components/NativeSelect.tsx
+++ b/packages/base/src/shared/components/NativeSelect.tsx
@@ -1,0 +1,57 @@
+import { ChevronDownIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from './utils';
+
+type NativeSelectProps = Omit<React.ComponentProps<'select'>, 'size'> & {
+  size?: 'sm' | 'default';
+};
+
+function NativeSelect({
+  className,
+  size = 'default',
+  ...props
+}: NativeSelectProps) {
+  return (
+    <div
+      className={cn('jgis-native-select', className)}
+      data-slot="native-select-wrapper"
+      data-size={size}
+    >
+      <select data-slot="native-select" data-size={size} {...props} />
+      <ChevronDownIcon
+        className="jgis-native-select-icon"
+        aria-hidden="true"
+        data-slot="native-select-icon"
+      />
+    </div>
+  );
+}
+
+function NativeSelectOption({
+  className,
+  ...props
+}: React.ComponentProps<'option'>) {
+  return (
+    <option
+      data-slot="native-select-option"
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+function NativeSelectOptGroup({
+  className,
+  ...props
+}: React.ComponentProps<'optgroup'>) {
+  return (
+    <optgroup
+      data-slot="native-select-optgroup"
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+export { NativeSelect, NativeSelectOptGroup, NativeSelectOption };

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -33,6 +33,7 @@
 @import url('./shared/command.css');
 @import url('./shared/combobox.css');
 @import url('./shared/input.css');
+@import url('./shared/nativeSelect.css');
 
 .errors {
   color: var(--jp-warn-color0);

--- a/packages/base/style/shared/nativeSelect.css
+++ b/packages/base/style/shared/nativeSelect.css
@@ -1,0 +1,75 @@
+.jgis-native-select {
+  position: relative;
+  width: fit-content;
+}
+
+.jgis-native-select:has(select:disabled) {
+  opacity: 0.5;
+}
+
+[data-slot='native-select'] {
+  box-sizing: border-box;
+  height: 2rem;
+  width: 100%;
+  min-width: 0;
+  appearance: none;
+  border-radius: var(--jp-border-radius, 0.375rem);
+  border: 1px solid var(--jp-border-color1);
+  background-color: transparent;
+  padding: 0.25rem 2rem 0.25rem 0.625rem;
+  font-size: 0.875rem;
+  color: var(--jp-ui-font-color1);
+  transition:
+    color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+  outline: none;
+  user-select: none;
+  cursor: pointer;
+}
+
+[data-slot='native-select']::selection {
+  background-color: var(--jp-brand-color1);
+  color: var(--jp-ui-inverse-font-color1);
+}
+
+[data-slot='native-select']:focus-visible {
+  border-color: var(--jp-brand-color1);
+  box-shadow: 0 0 0 3px rgba(var(--jp-brand-color1-rgb), 0.1);
+}
+
+[data-slot='native-select'][aria-invalid='true'] {
+  border-color: var(--jp-error-color1);
+  box-shadow: 0 0 0 3px rgba(var(--jp-error-color1-rgb), 0.2);
+}
+
+[data-slot='native-select']:disabled {
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+[data-slot='native-select'][data-size='sm'] {
+  height: 1.75rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  border-radius: min(var(--jp-border-radius, 0.375rem), 10px);
+}
+
+.jgis-native-select-icon {
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  right: 0.625rem;
+  width: 1rem;
+  height: 1rem;
+  transform: translateY(-50%);
+  color: var(--jp-ui-font-color2);
+  user-select: none;
+  flex-shrink: 0;
+}
+
+[data-slot='native-select-option'],
+[data-slot='native-select-optgroup'] {
+  background: Canvas;
+  color: CanvasText;
+}

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -65,12 +65,6 @@ select option {
   max-width: 25%;
 }
 
-.jp-gis-band-container {
-  display: flex;
-  flex-direction: column;
-  gap: 13px;
-}
-
 .jp-gis-layer-symbology-container {
   display: flex;
   flex-direction: column;
@@ -131,27 +125,6 @@ select option {
 
 .jp-gis-symbology-button-container {
   padding-top: 0.5rem;
-}
-
-.jp-gis-band-info-loading-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 2rem;
-  margin: auto;
-}
-
-.jp-gis-band-info-loading-container > span {
-  font-size: 1rem;
-}
-
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 .jp-gis-color-ramp-dropdown {
@@ -307,7 +280,7 @@ select option {
   align-items: center;
   gap: 6px;
   padding: 4px 6px;
-  background: var(--jp-layout-color3);
+  background: var(--jp-layout-color2);
   border-bottom: 1px solid var(--jp-border-color2);
   font-size: var(--jp-ui-font-size1);
 }
@@ -330,11 +303,23 @@ select option {
 /* 6-column grid: field | scheme | preview | arrow | channel | × */
 .jp-gis-grammar-rule-grid {
   display: grid;
-  grid-template-columns: 80px 80px 1fr auto 100px auto;
+  grid-template-columns: max-content max-content 1fr auto max-content auto;
   align-items: center;
   column-gap: 4px;
   row-gap: 3px;
   padding: 4px 6px;
+  position: relative;
+}
+
+.jp-gis-grammar-rule-grid .jp-gis-grammar-channel-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.jp-gis-grammar-rule-grid .jp-gis-grammar-channel-select .jgis-combobox-button,
+.jp-gis-grammar-rule-grid .jp-gis-grammar-channel-select .jgis-native-select {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 @media (max-width: 768px) {
@@ -493,11 +478,10 @@ select option {
   flex-wrap: nowrap;
 }
 
-.jp-gis-grammar-when-form .jp-select-wrapper {
-  margin-bottom: 0;
+.jp-gis-grammar-when-form .jgis-native-select {
+  flex: 0 0 auto;
 }
 
-.jp-gis-grammar-when-ok,
 .jp-gis-grammar-when-cancel {
   background: none;
   border: 1px solid var(--jp-border-color2);
@@ -509,9 +493,8 @@ select option {
   line-height: 1.4;
 }
 
-.jp-gis-grammar-when-ok:disabled {
-  opacity: 0.4;
-  cursor: default;
+.jgis-button.jp-gis-grammar-when-form-cancel {
+  color: var(--jp-error-color0);
 }
 
 /* Domain min/max pair inside a symbology row */


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Update the style of the new symbology panel a little bit, mostly to make text in the selects fit.  Also adds a new `NativeSelect` component based on Shadcn.

Prev:
<img width="1070" height="807" alt="image" src="https://github.com/user-attachments/assets/6a5082aa-39e9-4f28-a09c-f7036fffa37b" />


New:
<img width="1072" height="809" alt="image" src="https://github.com/user-attachments/assets/d148439a-d64b-486f-ad25-65ca24ceb54e" />




## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1469.org.readthedocs.build/en/1469/
💡 JupyterLite preview: https://jupytergis--1469.org.readthedocs.build/en/1469/lite
💡 Specta preview: https://jupytergis--1469.org.readthedocs.build/en/1469/lite/specta

<!-- readthedocs-preview jupytergis end -->