### PR TITLE
Add troubleshooting docs for missing `build_log.json` error during dev setup

### DIFF
--- a/docs/contributor_guide/troubleshooting.md
+++ b/docs/contributor_guide/troubleshooting.md
@@ -8,6 +8,23 @@ The [only known workaround](https://github.com/nrwl/nx/issues/27494#issuecomment
 is to remove the `.gitignore` file from your home directory or to work in a location
 outside of the home directory tree.
 
+## Setup of development environment fails for missing `build_log.json`
+
+```
+ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/home/myuser/micromamba/envs/jupytergis/share/jupyter/labextensions/@jupytergis/jupytergis-core/build_log.json'
+```
+
+This error can occur when re-using a conda environment across different working
+directories.
+
+To resolve, remove your conda environment and
+[recreate it](/contributor_guide/development_setup.md):
+
+```bash
+micromamba env remove -n jupytergis_dev
+micromamba create #... see the dev setup guide
+```
+
 ## Every UI test fails after 60 seconds due to timeout.
 
 This could be caused by having a JupyterLab instance already running at port `:8888`.


### PR DESCRIPTION
## Description

This happens for me occasionally and I think it's related to working across multiple Git worktrees. Adopting pixi should solve this by using separate environments for each worktree (and that won't come with a disk space cost since it uses hardlinking to avoid duplicate deps).

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1480.org.readthedocs.build/en/1480/
💡 JupyterLite preview: https://jupytergis--1480.org.readthedocs.build/en/1480/lite
💡 Specta preview: https://jupytergis--1480.org.readthedocs.build/en/1480/lite/specta

<!-- readthedocs-preview jupytergis end -->