### PR TITLE
Show layer name in symbology dialog title

### DIFF
--- a/packages/base/src/features/layers/symbology/symbologyDialog.tsx
+++ b/packages/base/src/features/layers/symbology/symbologyDialog.tsx
@@ -137,7 +137,10 @@ export class SymbologyWidget extends Dialog<boolean> {
       />
     );
 
-    super({ title: 'Symbology', body });
+    const layerId = Object.keys(options.model.localState!.selected.value!)[0];
+    const layerName = options.model.getLayer(layerId)!.name;
+
+    super({ title: `Symbology — ${layerName}`, body });
 
     this.id = 'jupytergis::symbologyWidget';
     this.okSignal = new Signal(this);


### PR DESCRIPTION
## Summary
- Display the selected layer name in the symbology dialog title (e.g. "Symbology — Buildings")

Closes #1478

## Test plan
- [ ] Open symbology on a layer, verify layer name appears in dialog title

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1484.org.readthedocs.build/en/1484/
💡 JupyterLite preview: https://jupytergis--1484.org.readthedocs.build/en/1484/lite
💡 Specta preview: https://jupytergis--1484.org.readthedocs.build/en/1484/lite/specta

<!-- readthedocs-preview jupytergis end -->