### PR TITLE
Fix mobile bottom sheet breakpoint and layout

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -3991,7 +3991,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 // ! TODO make mainview a modern react component instead of a class
 /** Thin wrapper that injects isMobile from useMediaQuery so MainView can use it in JSX. */
 function MainViewWithMediaQuery(props: Omit<IMainViewProps, 'isMobile'>) {
-  const isMobile = useMediaQuery('(max-width: 768px)');
+  const isMobile = useMediaQuery('(max-width: 960px)');
   return <MainView {...props} isMobile={isMobile} />;
 }
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -201,7 +201,7 @@ interface IMainViewProps {
   formSchemaRegistry?: IJGISFormSchemaRegistry;
   annotationModel?: IAnnotationModel;
   loggerRegistry?: ILoggerRegistry;
-  /** True when viewport matches (max-width: 768px). Injected by MainViewWithMediaQuery. */
+  /** True when viewport matches (max-width: 960px). Injected by MainViewWithMediaQuery. */
   isMobile: boolean;
 }
 

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -134,14 +134,13 @@ button.jp-mod-styled.jp-mod-reject {
 }
 
 /* Mobile bottom sheet — merged panel only */
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .jgis-merged-panel-container {
     position: fixed;
-    bottom: var(--jp-statusbar-height, 0px);
+    bottom: 16px;
     left: 0;
     right: 0;
     z-index: 1000;
-    border-radius: 8px 8px 0 0;
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.2);
     display: flex;
     flex-direction: column;
@@ -247,6 +246,15 @@ button.jp-mod-styled.jp-mod-reject {
   right: 0.125rem;
 }
 
+/* Move controls toolbar to top of map so it's not behind the bottom sheet */
+@media (max-width: 960px) {
+  .jgis-controls-toolbar {
+    top: 0.125rem;
+    bottom: unset;
+    align-items: flex-start;
+  }
+}
+
 .jgis-geometry-type-selector-overlay {
   position: absolute;
   bottom: 20px;
@@ -262,7 +270,7 @@ button.jp-mod-styled.jp-mod-reject {
   z-index: 9999;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .jgis-panels-wrapper {
     position: fixed;
     top: 30px;

--- a/packages/base/style/layerBrowser.css
+++ b/packages/base/style/layerBrowser.css
@@ -9,7 +9,7 @@
   max-height: 100%;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .jGIS-layerbrowser-FormDialog .jp-Dialog-content {
     width: 100%;
     height: 100%;
@@ -97,7 +97,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .jGIS-layer-browser-grid {
     grid-template-columns: repeat(2, minmax(0px, 1fr));
     padding: 0.5rem;

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -14,7 +14,7 @@ select option {
   max-height: 80%;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .jp-gis-symbology-dialog .jp-Dialog-content {
     width: 100%;
     max-width: 100%;
@@ -322,7 +322,7 @@ select option {
   box-sizing: border-box;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .jp-gis-grammar-rule-grid {
     grid-template-columns: 1fr 1fr auto;
   }
@@ -505,7 +505,7 @@ select option {
   max-width: 50%;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 960px) {
   .jp-gis-symbology-row {
     flex-wrap: wrap;
     gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Raise mobile breakpoint from 768px to 960px (half a 1920px display) so the bottom sheet triggers before side panels squeeze the map
- Remove border-radius so bottom sheet sits flush against the status bar
- Position bottom sheet above the 16px status bar to prevent pill from vanishing
- Move controls toolbar (scale line, fullscreen) to top of map in mobile mode

Closes #1362

## Test plan
- [ ] Resize window to ~960px width, verify bottom sheet appears
- [ ] Verify no gap between bottom sheet and status bar
- [ ] Verify scale line and fullscreen button are visible at top of map
- [ ] Minimize bottom sheet fully, verify pill handle remains accessible

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1485.org.readthedocs.build/en/1485/
💡 JupyterLite preview: https://jupytergis--1485.org.readthedocs.build/en/1485/lite
💡 Specta preview: https://jupytergis--1485.org.readthedocs.build/en/1485/lite/specta

<!-- readthedocs-preview jupytergis end -->