### PR TITLE
Enable reordering symbology rules and layers; top-to-bottom mobile UI for symbology; symbology UI harmonization

### DIFF
--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -89,15 +89,33 @@ interface ITransformRowProps {
   transform: ITransform;
   availableFields: string[];
   onChange: (t: ITransform) => void;
+  onDelete: () => void;
 }
 
 const TransformRow: React.FC<ITransformRowProps> = ({
   transform,
   availableFields,
   onChange,
+  onDelete,
 }) => {
+  const handleTypeChange = (type: ITransform['type']) => {
+    onChange(defaultTransform(type));
+  };
+
   return (
     <div className="jp-gis-grammar-transform-row">
+      {/* Type selector */}
+      <NativeSelect
+        value={transform.type}
+        onChange={e => handleTypeChange(e.target.value as ITransform['type'])}
+      >
+        {TRANSFORM_TYPES.map(({ value, label }) => (
+          <NativeSelectOption key={value} value={value}>
+            {label}
+          </NativeSelectOption>
+        ))}
+      </NativeSelect>
+
       {/* KDE params */}
       {transform.type === 'kde' && (
         <>
@@ -144,6 +162,16 @@ const TransformRow: React.FC<ITransformRowProps> = ({
           />
         </>
       )}
+
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={onDelete}
+        title="Remove transform"
+        style={{ marginLeft: 'auto' }}
+      >
+        <FontAwesomeIcon icon={faTrash} />
+      </Button>
     </div>
   );
 };
@@ -211,15 +239,15 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
     [layer, onChange],
   );
 
-  const setTransform = useCallback(
-    (type: ITransform['type'] | 'none') => {
-      onChange({
-        ...layer,
-        transforms: type === 'none' ? [] : [defaultTransform(type)],
-      });
-    },
-    [layer, onChange],
-  );
+  const addTransform = useCallback(() => {
+    if (layer.transforms.length > 0) {
+      return;
+    }
+    onChange({
+      ...layer,
+      transforms: [defaultTransform('kde')],
+    });
+  }, [layer, onChange]);
 
   const updateTransform = useCallback(
     (t: ITransform) => {
@@ -227,6 +255,10 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
     },
     [layer, onChange],
   );
+
+  const removeTransform = useCallback(() => {
+    onChange({ ...layer, transforms: [] });
+  }, [layer, onChange]);
 
   const updateRow = useCallback(
     (index: number, row: IGrammarRow) => {
@@ -275,19 +307,17 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         <span className="jp-gis-grammar-layer-label">
           Layer {layerIndex + 1}
         </span>
-        <NativeSelect
-          value={layer.transforms[0]?.type ?? 'none'}
-          onChange={e =>
-            setTransform(e.target.value as ITransform['type'] | 'none')
-          }
-        >
-          <NativeSelectOption value="none">no transform</NativeSelectOption>
-          {TRANSFORM_TYPES.map(({ value, label }) => (
-            <NativeSelectOption key={value} value={value}>
-              {label}
-            </NativeSelectOption>
-          ))}
-        </NativeSelect>
+        {layer.transforms.length === 0 && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={addTransform}
+            title="Add transform"
+          >
+            <FontAwesomeIcon data-icon="inline-start" icon={faPlus} />
+            Transform
+          </Button>
+        )}
 
         {totalLayers > 1 && onMoveUp && (
           <Button
@@ -376,97 +406,114 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
           transform={layer.transforms[0]}
           availableFields={availableFields}
           onChange={updateTransform}
+          onDelete={removeTransform}
         />
       )}
 
       {/* Mapping rows — reorder bar (drag + arrows) above each rule */}
-      {layer.rows.map((row, i) => (
-        <div
-          key={row.id}
-          className="jp-gis-grammar-drag-wrapper"
-          draggable={dragIndexRef.current !== null}
-          onDragOver={e => {
-            e.preventDefault();
-            const rect = e.currentTarget.getBoundingClientRect();
+      {/* Container handles drag events so drops work even at top/bottom edges */}
+      <div
+        className="jp-gis-grammar-rules-container"
+        onDragOver={e => {
+          e.preventDefault();
+          // Find which wrapper the cursor is closest to
+          const wrappers = Array.from(
+            e.currentTarget.querySelectorAll(
+              ':scope > .jp-gis-grammar-drag-wrapper',
+            ),
+          );
+          let idx = layer.rows.length;
+          for (let j = 0; j < wrappers.length; j++) {
+            const rect = wrappers[j].getBoundingClientRect();
             const midY = rect.top + rect.height / 2;
-            const idx = e.clientY < midY ? i : i + 1;
-            dragOverRef.current = idx;
-            setDragOverIndex(idx);
-          }}
-          onDrop={() => {
-            const over = dragOverRef.current;
-            if (dragIndexRef.current !== null && over !== null) {
-              const to = over > dragIndexRef.current ? over - 1 : over;
-              moveRow(dragIndexRef.current, to);
+            if (e.clientY < midY) {
+              idx = j;
+              break;
             }
-            dragIndexRef.current = null;
-            dragOverRef.current = null;
-            setDragOverIndex(null);
-          }}
-          onDragEnd={() => {
-            dragIndexRef.current = null;
-            dragOverRef.current = null;
-            setDragOverIndex(null);
-          }}
-          style={{
-            borderTop:
-              dragOverIndex === i && dragIndexRef.current !== i
-                ? '2px solid var(--jp-brand-color1)'
-                : '2px solid transparent',
-            borderBottom:
-              dragOverIndex === layer.rows.length &&
-              i === layer.rows.length - 1 &&
-              dragIndexRef.current !== i
-                ? '2px solid var(--jp-brand-color1)'
-                : '2px solid transparent',
-          }}
-        >
-          {layer.rows.length > 1 && (
-            <div className="jp-gis-grammar-reorder-bar">
-              <Button
-                type="button"
-                disabled={i === 0}
-                onClick={() => moveRow(i, i - 1)}
-                title="Move up"
-              >
-                <FontAwesomeIcon icon={faArrowUp} />
-              </Button>
-              <div
-                className="jp-gis-grammar-drag-handle"
-                draggable
-                onDragStart={e => {
-                  dragIndexRef.current = i;
-                  const wrapper = e.currentTarget.closest(
-                    '.jp-gis-grammar-drag-wrapper',
-                  );
-                  if (wrapper) {
-                    e.dataTransfer.setDragImage(wrapper, 0, 0);
-                  }
-                }}
-                title="Drag to reorder"
-              >
-                <FontAwesomeIcon icon={faGripVertical} />
+          }
+          dragOverRef.current = idx;
+          setDragOverIndex(idx);
+        }}
+        onDrop={() => {
+          const over = dragOverRef.current;
+          if (dragIndexRef.current !== null && over !== null) {
+            const to = over > dragIndexRef.current ? over - 1 : over;
+            moveRow(dragIndexRef.current, to);
+          }
+          dragIndexRef.current = null;
+          dragOverRef.current = null;
+          setDragOverIndex(null);
+        }}
+        onDragEnd={() => {
+          dragIndexRef.current = null;
+          dragOverRef.current = null;
+          setDragOverIndex(null);
+        }}
+      >
+        {layer.rows.map((row, i) => (
+          <div
+            key={row.id}
+            className="jp-gis-grammar-drag-wrapper"
+            style={{
+              borderTop:
+                dragOverIndex === i && dragIndexRef.current !== i
+                  ? '2px solid var(--jp-brand-color1)'
+                  : '2px solid transparent',
+              borderBottom:
+                dragOverIndex === layer.rows.length &&
+                i === layer.rows.length - 1 &&
+                dragIndexRef.current !== i
+                  ? '2px solid var(--jp-brand-color1)'
+                  : '2px solid transparent',
+            }}
+          >
+            {layer.rows.length > 1 && (
+              <div className="jp-gis-grammar-reorder-bar">
+                <Button
+                  type="button"
+                  disabled={i === 0}
+                  onClick={() => moveRow(i, i - 1)}
+                  title="Move up"
+                >
+                  <FontAwesomeIcon icon={faArrowUp} />
+                </Button>
+                <div
+                  className="jp-gis-grammar-drag-handle"
+                  draggable
+                  onDragStart={e => {
+                    dragIndexRef.current = i;
+                    const wrapper = e.currentTarget.closest(
+                      '.jp-gis-grammar-drag-wrapper',
+                    );
+                    if (wrapper) {
+                      e.dataTransfer.setDragImage(wrapper, 0, 0);
+                    }
+                  }}
+                  title="Drag to reorder"
+                >
+                  <FontAwesomeIcon icon={faGripVertical} />
+                </div>
+                <Button
+                  type="button"
+                  disabled={i === layer.rows.length - 1}
+                  onClick={() => moveRow(i, i + 1)}
+                  title="Move down"
+                >
+                  <FontAwesomeIcon icon={faArrowDown} />
+                </Button>
               </div>
-              <Button
-                type="button"
-                disabled={i === layer.rows.length - 1}
-                onClick={() => moveRow(i, i + 1)}
-                title="Move down"
-              >
-                <FontAwesomeIcon icon={faArrowDown} />
-              </Button>
-            </div>
-          )}
-          <MappingRow
-            row={row}
-            availableFields={encodingFields}
-            featureValues={featureValues}
-            isRaster={isRaster}
-            onChange={updated => updateRow(i, updated)}
-            onDelete={() => removeRow(i)}
-          />
-        </div>
-      ))}
+            )}
+            <MappingRow
+              row={row}
+              availableFields={encodingFields}
+              featureValues={featureValues}
+              isRaster={isRaster}
+              onChange={updated => updateRow(i, updated)}
+              onDelete={() => removeRow(i)}
+            />
+          </div>
+        ))}
+      </div>
 
       <div className="jp-gis-symbology-button-container">
         <Button

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -9,6 +9,7 @@
 import {
   faArrowDown,
   faArrowUp,
+  faGripVertical,
   faPlus,
   faTrash,
   faXmark,
@@ -206,6 +207,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
 }) => {
   const [addingLayerWhen, setAddingLayerWhen] = useState(false);
   const dragIndexRef = useRef<number | null>(null);
+  const dragOverRef = useRef<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const moveRow = useCallback(
@@ -412,27 +414,33 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         />
       ))}
 
-      {/* Mapping rows — draggable to reorder */}
+      {/* Mapping rows — reorder bar (drag + arrows) above each rule */}
       {layer.rows.map((row, i) => (
         <div
           key={row.id}
-          draggable
-          onDragStart={() => {
-            dragIndexRef.current = i;
-          }}
+          className="jp-gis-grammar-drag-wrapper"
+          draggable={dragIndexRef.current !== null}
           onDragOver={e => {
             e.preventDefault();
-            setDragOverIndex(i);
+            const rect = e.currentTarget.getBoundingClientRect();
+            const midY = rect.top + rect.height / 2;
+            const idx = e.clientY < midY ? i : i + 1;
+            dragOverRef.current = idx;
+            setDragOverIndex(idx);
           }}
           onDrop={() => {
-            if (dragIndexRef.current !== null) {
-              moveRow(dragIndexRef.current, i);
+            const over = dragOverRef.current;
+            if (dragIndexRef.current !== null && over !== null) {
+              const to = over > dragIndexRef.current ? over - 1 : over;
+              moveRow(dragIndexRef.current, to);
             }
             dragIndexRef.current = null;
+            dragOverRef.current = null;
             setDragOverIndex(null);
           }}
           onDragEnd={() => {
             dragIndexRef.current = null;
+            dragOverRef.current = null;
             setDragOverIndex(null);
           }}
           style={{
@@ -440,7 +448,12 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
               dragOverIndex === i && dragIndexRef.current !== i
                 ? '2px solid var(--jp-brand-color1)'
                 : '2px solid transparent',
-            cursor: 'grab',
+            borderBottom:
+              dragOverIndex === layer.rows.length &&
+              i === layer.rows.length - 1 &&
+              dragIndexRef.current !== i
+                ? '2px solid var(--jp-brand-color1)'
+                : '2px solid transparent',
           }}
         >
           <MappingRow
@@ -450,6 +463,44 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
             isRaster={isRaster}
             onChange={updated => updateRow(i, updated)}
             onDelete={() => removeRow(i)}
+            header={
+              layer.rows.length > 1 ? (
+                <div className="jp-gis-grammar-reorder-bar">
+                  <Button
+                    type="button"
+                    disabled={i === 0}
+                    onClick={() => moveRow(i, i - 1)}
+                    title="Move up"
+                  >
+                    <FontAwesomeIcon icon={faArrowUp} />
+                  </Button>
+                  <div
+                    className="jp-gis-grammar-drag-handle"
+                    draggable
+                    onDragStart={e => {
+                      dragIndexRef.current = i;
+                      const wrapper = e.currentTarget.closest(
+                        '.jp-gis-grammar-drag-wrapper',
+                      );
+                      if (wrapper) {
+                        e.dataTransfer.setDragImage(wrapper, 0, 0);
+                      }
+                    }}
+                    title="Drag to reorder"
+                  >
+                    <FontAwesomeIcon icon={faGripVertical} />
+                  </div>
+                  <Button
+                    type="button"
+                    disabled={i === layer.rows.length - 1}
+                    onClick={() => moveRow(i, i + 1)}
+                    title="Move down"
+                  >
+                    <FontAwesomeIcon icon={faArrowDown} />
+                  </Button>
+                </div>
+              ) : undefined
+            }
           />
         </div>
       ))}

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -505,10 +505,11 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
 
       <div className="jp-gis-symbology-button-container">
         <Button
-          className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+          variant="ghost"
           style={{ margin: '0 0 0.5rem 1rem' }}
           onClick={addRow}
         >
+          <FontAwesomeIcon icon={faPlus} />
           Add Mapping
         </Button>
       </div>

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -314,7 +314,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         </span>
         <Button
           type="button"
-          variant="outline"
+          variant="ghost"
           onClick={addTransform}
           title="Add transform"
         >
@@ -325,7 +325,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         {totalLayers > 1 && onMoveUp && (
           <Button
             type="button"
-            variant="outline"
+            variant="ghost"
             style={{ height: 32, width: 32 }}
             onClick={onMoveUp}
             title="Move layer up"
@@ -336,7 +336,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         {totalLayers > 1 && onMoveDown && (
           <Button
             type="button"
-            variant="outline"
+            variant="ghost"
             style={{ height: 32, width: 32 }}
             onClick={onMoveDown}
             title="Move layer down"
@@ -347,7 +347,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         {totalLayers > 1 && (
           <Button
             type="button"
-            variant="outline"
+            variant="ghost"
             style={{ height: 32, width: 32 }}
             onClick={onDelete}
             title="Remove layer"

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -89,33 +89,15 @@ interface ITransformRowProps {
   transform: ITransform;
   availableFields: string[];
   onChange: (t: ITransform) => void;
-  onDelete: () => void;
 }
 
 const TransformRow: React.FC<ITransformRowProps> = ({
   transform,
   availableFields,
   onChange,
-  onDelete,
 }) => {
-  const handleTypeChange = (type: ITransform['type']) => {
-    onChange(defaultTransform(type));
-  };
-
   return (
     <div className="jp-gis-grammar-transform-row">
-      {/* Type selector */}
-      <NativeSelect
-        value={transform.type}
-        onChange={e => handleTypeChange(e.target.value as ITransform['type'])}
-      >
-        {TRANSFORM_TYPES.map(({ value, label }) => (
-          <NativeSelectOption key={value} value={value}>
-            {label}
-          </NativeSelectOption>
-        ))}
-      </NativeSelect>
-
       {/* KDE params */}
       {transform.type === 'kde' && (
         <>
@@ -162,16 +144,6 @@ const TransformRow: React.FC<ITransformRowProps> = ({
           />
         </>
       )}
-
-      <Button
-        type="button"
-        className="jp-gis-grammar-delete-btn"
-        onClick={onDelete}
-        title="Remove transform"
-        style={{ marginLeft: 'auto' }}
-      >
-        <FontAwesomeIcon icon={faTrash} />
-      </Button>
     </div>
   );
 };
@@ -239,31 +211,22 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
     [layer, onChange],
   );
 
-  const updateTransform = useCallback(
-    (index: number, t: ITransform) => {
-      const next = [...layer.transforms];
-      next[index] = t;
-      onChange({ ...layer, transforms: next });
-    },
-    [layer, onChange],
-  );
-
-  const removeTransform = useCallback(
-    (index: number) => {
+  const setTransform = useCallback(
+    (type: ITransform['type'] | 'none') => {
       onChange({
         ...layer,
-        transforms: layer.transforms.filter((_, i) => i !== index),
+        transforms: type === 'none' ? [] : [defaultTransform(type)],
       });
     },
     [layer, onChange],
   );
 
-  const addTransform = useCallback(() => {
-    onChange({
-      ...layer,
-      transforms: [...layer.transforms, defaultTransform('kde')],
-    });
-  }, [layer, onChange]);
+  const updateTransform = useCallback(
+    (t: ITransform) => {
+      onChange({ ...layer, transforms: [t] });
+    },
+    [layer, onChange],
+  );
 
   const updateRow = useCallback(
     (index: number, row: IGrammarRow) => {
@@ -312,15 +275,19 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         <span className="jp-gis-grammar-layer-label">
           Layer {layerIndex + 1}
         </span>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={addTransform}
-          title="Add transform"
+        <NativeSelect
+          value={layer.transforms[0]?.type ?? 'none'}
+          onChange={e =>
+            setTransform(e.target.value as ITransform['type'] | 'none')
+          }
         >
-          <FontAwesomeIcon data-icon="inline-start" icon={faPlus} />
-          Transform
-        </Button>
+          <NativeSelectOption value="none">no transform</NativeSelectOption>
+          {TRANSFORM_TYPES.map(({ value, label }) => (
+            <NativeSelectOption key={value} value={value}>
+              {label}
+            </NativeSelectOption>
+          ))}
+        </NativeSelect>
 
         {totalLayers > 1 && onMoveUp && (
           <Button
@@ -403,16 +370,14 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         )}
       </div>
 
-      {/* Transforms */}
-      {layer.transforms.map((t, i) => (
+      {/* Transform params (single transform per layer) */}
+      {layer.transforms[0] && (
         <TransformRow
-          key={i}
-          transform={t}
+          transform={layer.transforms[0]}
           availableFields={availableFields}
-          onChange={updated => updateTransform(i, updated)}
-          onDelete={() => removeTransform(i)}
+          onChange={updateTransform}
         />
-      ))}
+      )}
 
       {/* Mapping rows — reorder bar (drag + arrows) above each rule */}
       {layer.rows.map((row, i) => (
@@ -686,10 +651,7 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
         />
       ))}
       <div className="jp-gis-symbology-button-container">
-        <Button
-          className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-          onClick={addLayer}
-        >
+        <Button className="jp-gis-grammar-action-btn" onClick={addLayer}>
           Add Layer
         </Button>
       </div>

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -456,6 +456,42 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
                 : '2px solid transparent',
           }}
         >
+          {layer.rows.length > 1 && (
+            <div className="jp-gis-grammar-reorder-bar">
+              <Button
+                type="button"
+                disabled={i === 0}
+                onClick={() => moveRow(i, i - 1)}
+                title="Move up"
+              >
+                <FontAwesomeIcon icon={faArrowUp} />
+              </Button>
+              <div
+                className="jp-gis-grammar-drag-handle"
+                draggable
+                onDragStart={e => {
+                  dragIndexRef.current = i;
+                  const wrapper = e.currentTarget.closest(
+                    '.jp-gis-grammar-drag-wrapper',
+                  );
+                  if (wrapper) {
+                    e.dataTransfer.setDragImage(wrapper, 0, 0);
+                  }
+                }}
+                title="Drag to reorder"
+              >
+                <FontAwesomeIcon icon={faGripVertical} />
+              </div>
+              <Button
+                type="button"
+                disabled={i === layer.rows.length - 1}
+                onClick={() => moveRow(i, i + 1)}
+                title="Move down"
+              >
+                <FontAwesomeIcon icon={faArrowDown} />
+              </Button>
+            </div>
+          )}
           <MappingRow
             row={row}
             availableFields={encodingFields}
@@ -463,44 +499,6 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
             isRaster={isRaster}
             onChange={updated => updateRow(i, updated)}
             onDelete={() => removeRow(i)}
-            header={
-              layer.rows.length > 1 ? (
-                <div className="jp-gis-grammar-reorder-bar">
-                  <Button
-                    type="button"
-                    disabled={i === 0}
-                    onClick={() => moveRow(i, i - 1)}
-                    title="Move up"
-                  >
-                    <FontAwesomeIcon icon={faArrowUp} />
-                  </Button>
-                  <div
-                    className="jp-gis-grammar-drag-handle"
-                    draggable
-                    onDragStart={e => {
-                      dragIndexRef.current = i;
-                      const wrapper = e.currentTarget.closest(
-                        '.jp-gis-grammar-drag-wrapper',
-                      );
-                      if (wrapper) {
-                        e.dataTransfer.setDragImage(wrapper, 0, 0);
-                      }
-                    }}
-                    title="Drag to reorder"
-                  >
-                    <FontAwesomeIcon icon={faGripVertical} />
-                  </div>
-                  <Button
-                    type="button"
-                    disabled={i === layer.rows.length - 1}
-                    onClick={() => moveRow(i, i + 1)}
-                    title="Move down"
-                  >
-                    <FontAwesomeIcon icon={faArrowDown} />
-                  </Button>
-                </div>
-              ) : undefined
-            }
           />
         </div>
       ))}

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -6,7 +6,13 @@
  * Multiple layers allow independent rendering pipelines on the same source.
  */
 
-import { faPlus, faTrash, faXmark } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowDown,
+  faArrowUp,
+  faPlus,
+  faTrash,
+  faXmark,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   IEncodingRule,
@@ -18,7 +24,7 @@ import {
   RGBA,
 } from '@jupytergis/schema';
 import { UUID } from '@lumino/coreutils';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import MappingRow, {
   IGrammarRow,
@@ -182,6 +188,8 @@ interface ILayerSectionProps {
   isRasterLayer?: boolean;
   onChange: (layer: ILayerUIState) => void;
   onDelete: () => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
 }
 
 const LayerSection: React.FC<ILayerSectionProps> = ({
@@ -193,8 +201,25 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
   isRasterLayer = false,
   onChange,
   onDelete,
+  onMoveUp,
+  onMoveDown,
 }) => {
   const [addingLayerWhen, setAddingLayerWhen] = useState(false);
+  const dragIndexRef = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const moveRow = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (fromIndex === toIndex) {
+        return;
+      }
+      const next = [...layer.rows];
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
+      onChange({ ...layer, rows: next });
+    },
+    [layer, onChange],
+  );
 
   const addLayerPredicate = useCallback(
     (pred: IPredicate) => {
@@ -295,6 +320,28 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
           Transform
         </Button>
 
+        {totalLayers > 1 && onMoveUp && (
+          <Button
+            type="button"
+            variant="outline"
+            style={{ height: 32, width: 32 }}
+            onClick={onMoveUp}
+            title="Move layer up"
+          >
+            <FontAwesomeIcon icon={faArrowUp} />
+          </Button>
+        )}
+        {totalLayers > 1 && onMoveDown && (
+          <Button
+            type="button"
+            variant="outline"
+            style={{ height: 32, width: 32 }}
+            onClick={onMoveDown}
+            title="Move layer down"
+          >
+            <FontAwesomeIcon icon={faArrowDown} />
+          </Button>
+        )}
         {totalLayers > 1 && (
           <Button
             type="button"
@@ -365,17 +412,46 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
         />
       ))}
 
-      {/* Mapping rows */}
+      {/* Mapping rows — draggable to reorder */}
       {layer.rows.map((row, i) => (
-        <MappingRow
+        <div
           key={row.id}
-          row={row}
-          availableFields={encodingFields}
-          featureValues={featureValues}
-          isRaster={isRaster}
-          onChange={updated => updateRow(i, updated)}
-          onDelete={() => removeRow(i)}
-        />
+          draggable
+          onDragStart={() => {
+            dragIndexRef.current = i;
+          }}
+          onDragOver={e => {
+            e.preventDefault();
+            setDragOverIndex(i);
+          }}
+          onDrop={() => {
+            if (dragIndexRef.current !== null) {
+              moveRow(dragIndexRef.current, i);
+            }
+            dragIndexRef.current = null;
+            setDragOverIndex(null);
+          }}
+          onDragEnd={() => {
+            dragIndexRef.current = null;
+            setDragOverIndex(null);
+          }}
+          style={{
+            borderTop:
+              dragOverIndex === i && dragIndexRef.current !== i
+                ? '2px solid var(--jp-brand-color1)'
+                : '2px solid transparent',
+            cursor: 'grab',
+          }}
+        >
+          <MappingRow
+            row={row}
+            availableFields={encodingFields}
+            featureValues={featureValues}
+            isRaster={isRaster}
+            onChange={updated => updateRow(i, updated)}
+            onDelete={() => removeRow(i)}
+          />
+        </div>
       ))}
 
       <div className="jp-gis-symbology-button-container">
@@ -519,6 +595,21 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
     ]);
   };
 
+  const moveLayer = useCallback(
+    (from: number, to: number) => {
+      if (from === to) {
+        return;
+      }
+      setLayers(prev => {
+        const next = [...prev];
+        const [moved] = next.splice(from, 1);
+        next.splice(to, 0, moved);
+        return next;
+      });
+    },
+    [setLayers],
+  );
+
   const availableFields = isRasterLayer
     ? bandRows.map(b => `$band-${b.band}`)
     : Object.keys(selectableAttributesAndValues);
@@ -538,6 +629,10 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
             setLayers(prev => prev.map((l, j) => (j === i ? updated : l)))
           }
           onDelete={() => setLayers(prev => prev.filter((_, j) => j !== i))}
+          onMoveUp={i > 0 ? () => moveLayer(i, i - 1) : undefined}
+          onMoveDown={
+            i < layers.length - 1 ? () => moveLayer(i, i + 1) : undefined
+          }
         />
       ))}
       <div className="jp-gis-symbology-button-container">

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -830,10 +830,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
             title={expanded ? 'Collapse editor' : 'Edit scale'}
           >
             <ScalePreview scale={row.scale} />
-            <span
-              className="jp-gis-grammar-preview-chevron"
-              aria-hidden="true"
-            >
+            <span className="jp-gis-grammar-preview-chevron" aria-hidden="true">
               {expanded ? '▾' : '▸'}
             </span>
           </button>
@@ -864,7 +861,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
               </div>
               <Button
                 type="button"
-                variant="outline"
+                variant="ghost"
                 size="icon-md"
                 className="jp-mod-styled"
                 onClick={() => removeChannel(ch)}

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -670,6 +670,7 @@ interface IMappingRowProps {
   availableFields: string[];
   featureValues: Record<string, Set<any>>;
   isRaster?: boolean;
+  header?: React.ReactNode;
   onChange: (row: IGrammarRow) => void;
   onDelete: () => void;
 }
@@ -683,6 +684,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
   availableFields,
   featureValues,
   isRaster = false,
+  header,
   onChange,
   onDelete,
 }) => {
@@ -791,6 +793,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
 
   return (
     <div className="jp-gis-grammar-rule">
+      {header}
       {/* CSS grid: col1=field col2=scheme col3=preview col4=arrow col5=channel col6=× */}
       <div className="jp-gis-grammar-rule-grid">
         {/* Field selector — row 1. Layout depends on fieldCountForScale. */}

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -830,6 +830,12 @@ const MappingRow: React.FC<IMappingRowProps> = ({
             title={expanded ? 'Collapse editor' : 'Edit scale'}
           >
             <ScalePreview scale={row.scale} />
+            <span
+              className="jp-gis-grammar-preview-chevron"
+              aria-hidden="true"
+            >
+              {expanded ? '▾' : '▸'}
+            </span>
           </button>
         </div>
 

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -670,7 +670,6 @@ interface IMappingRowProps {
   availableFields: string[];
   featureValues: Record<string, Set<any>>;
   isRaster?: boolean;
-  header?: React.ReactNode;
   onChange: (row: IGrammarRow) => void;
   onDelete: () => void;
 }
@@ -684,7 +683,6 @@ const MappingRow: React.FC<IMappingRowProps> = ({
   availableFields,
   featureValues,
   isRaster = false,
-  header,
   onChange,
   onDelete,
 }) => {
@@ -788,25 +786,29 @@ const MappingRow: React.FC<IMappingRowProps> = ({
 
   const compat = compatibleChannels(row.scale, isRaster);
   const availableToAdd = compat.filter(ch => !row.channels.includes(ch));
-  const previewRowSpan =
-    row.channels.length + (availableToAdd.length > 0 ? 1 : 0);
 
   return (
     <div className="jp-gis-grammar-rule">
-      {header}
-      {/* CSS grid: col1=field col2=scheme col3=preview col4=arrow col5=channel col6=× */}
+      {/* Desktop: 7-col grid; Mobile: stacked top-to-bottom via sections */}
       <div className="jp-gis-grammar-rule-grid">
-        {/* Field selector — row 1. Layout depends on fieldCountForScale. */}
-        <FieldSelector
-          fieldCount={fieldCountForScale(row.scale.scheme)}
-          fields={row.fields ?? []}
-          availableFields={availableFields}
-          onFieldChange={handleFieldChange}
-          onAddField={addField}
-        />
+        {/* --- Input section --- */}
+        <div className="jp-gis-grammar-section jp-gis-grammar-input-section">
+          <FieldSelector
+            fieldCount={fieldCountForScale(row.scale.scheme)}
+            fields={row.fields ?? []}
+            availableFields={availableFields}
+            onFieldChange={handleFieldChange}
+            onAddField={addField}
+          />
+        </div>
 
-        {/* Scheme — row 1 */}
-        <div style={{ gridRow: 1, gridColumn: 2 }}>
+        {/* Arrow: input → scale */}
+        <span className="jp-gis-grammar-arrow jp-gis-grammar-arrow-input">
+          →
+        </span>
+
+        {/* --- Scale section --- */}
+        <div className="jp-gis-grammar-section jp-gis-grammar-scale-section">
           <NativeSelect
             value={row.scale.scheme}
             onChange={e =>
@@ -821,92 +823,81 @@ const MappingRow: React.FC<IMappingRowProps> = ({
               ),
             )}
           </NativeSelect>
+          <button
+            type="button"
+            className="jp-gis-grammar-preview-btn"
+            onClick={() => setExpanded(v => !v)}
+            title={expanded ? 'Collapse editor' : 'Edit scale'}
+          >
+            <ScalePreview scale={row.scale} />
+          </button>
         </div>
 
-        {/* Scale preview — spans all channel rows + optional add-channel row */}
-        <button
-          type="button"
-          className="jp-gis-grammar-preview-btn"
-          style={{ gridRow: `1 / span ${previewRowSpan}`, gridColumn: 3 }}
-          onClick={() => setExpanded(v => !v)}
-          title={expanded ? 'Collapse editor' : 'Edit scale'}
-        >
-          <ScalePreview scale={row.scale} />
-        </button>
+        {/* Arrow: scale → output */}
+        <span className="jp-gis-grammar-arrow jp-gis-grammar-arrow-output">
+          →
+        </span>
 
-        {/* Per-channel rows */}
-        {row.channels.map((ch, i) => (
-          <React.Fragment key={`${ch}-${i}`}>
-            <span
-              className="jp-gis-grammar-arrow"
-              style={{ gridRow: i + 1, gridColumn: 4 }}
-            >
-              →
-            </span>
-            <div
-              className="jp-gis-grammar-channel-select"
-              style={{ gridRow: i + 1, gridColumn: 5 }}
-            >
-              <NativeSelect
-                value={ch}
-                onChange={e =>
-                  handleChannelChange(i, e.target.value as StyleChannel)
+        {/* --- Output section --- */}
+        <div className="jp-gis-grammar-section jp-gis-grammar-output-section">
+          {row.channels.map((ch, i) => (
+            <div key={`${ch}-${i}`} className="jp-gis-grammar-channel-row">
+              <div className="jp-gis-grammar-channel-select">
+                <NativeSelect
+                  value={ch}
+                  onChange={e =>
+                    handleChannelChange(i, e.target.value as StyleChannel)
+                  }
+                >
+                  {compat.map(c => (
+                    <NativeSelectOption key={c} value={c}>
+                      {CHANNEL_LABELS[c] ?? c}
+                    </NativeSelectOption>
+                  ))}
+                </NativeSelect>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-md"
+                className="jp-mod-styled"
+                onClick={() => removeChannel(ch)}
+                title={
+                  row.channels.length === 1
+                    ? 'Remove mapping'
+                    : 'Remove channel'
                 }
               >
-                {compat.map(c => (
-                  <NativeSelectOption key={c} value={c}>
-                    {CHANNEL_LABELS[c] ?? c}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
+                <FontAwesomeIcon icon={faTrash} />
+              </Button>
             </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon-md"
-              className="jp-mod-styled"
-              style={{ gridRow: i + 1, gridColumn: 6 }}
-              onClick={() => removeChannel(ch)}
-              title={
-                row.channels.length === 1 ? 'Remove mapping' : 'Remove channel'
-              }
-            >
-              <FontAwesomeIcon icon={faTrash} />
-            </Button>
-          </React.Fragment>
-        ))}
+          ))}
 
-        {/* Add channel row */}
-        {availableToAdd.length > 0 && (
-          <React.Fragment>
-            <span
-              className="jp-gis-grammar-arrow"
-              style={{ gridRow: row.channels.length + 1, gridColumn: 4 }}
-            >
-              +
-            </span>
-            <div
-              className="jp-gis-grammar-channel-select"
-              style={{ gridRow: row.channels.length + 1, gridColumn: 5 }}
-            >
-              <NativeSelect
-                value=""
-                onChange={e => {
-                  if (e.target.value) {
-                    addChannel(e.target.value as StyleChannel);
-                  }
-                }}
-              >
-                <NativeSelectOption value="">(add channel)</NativeSelectOption>
-                {availableToAdd.map(ch => (
-                  <NativeSelectOption key={ch} value={ch}>
-                    {CHANNEL_LABELS[ch] ?? ch}
+          {/* Add channel row */}
+          {availableToAdd.length > 0 && (
+            <div className="jp-gis-grammar-channel-row">
+              <div className="jp-gis-grammar-channel-select">
+                <NativeSelect
+                  value=""
+                  onChange={e => {
+                    if (e.target.value) {
+                      addChannel(e.target.value as StyleChannel);
+                    }
+                  }}
+                >
+                  <NativeSelectOption value="">
+                    (add channel)
                   </NativeSelectOption>
-                ))}
-              </NativeSelect>
+                  {availableToAdd.map(ch => (
+                    <NativeSelectOption key={ch} value={ch}>
+                      {CHANNEL_LABELS[ch] ?? ch}
+                    </NativeSelectOption>
+                  ))}
+                </NativeSelect>
+              </div>
             </div>
-          </React.Fragment>
-        )}
+          )}
+        </div>
       </div>
 
       {/* When clause */}

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -250,7 +250,7 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
         />
       </div>
       <button
-        className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+        className="jp-gis-grammar-action-btn"
         disabled={!field}
         onClick={classify}
       >
@@ -352,7 +352,7 @@ export const CategoricalEditor: React.FC<ICategoricalEditorProps> = ({
         />
       </div>
       <button
-        className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+        className="jp-gis-grammar-action-btn"
         disabled={!field}
         onClick={classify}
       >
@@ -476,10 +476,7 @@ export const ScalarEditor: React.FC<IScalarEditorProps> = ({
           onChange={v => update({ fallback: v })}
         />
       </div>
-      <button
-        className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-        onClick={classify}
-      >
+      <button className="jp-gis-grammar-action-btn" onClick={classify}>
         Set stops
       </button>
       {stopRows.length > 0 && (

--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampControls.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampControls.tsx
@@ -147,7 +147,7 @@ const ColorRampControls: React.FC<IColorRampControlsProps> = ({
         <LoadingIcon />
       ) : (
         <Button
-          className="jp-Dialog-button jp-mod-accept jp-mod-styled"
+          className="jp-gis-grammar-action-btn"
           disabled={
             !isValidNumberOfShades(numberOfShades) || !selectedMode || !!warning
           }

--- a/packages/base/src/features/layers/symbology/components/color_stops/StopContainer.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_stops/StopContainer.tsx
@@ -55,10 +55,7 @@ const StopContainer: React.FC<IStopContainerProps> = ({
         ))}
       </div>
       <div className="jp-gis-symbology-button-container">
-        <Button
-          className="jp-Dialog-button jp-mod-accept jp-mod-styled"
-          onClick={addStopRow}
-        >
+        <Button className="jp-gis-grammar-action-btn" onClick={addStopRow}>
           Add Stop
         </Button>
       </div>

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -513,6 +513,26 @@ select option {
   background: var(--jp-layout-color0);
 }
 
+.jp-gis-grammar-action-btn {
+  background: transparent;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: var(--jp-border-radius, 0.375rem);
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  padding: 4px 12px;
+  cursor: pointer;
+  width: fit-content;
+}
+
+.jp-gis-grammar-action-btn:hover {
+  background: var(--jp-layout-color2);
+}
+
+.jp-gis-grammar-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Preview button spans all channel rows — stretches vertically */
 .jp-gis-grammar-preview-btn {
   background: none;

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -257,6 +257,7 @@ select option {
   border-radius: 4px;
   margin-bottom: 8px;
   overflow: hidden;
+  background: color-mix(in srgb, var(--jp-layout-color2) 50%, transparent);
 }
 
 .jp-gis-grammar-layer-header {
@@ -264,8 +265,7 @@ select option {
   align-items: center;
   gap: 6px;
   padding: 4px 6px;
-  background: var(--jp-layout-color2);
-  border-bottom: 1px solid var(--jp-border-color2);
+  background: color-mix(in srgb, var(--jp-layout-color2) 50%, transparent);
 }
 
 .jp-gis-grammar-layer-label {
@@ -280,7 +280,7 @@ select option {
   align-items: center;
   gap: 6px;
   padding: 4px 6px;
-  background: var(--jp-layout-color2);
+  background: color-mix(in srgb, var(--jp-layout-color2) 50%, transparent);
   border-bottom: 1px solid var(--jp-border-color2);
   font-size: var(--jp-ui-font-size1);
 }
@@ -291,8 +291,20 @@ select option {
 }
 
 .jp-gis-grammar-transform-row input,
-.jp-gis-grammar-transform-row [data-slot='native-select'] {
+.jp-gis-grammar-transform-row [data-slot='native-select'],
+.jp-gis-grammar-transform-row select,
+.jp-gis-grammar-transform-row .jgis-native-select {
+  background: var(--jp-layout-color0);
+  background-color: var(--jp-layout-color0);
+  border-color: transparent;
+}
+
+.jp-gis-grammar-transform-row .jgis-button,
+.jp-gis-grammar-layer-header .jgis-button,
+.jp-gis-grammar-layer-section > .jp-gis-grammar-when-row .jgis-button {
+  background: transparent;
   background-color: transparent;
+  border-color: transparent;
 }
 
 /* ---------------------------------------------------------------------------
@@ -320,7 +332,7 @@ select option {
   gap: 0;
   padding: 2px 0;
   color: var(--jp-ui-font-color3);
-  background: var(--jp-layout-color2);
+  background: color-mix(in srgb, var(--jp-layout-color2) 50%, transparent);
   border: 1px solid var(--jp-border-color2);
   border-right: none;
   border-radius: 4px 0 0 4px;
@@ -400,6 +412,7 @@ select option {
   border: 1px solid var(--jp-border-color2);
   border-radius: 4px;
   overflow: hidden;
+  background: var(--jp-layout-color0);
 }
 
 /* Desktop: horizontal flow — input → scale+preview → output */
@@ -423,7 +436,6 @@ select option {
 }
 
 .jp-gis-grammar-scale-section .jp-gis-grammar-preview-btn {
-  flex: 1;
   min-width: 0;
 }
 
@@ -484,6 +496,7 @@ select option {
   .jp-gis-grammar-rule-grid > .jp-gis-grammar-arrow {
     align-self: flex-start;
     text-align: left;
+    transform: rotate(90deg);
   }
 
   .jp-gis-grammar-scale-section .jgis-native-select {
@@ -497,6 +510,7 @@ select option {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  background: var(--jp-layout-color0);
 }
 
 /* Preview button spans all channel rows — stretches vertically */
@@ -528,7 +542,7 @@ select option {
 }
 
 .jp-gis-grammar-preview-btn:hover {
-  background: var(--jp-layout-color2);
+  background: color-mix(in srgb, var(--jp-layout-color2) 40%, transparent);
 }
 
 .jp-gis-grammar-preview-btn:hover .jp-gis-grammar-preview-chevron {
@@ -588,6 +602,10 @@ select option {
 
 /* When clause */
 
+.jp-gis-grammar-layer-section > .jp-gis-grammar-when-row {
+  background: color-mix(in srgb, var(--jp-layout-color2) 50%, transparent);
+}
+
 .jp-gis-grammar-when-row {
   display: flex;
   align-items: center;
@@ -595,7 +613,7 @@ select option {
   gap: 4px;
   padding: 3px 6px 4px;
   border-top: 1px solid var(--jp-border-color3);
-  background: var(--jp-layout-color2);
+  background: var(--jp-layout-color1);
 }
 
 .jp-gis-grammar-when-label {
@@ -610,8 +628,8 @@ select option {
   padding: 0 4px;
   font-size: var(--jp-ui-font-size0);
   border-radius: 10px;
-  border: 1px solid var(--jp-border-color2);
-  background: var(--jp-layout-color2);
+  border: 1px solid transparent;
+  background: var(--jp-layout-color0);
   color: var(--jp-ui-font-color1);
   cursor: pointer;
 }
@@ -621,8 +639,8 @@ select option {
   align-items: center;
   gap: 2px;
   padding: 1px 6px;
-  background: var(--jp-layout-color2);
-  border: 1px solid var(--jp-border-color2);
+  background: var(--jp-layout-color0);
+  border: 1px solid transparent;
   border-radius: 10px;
   font-size: var(--jp-ui-font-size0);
   white-space: nowrap;
@@ -638,8 +656,9 @@ select option {
   font-size: 11px;
 }
 
-.jp-gis-grammar-when-add-btn {
-  background: none;
+.jgis-button.jp-gis-grammar-when-add-btn {
+  background: transparent;
+  background-color: transparent;
   border: 1px dashed var(--jp-border-color2);
   border-radius: 10px;
   padding: 1px 8px;

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -509,6 +509,18 @@ select option {
   overflow: hidden;
 }
 
+.jp-gis-grammar-preview-chevron {
+  flex-shrink: 0;
+  margin-left: auto;
+  color: var(--jp-ui-font-color3);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.jp-gis-grammar-preview-btn:hover .jp-gis-grammar-preview-chevron {
+  color: var(--jp-ui-font-color1);
+}
+
 .jp-gis-scale-preview {
   display: flex;
   align-items: center;

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -291,6 +291,64 @@ select option {
 }
 
 /* ---------------------------------------------------------------------------
+ * Grammar reorder pill (drag handle + arrows above each rule)
+ * --------------------------------------------------------------------------*/
+
+.jp-gis-grammar-drag-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.jp-gis-grammar-reorder-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0;
+  padding: 2px 4px;
+  border-bottom: 1px solid var(--jp-border-color2);
+  color: var(--jp-ui-font-color3);
+}
+
+.jp-gis-grammar-reorder-bar .jgis-button {
+  height: 20px;
+  width: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  color: var(--jp-ui-font-color3);
+  background: none;
+}
+
+.jp-gis-grammar-reorder-bar .jgis-button:hover:not(:disabled) {
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color3);
+}
+
+.jp-gis-grammar-reorder-bar .jgis-button:disabled {
+  opacity: 0.3;
+}
+
+.jp-gis-grammar-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  cursor: grab;
+  color: var(--jp-ui-font-color3);
+}
+
+.jp-gis-grammar-drag-handle:hover {
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color3);
+}
+
+.jp-gis-grammar-drag-handle:active {
+  cursor: grabbing;
+}
+
+/* ---------------------------------------------------------------------------
  * Grammar rule rows
  * --------------------------------------------------------------------------*/
 

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -290,6 +290,11 @@ select option {
   white-space: nowrap;
 }
 
+.jp-gis-grammar-transform-row input,
+.jp-gis-grammar-transform-row [data-slot='native-select'] {
+  background-color: transparent;
+}
+
 /* ---------------------------------------------------------------------------
  * Grammar reorder pill (drag handle + arrows above each rule)
  * --------------------------------------------------------------------------*/
@@ -444,11 +449,13 @@ select option {
   box-sizing: border-box;
 }
 
-.jp-gis-grammar-rule-grid [data-slot='native-select'] {
+.jp-gis-grammar-rule-grid [data-slot='native-select'],
+.jp-gis-grammar-transform-row [data-slot='native-select'] {
   border-color: transparent;
 }
 
-.jp-gis-grammar-rule-grid [data-slot='native-select']:hover {
+.jp-gis-grammar-rule-grid [data-slot='native-select']:hover,
+.jp-gis-grammar-transform-row [data-slot='native-select']:hover {
   border-color: var(--jp-border-color1);
 }
 
@@ -495,7 +502,7 @@ select option {
 /* Preview button spans all channel rows — stretches vertically */
 .jp-gis-grammar-preview-btn {
   background: none;
-  border: 1px solid var(--jp-border-color2);
+  border: 1px solid transparent;
   border-radius: 4px;
   padding: 4px 8px;
   cursor: pointer;
@@ -509,12 +516,19 @@ select option {
   overflow: hidden;
 }
 
+.jp-gis-grammar-preview-btn:hover {
+  border-color: var(--jp-border-color2);
+}
+
 .jp-gis-grammar-preview-chevron {
   flex-shrink: 0;
-  margin-left: auto;
   color: var(--jp-ui-font-color3);
   font-size: 12px;
   line-height: 1;
+}
+
+.jp-gis-grammar-preview-btn:hover {
+  background: var(--jp-layout-color2);
 }
 
 .jp-gis-grammar-preview-btn:hover .jp-gis-grammar-preview-chevron {
@@ -581,7 +595,7 @@ select option {
   gap: 4px;
   padding: 3px 6px 4px;
   border-top: 1px solid var(--jp-border-color3);
-  background: var(--jp-layout-color1);
+  background: var(--jp-layout-color2);
 }
 
 .jp-gis-grammar-when-label {

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -294,8 +294,8 @@ select option {
 .jp-gis-grammar-transform-row [data-slot='native-select'],
 .jp-gis-grammar-transform-row select,
 .jp-gis-grammar-transform-row .jgis-native-select {
-  background: var(--jp-layout-color0);
-  background-color: var(--jp-layout-color0);
+  background: transparent;
+  background-color: transparent;
   border-color: transparent;
 }
 
@@ -703,15 +703,29 @@ select option {
   flex: 0 0 auto;
 }
 
-.jp-gis-grammar-when-cancel {
-  background: none;
-  border: 1px solid var(--jp-border-color2);
-  border-radius: 3px;
-  padding: 1px 5px;
-  cursor: pointer;
+/* Make when-form selects compact to match the when-row height */
+.jp-gis-grammar-when-form [data-slot='native-select'] {
+  height: 24px;
   font-size: var(--jp-ui-font-size0);
-  color: var(--jp-ui-font-color1);
-  line-height: 1.4;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-color: transparent;
+}
+
+/* Make when-form inputs compact too */
+.jp-gis-grammar-when-form [data-slot='input'],
+.jp-gis-grammar-when-form input {
+  height: 24px;
+  font-size: var(--jp-ui-font-size0);
+  border-color: var(--jp-border-color2);
+  box-shadow: none;
+}
+
+/* Icon buttons in the when-form should be transparent, not white */
+.jp-gis-grammar-when-form .jgis-button {
+  background: transparent;
+  background-color: transparent;
+  border-color: transparent;
 }
 
 .jgis-button.jp-gis-grammar-when-form-cancel {

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -294,19 +294,36 @@ select option {
  * Grammar reorder pill (drag handle + arrows above each rule)
  * --------------------------------------------------------------------------*/
 
+/* Desktop: horizontal row with sidebar left of rule */
 .jp-gis-grammar-drag-wrapper {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: stretch;
 }
 
+.jp-gis-grammar-drag-wrapper > .jp-gis-grammar-rule {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Vertical sidebar: ↑ ⠿ ↓ stacked */
 .jp-gis-grammar-reorder-bar {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0;
-  padding: 2px 4px;
-  border-bottom: 1px solid var(--jp-border-color2);
+  padding: 2px 0;
   color: var(--jp-ui-font-color3);
+  background: var(--jp-layout-color2);
+  border: 1px solid var(--jp-border-color2);
+  border-right: none;
+  border-radius: 4px 0 0 4px;
+}
+
+.jp-gis-grammar-reorder-bar + .jp-gis-grammar-rule {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .jp-gis-grammar-reorder-bar .jgis-button {
@@ -332,7 +349,7 @@ select option {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
+  width: 22px;
   height: 20px;
   flex-shrink: 0;
   cursor: grab;
@@ -348,6 +365,28 @@ select option {
   cursor: grabbing;
 }
 
+/* Mobile: horizontal bar on top */
+@media (max-width: 960px) {
+  .jp-gis-grammar-drag-wrapper {
+    flex-direction: column;
+  }
+
+  .jp-gis-grammar-reorder-bar {
+    flex-direction: row;
+    justify-content: flex-start;
+    padding: 0 2px;
+    border-right: 1px solid var(--jp-border-color2);
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+  }
+
+  .jp-gis-grammar-reorder-bar + .jp-gis-grammar-rule {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-left-radius: 4px;
+  }
+}
+
 /* ---------------------------------------------------------------------------
  * Grammar rule rows
  * --------------------------------------------------------------------------*/
@@ -358,31 +397,90 @@ select option {
   overflow: hidden;
 }
 
-/* 6-column grid: field | scheme | preview | arrow | channel | × */
+/* Desktop: horizontal flow — input → scale+preview → output */
 .jp-gis-grammar-rule-grid {
-  display: grid;
-  grid-template-columns: max-content max-content 1fr auto max-content auto;
+  display: flex;
   align-items: center;
-  column-gap: 4px;
-  row-gap: 3px;
+  gap: 4px;
   padding: 4px 6px;
-  position: relative;
 }
 
-.jp-gis-grammar-rule-grid .jp-gis-grammar-channel-select {
-  width: 100%;
+.jp-gis-grammar-section {
+  display: contents;
+}
+
+.jp-gis-grammar-scale-section {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
   min-width: 0;
 }
 
-.jp-gis-grammar-rule-grid .jp-gis-grammar-channel-select .jgis-combobox-button,
-.jp-gis-grammar-rule-grid .jp-gis-grammar-channel-select .jgis-native-select {
+.jp-gis-grammar-scale-section .jp-gis-grammar-preview-btn {
+  flex: 1;
+  min-width: 0;
+}
+
+.jp-gis-grammar-output-section {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.jp-gis-grammar-channel-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.jp-gis-grammar-channel-select {
+  min-width: 0;
+}
+
+.jp-gis-grammar-channel-select .jgis-combobox-button,
+.jp-gis-grammar-channel-select .jgis-native-select {
   width: 100%;
   box-sizing: border-box;
 }
 
+.jp-gis-grammar-rule-grid [data-slot='native-select'] {
+  border-color: transparent;
+}
+
+.jp-gis-grammar-rule-grid [data-slot='native-select']:hover {
+  border-color: var(--jp-border-color1);
+}
+
+/* Mobile: stacked top-to-bottom */
 @media (max-width: 960px) {
   .jp-gis-grammar-rule-grid {
-    grid-template-columns: 1fr 1fr auto;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .jp-gis-grammar-section {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .jp-gis-grammar-input-section {
+    display: contents;
+  }
+
+  .jp-gis-grammar-scale-section {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .jp-gis-grammar-rule-grid > .jp-gis-grammar-arrow {
+    align-self: flex-start;
+    text-align: left;
+  }
+
+  .jp-gis-grammar-scale-section .jgis-native-select {
+    align-self: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- Rules within a layer can be reordered via drag-and-drop
- Layers can be reordered via up/down arrow buttons in the layer header
- harminize styling
- move from left to right to top to bottom layout for individual rules on mobile

Closes #1476

## Test plan
- [ ] Open symbology dialog with multiple rules, drag to reorder, verify render order changes
- [ ] Add multiple layers, use arrow buttons to reorder, verify render order changes

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1486.org.readthedocs.build/en/1486/
💡 JupyterLite preview: https://jupytergis--1486.org.readthedocs.build/en/1486/lite
💡 Specta preview: https://jupytergis--1486.org.readthedocs.build/en/1486/lite/specta

<!-- readthedocs-preview jupytergis end -->