### PR TITLE
Add navbar to vertical scroll stories

### DIFF
--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -1,5 +1,5 @@
 import { IJupyterGISModel } from '@jupytergis/schema';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 
 import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
 import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSegmentIndex';
@@ -16,8 +16,19 @@ interface IListStoryTitleBarProps {
 export function ListStoryTitleBar({
   model,
 }: IListStoryTitleBarProps): JSX.Element {
+  const segmentsRef = useRef<HTMLDivElement>(null);
   const currentIndex = useCurrentSegmentIndex(model);
   const { scrollToSegmentIndex } = useListStoryScrollTrackContext();
+
+  const scrollSegments = useCallback((direction: -1 | 1): void => {
+    const segments = segmentsRef.current;
+    if (!segments) {
+      return;
+    }
+
+    const amount = Math.max(120, segments.clientWidth * 0.6);
+    segments.scrollBy({ left: direction * amount, behavior: 'smooth' });
+  }, []);
 
   const segmentItems = useMemo(
     () =>
@@ -30,7 +41,17 @@ export function ListStoryTitleBar({
 
   return (
     <nav className="jgis-story-title-bar" aria-label="Story segments">
-      <div className="jgis-story-title-bar-segments">
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="jgis-story-title-bar-scroll-btn"
+        aria-label="Scroll segments left"
+        onClick={() => scrollSegments(-1)}
+      >
+        ‹
+      </Button>
+      <div ref={segmentsRef} className="jgis-story-title-bar-segments">
         {segmentItems.map(item => (
           <Button
             key={item.id}
@@ -46,6 +67,16 @@ export function ListStoryTitleBar({
           </Button>
         ))}
       </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="jgis-story-title-bar-scroll-btn"
+        aria-label="Scroll segments right"
+        onClick={() => scrollSegments(1)}
+      >
+        ›
+      </Button>
     </nav>
   );
 }

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -78,9 +78,30 @@ export function ListStoryTitleBar({
     [model],
   );
 
+  const activeSegment = segmentItems.find(item => item.index === currentIndex);
+
   const currentPosition = segmentItems.findIndex(
     item => item.index === currentIndex,
   );
+  const prevSegmentIdRef = useRef<string | undefined>(undefined);
+  const slideDirectionRef = useRef<'next' | 'prev' | undefined>(undefined);
+
+  if (activeSegment?.id !== prevSegmentIdRef.current) {
+    const prevId = prevSegmentIdRef.current;
+    if (prevId) {
+      const prevPosition = segmentItems.findIndex(item => item.id === prevId);
+      if (prevPosition >= 0 && currentPosition >= 0) {
+        slideDirectionRef.current =
+          currentPosition > prevPosition ? 'next' : 'prev';
+      } else {
+        slideDirectionRef.current = undefined;
+      }
+    } else {
+      slideDirectionRef.current = undefined;
+    }
+    prevSegmentIdRef.current = activeSegment?.id;
+  }
+
   const hasPrev = currentPosition > 0;
   const hasNext =
     currentPosition >= 0 && currentPosition < segmentItems.length - 1;
@@ -131,6 +152,10 @@ export function ListStoryTitleBar({
   }, [isMobile]);
 
   useLayoutEffect(() => {
+    if (isMobile) {
+      return;
+    }
+
     const segments = segmentsRef.current;
     if (!segments) {
       return;
@@ -148,7 +173,7 @@ export function ListStoryTitleBar({
       block: 'nearest',
       inline: 'nearest',
     });
-  }, [currentIndex]);
+  }, [currentIndex, isMobile]);
 
   return (
     <nav
@@ -205,12 +230,23 @@ export function ListStoryTitleBar({
           <ChevronLeft />
         </Button>
       ) : null}
-      <ListStoryTitleBarSegments
-        ref={segmentsRef}
-        segmentItems={segmentItems}
-        currentIndex={currentIndex}
-        onSegmentClick={scrollToSegmentIndex}
-      />
+      {isMobile ? (
+        <span
+          key={activeSegment?.id}
+          className="jGIS-layer-browser-category jgis-story-title-bar-active-segment"
+          data-state="active"
+          data-slide-direction={slideDirectionRef.current}
+        >
+          {activeSegment?.layerName ?? ''}
+        </span>
+      ) : (
+        <ListStoryTitleBarSegments
+          ref={segmentsRef}
+          segmentItems={segmentItems}
+          currentIndex={currentIndex}
+          onSegmentClick={scrollToSegmentIndex}
+        />
+      )}
       {!isMobile && hasOverflow ? (
         <Button
           type="button"

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -1,10 +1,17 @@
 import { IJupyterGISModel } from '@jupytergis/schema';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
 import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSegmentIndex';
 import { buildStorySegmentViewItems } from '@/src/features/story/utils/storySegmentViewItems';
 import { Button } from '@/src/shared/components/Button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface IListStoryTitleBarProps {
   model: IJupyterGISModel;
@@ -17,6 +24,7 @@ export function ListStoryTitleBar({
   model,
 }: IListStoryTitleBarProps): JSX.Element {
   const segmentsRef = useRef<HTMLDivElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
   const currentIndex = useCurrentSegmentIndex(model);
   const { scrollToSegmentIndex } = useListStoryScrollTrackContext();
 
@@ -36,25 +44,46 @@ export function ListStoryTitleBar({
     [model],
   );
 
+  useLayoutEffect(() => {
+    const segments = segmentsRef.current;
+    if (!segments) {
+      return;
+    }
+
+    const update = (): void => {
+      setHasOverflow(segments.scrollWidth > segments.clientWidth);
+    };
+
+    update();
+
+    const ro = new ResizeObserver(update);
+    ro.observe(segments);
+
+    return () => {
+      ro.disconnect();
+    };
+  }, []);
+
   return (
     <nav className="jgis-story-title-bar" aria-label="Story segments">
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="jgis-story-title-bar-scroll-btn"
-        aria-label="Scroll segments left"
-        onClick={() => scrollSegments(-1)}
-      >
-        ‹
-      </Button>
+      {hasOverflow ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="jgis-story-title-bar-scroll-btn"
+          aria-label="Scroll segments left"
+          onClick={() => scrollSegments(-1)}
+        >
+          <ChevronLeft />
+        </Button>
+      ) : null}
       <div ref={segmentsRef} className="jgis-story-title-bar-segments">
         {segmentItems.map(item => {
           const isActive = item.index === currentIndex;
           return (
             <button
               key={item.id}
-              type="button"
               className="jGIS-layer-browser-category jgis-story-title-bar-segment"
               data-state={isActive ? 'active' : 'inactive'}
               aria-current={isActive ? 'true' : undefined}
@@ -66,16 +95,18 @@ export function ListStoryTitleBar({
           );
         })}
       </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="jgis-story-title-bar-scroll-btn"
-        aria-label="Scroll segments right"
-        onClick={() => scrollSegments(1)}
-      >
-        ›
-      </Button>
+      {hasOverflow ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="jgis-story-title-bar-scroll-btn"
+          aria-label="Scroll segments right"
+          onClick={() => scrollSegments(1)}
+        >
+          <ChevronRight />
+        </Button>
+      ) : null}
     </nav>
   );
 }

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -9,19 +9,57 @@ import React, {
 
 import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
 import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSegmentIndex';
+import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
 import { buildStorySegmentViewItems } from '@/src/features/story/utils/storySegmentViewItems';
 import { Button } from '@/src/shared/components/Button';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Menu } from 'lucide-react';
 
 interface IListStoryTitleBarProps {
   model: IJupyterGISModel;
+  isMobile: boolean;
 }
+
+interface IListStoryTitleBarSegmentsProps {
+  segmentItems: IStorySegmentViewItem[];
+  currentIndex: number;
+  onSegmentClick: (index: number) => void;
+}
+
+const ListStoryTitleBarSegments = React.forwardRef<
+  HTMLDivElement,
+  IListStoryTitleBarSegmentsProps
+>(function ListStoryTitleBarSegments(
+  { segmentItems, currentIndex, onSegmentClick },
+  ref,
+) {
+  return (
+    <div ref={ref} className="jgis-story-title-bar-segments">
+      {segmentItems.map(item => {
+        const isActive = item.index === currentIndex;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            className="jGIS-layer-browser-category jgis-story-title-bar-segment"
+            data-state={isActive ? 'active' : 'inactive'}
+            aria-current={isActive ? 'true' : undefined}
+            aria-label={`Go to ${item.layerName}`}
+            onClick={() => onSegmentClick(item.index)}
+          >
+            {item.layerName}
+          </button>
+        );
+      })}
+    </div>
+  );
+});
 
 /**
  * Story stage title bar: one button per segment, labeled with the segment layer name.
  */
 export function ListStoryTitleBar({
   model,
+  isMobile,
 }: IListStoryTitleBarProps): JSX.Element {
   const segmentsRef = useRef<HTMLDivElement>(null);
   const [hasOverflow, setHasOverflow] = useState(false);
@@ -55,6 +93,10 @@ export function ListStoryTitleBar({
   );
 
   useLayoutEffect(() => {
+    if (isMobile) {
+      return;
+    }
+
     const segments = segmentsRef.current;
     if (!segments) {
       return;
@@ -72,7 +114,7 @@ export function ListStoryTitleBar({
     return () => {
       ro.disconnect();
     };
-  }, []);
+  }, [isMobile]);
 
   useLayoutEffect(() => {
     const segments = segmentsRef.current;
@@ -95,8 +137,23 @@ export function ListStoryTitleBar({
   }, [currentIndex]);
 
   return (
-    <nav className="jgis-story-title-bar" aria-label="Story segments">
-      {hasOverflow ? (
+    <nav
+      className={`jgis-story-title-bar${
+        isMobile ? ' jgis-story-title-bar--mobile' : ''
+      }`}
+      aria-label="Story segments"
+    >
+      {isMobile ? (
+        <Button
+          type="button"
+          variant="ghost"
+          className="jgis-story-title-bar-menu-btn"
+          aria-label="Open story menu"
+        >
+          <Menu />
+        </Button>
+      ) : null}
+      {!isMobile && hasOverflow ? (
         <Button
           type="button"
           variant="ghost"
@@ -109,25 +166,13 @@ export function ListStoryTitleBar({
           <ChevronLeft />
         </Button>
       ) : null}
-      <div ref={segmentsRef} className="jgis-story-title-bar-segments">
-        {segmentItems.map(item => {
-          const isActive = item.index === currentIndex;
-          return (
-            <button
-              key={item.id}
-              type="button"
-              className="jGIS-layer-browser-category jgis-story-title-bar-segment"
-              data-state={isActive ? 'active' : 'inactive'}
-              aria-current={isActive ? 'true' : undefined}
-              aria-label={`Go to ${item.layerName}`}
-              onClick={() => scrollToSegmentIndex(item.index)}
-            >
-              {item.layerName}
-            </button>
-          );
-        })}
-      </div>
-      {hasOverflow ? (
+      <ListStoryTitleBarSegments
+        ref={segmentsRef}
+        segmentItems={segmentItems}
+        currentIndex={currentIndex}
+        onSegmentClick={scrollToSegmentIndex}
+      />
+      {!isMobile && hasOverflow ? (
         <Button
           type="button"
           variant="ghost"

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -28,20 +28,30 @@ export function ListStoryTitleBar({
   const currentIndex = useCurrentSegmentIndex(model);
   const { scrollToSegmentIndex } = useListStoryScrollTrackContext();
 
-  const scrollSegments = useCallback((direction: -1 | 1): void => {
-    const segments = segmentsRef.current;
-    if (!segments) {
-      return;
-    }
-
-    const amount = Math.max(120, segments.clientWidth * 0.6);
-    segments.scrollBy({ left: direction * amount, behavior: 'smooth' });
-  }, []);
-
   const segmentItems = useMemo(
     () =>
       buildStorySegmentViewItems(model, model.getSelectedStory().story ?? null),
     [model],
+  );
+
+  const currentPosition = segmentItems.findIndex(
+    item => item.index === currentIndex,
+  );
+  const hasPrev = currentPosition > 0;
+  const hasNext =
+    currentPosition >= 0 && currentPosition < segmentItems.length - 1;
+
+  const goToAdjacentSegment = useCallback(
+    (direction: -1 | 1): void => {
+      const nextPosition = currentPosition + direction;
+      const nextItem = segmentItems[nextPosition];
+      if (!nextItem) {
+        return;
+      }
+
+      scrollToSegmentIndex(nextItem.index);
+    },
+    [currentPosition, segmentItems, scrollToSegmentIndex],
   );
 
   useLayoutEffect(() => {
@@ -64,6 +74,26 @@ export function ListStoryTitleBar({
     };
   }, []);
 
+  useLayoutEffect(() => {
+    const segments = segmentsRef.current;
+    if (!segments) {
+      return;
+    }
+
+    const active = segments.querySelector(
+      '.jgis-story-title-bar-segment[data-state="active"]',
+    );
+    if (!(active instanceof HTMLElement)) {
+      return;
+    }
+
+    active.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  }, [currentIndex]);
+
   return (
     <nav className="jgis-story-title-bar" aria-label="Story segments">
       {hasOverflow ? (
@@ -72,8 +102,9 @@ export function ListStoryTitleBar({
           variant="ghost"
           size="icon-sm"
           className="jgis-story-title-bar-scroll-btn"
-          aria-label="Scroll segments left"
-          onClick={() => scrollSegments(-1)}
+          aria-label="Previous segment"
+          disabled={!hasPrev}
+          onClick={() => goToAdjacentSegment(-1)}
         >
           <ChevronLeft />
         </Button>
@@ -84,6 +115,7 @@ export function ListStoryTitleBar({
           return (
             <button
               key={item.id}
+              type="button"
               className="jGIS-layer-browser-category jgis-story-title-bar-segment"
               data-state={isActive ? 'active' : 'inactive'}
               aria-current={isActive ? 'true' : undefined}
@@ -101,8 +133,9 @@ export function ListStoryTitleBar({
           variant="ghost"
           size="icon-sm"
           className="jgis-story-title-bar-scroll-btn"
-          aria-label="Scroll segments right"
-          onClick={() => scrollSegments(1)}
+          aria-label="Next segment"
+          disabled={!hasNext}
+          onClick={() => goToAdjacentSegment(1)}
         >
           <ChevronRight />
         </Button>

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -1,63 +1,16 @@
 import { IJupyterGISModel } from '@jupytergis/schema';
-import React, {
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useMemo } from 'react';
 
+import { ListStoryTitleBarDesktop } from '@/src/features/story/components/ListStoryTitleBarDesktop';
+import { ListStoryTitleBarMobile } from '@/src/features/story/components/ListStoryTitleBarMobile';
 import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
 import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSegmentIndex';
-import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
 import { buildStorySegmentViewItems } from '@/src/features/story/utils/storySegmentViewItems';
-import { Button } from '@/src/shared/components/Button';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/src/shared/components/Popover';
-import { ChevronLeft, ChevronRight, Menu } from 'lucide-react';
 
 interface IListStoryTitleBarProps {
   model: IJupyterGISModel;
   isMobile: boolean;
 }
-
-interface IListStoryTitleBarSegmentsProps {
-  segmentItems: IStorySegmentViewItem[];
-  currentIndex: number;
-  onSegmentClick: (index: number) => void;
-}
-
-const ListStoryTitleBarSegments = React.forwardRef<
-  HTMLDivElement,
-  IListStoryTitleBarSegmentsProps
->(function ListStoryTitleBarSegments(
-  { segmentItems, currentIndex, onSegmentClick },
-  ref,
-) {
-  return (
-    <div ref={ref} className="jgis-story-title-bar-segments">
-      {segmentItems.map(item => {
-        const isActive = item.index === currentIndex;
-        return (
-          <button
-            key={item.id}
-            type="button"
-            className="jGIS-layer-browser-category jgis-story-title-bar-segment"
-            data-state={isActive ? 'active' : 'inactive'}
-            aria-current={isActive ? 'true' : undefined}
-            aria-label={`Go to ${item.layerName}`}
-            onClick={() => onSegmentClick(item.index)}
-          >
-            {item.layerName}
-          </button>
-        );
-      })}
-    </div>
-  );
-});
 
 /**
  * Story stage title bar: one button per segment, labeled with the segment layer name.
@@ -66,9 +19,6 @@ export function ListStoryTitleBar({
   model,
   isMobile,
 }: IListStoryTitleBarProps): JSX.Element {
-  const segmentsRef = useRef<HTMLDivElement>(null);
-  const [hasOverflow, setHasOverflow] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
   const currentIndex = useCurrentSegmentIndex(model);
   const { scrollToSegmentIndex } = useListStoryScrollTrackContext();
 
@@ -78,188 +28,15 @@ export function ListStoryTitleBar({
     [model],
   );
 
-  const activeSegment = segmentItems.find(item => item.index === currentIndex);
+  const titleBarProps = {
+    segmentItems,
+    currentIndex,
+    onSegmentClick: scrollToSegmentIndex,
+  };
 
-  const currentPosition = segmentItems.findIndex(
-    item => item.index === currentIndex,
-  );
-  const prevSegmentIdRef = useRef<string | undefined>(undefined);
-  const slideDirectionRef = useRef<'next' | 'prev' | undefined>(undefined);
-
-  if (activeSegment?.id !== prevSegmentIdRef.current) {
-    const prevId = prevSegmentIdRef.current;
-    if (prevId) {
-      const prevPosition = segmentItems.findIndex(item => item.id === prevId);
-      if (prevPosition >= 0 && currentPosition >= 0) {
-        slideDirectionRef.current =
-          currentPosition > prevPosition ? 'next' : 'prev';
-      } else {
-        slideDirectionRef.current = undefined;
-      }
-    } else {
-      slideDirectionRef.current = undefined;
-    }
-    prevSegmentIdRef.current = activeSegment?.id;
+  if (isMobile) {
+    return <ListStoryTitleBarMobile {...titleBarProps} />;
   }
 
-  const hasPrev = currentPosition > 0;
-  const hasNext =
-    currentPosition >= 0 && currentPosition < segmentItems.length - 1;
-
-  const goToAdjacentSegment = useCallback(
-    (direction: -1 | 1): void => {
-      const nextPosition = currentPosition + direction;
-      const nextItem = segmentItems[nextPosition];
-      if (!nextItem) {
-        return;
-      }
-
-      scrollToSegmentIndex(nextItem.index);
-    },
-    [currentPosition, segmentItems, scrollToSegmentIndex],
-  );
-
-  const handleMenuSegmentClick = useCallback(
-    (index: number): void => {
-      scrollToSegmentIndex(index);
-      setMenuOpen(false);
-    },
-    [scrollToSegmentIndex],
-  );
-
-  useLayoutEffect(() => {
-    if (isMobile) {
-      return;
-    }
-
-    const segments = segmentsRef.current;
-    if (!segments) {
-      return;
-    }
-
-    const update = (): void => {
-      setHasOverflow(segments.scrollWidth > segments.clientWidth);
-    };
-
-    update();
-
-    const ro = new ResizeObserver(update);
-    ro.observe(segments);
-
-    return () => {
-      ro.disconnect();
-    };
-  }, [isMobile]);
-
-  useLayoutEffect(() => {
-    if (isMobile) {
-      return;
-    }
-
-    const segments = segmentsRef.current;
-    if (!segments) {
-      return;
-    }
-
-    const active = segments.querySelector(
-      '.jgis-story-title-bar-segment[data-state="active"]',
-    );
-    if (!(active instanceof HTMLElement)) {
-      return;
-    }
-
-    active.scrollIntoView({
-      behavior: 'smooth',
-      block: 'nearest',
-      inline: 'nearest',
-    });
-  }, [currentIndex, isMobile]);
-
-  return (
-    <nav
-      className={`jgis-story-title-bar${
-        isMobile ? ' jgis-story-title-bar--mobile' : ''
-      }`}
-      aria-label="Story segments"
-    >
-      {isMobile ? (
-        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              className="jgis-story-title-bar-menu-btn"
-              aria-label="Open story menu"
-            >
-              <Menu />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent
-            align="center"
-            side="bottom"
-            className="jgis-story-title-bar-segment-menu"
-          >
-            {segmentItems.map(item => {
-              const isActive = item.index === currentIndex;
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  className="jGIS-layer-browser-category jgis-story-title-bar-segment-menu-item"
-                  data-state={isActive ? 'active' : 'inactive'}
-                  aria-current={isActive ? 'true' : undefined}
-                  onClick={() => handleMenuSegmentClick(item.index)}
-                >
-                  {item.layerName}
-                </button>
-              );
-            })}
-          </PopoverContent>
-        </Popover>
-      ) : null}
-      {!isMobile && hasOverflow ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          className="jgis-story-title-bar-scroll-btn"
-          aria-label="Previous segment"
-          disabled={!hasPrev}
-          onClick={() => goToAdjacentSegment(-1)}
-        >
-          <ChevronLeft />
-        </Button>
-      ) : null}
-      {isMobile ? (
-        <span
-          key={activeSegment?.id}
-          className="jGIS-layer-browser-category jgis-story-title-bar-active-segment"
-          data-state="active"
-          data-slide-direction={slideDirectionRef.current}
-        >
-          {activeSegment?.layerName ?? ''}
-        </span>
-      ) : (
-        <ListStoryTitleBarSegments
-          ref={segmentsRef}
-          segmentItems={segmentItems}
-          currentIndex={currentIndex}
-          onSegmentClick={scrollToSegmentIndex}
-        />
-      )}
-      {!isMobile && hasOverflow ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          className="jgis-story-title-bar-scroll-btn"
-          aria-label="Next segment"
-          disabled={!hasNext}
-          onClick={() => goToAdjacentSegment(1)}
-        >
-          <ChevronRight />
-        </Button>
-      ) : null}
-    </nav>
-  );
+  return <ListStoryTitleBarDesktop {...titleBarProps} />;
 }

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -12,9 +12,6 @@ interface IListStoryTitleBarProps {
   isMobile: boolean;
 }
 
-/**
- * Story stage title bar: one button per segment, labeled with the segment layer name.
- */
 export function ListStoryTitleBar({
   model,
   isMobile,

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -1,0 +1,51 @@
+import { IJupyterGISModel } from '@jupytergis/schema';
+import React, { useMemo } from 'react';
+
+import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
+import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSegmentIndex';
+import { buildStorySegmentViewItems } from '@/src/features/story/utils/storySegmentViewItems';
+import { Button } from '@/src/shared/components/Button';
+
+interface IListStoryTitleBarProps {
+  model: IJupyterGISModel;
+}
+
+/**
+ * Story stage title bar: one button per segment, labeled with the segment layer name.
+ */
+export function ListStoryTitleBar({
+  model,
+}: IListStoryTitleBarProps): JSX.Element {
+  const currentIndex = useCurrentSegmentIndex(model);
+  const { scrollToSegmentIndex } = useListStoryScrollTrackContext();
+
+  const segmentItems = useMemo(
+    () =>
+      buildStorySegmentViewItems(
+        model,
+        model.getSelectedStory().story ?? null,
+      ),
+    [model],
+  );
+
+  return (
+    <nav className="jgis-story-title-bar" aria-label="Story segments">
+      <div className="jgis-story-title-bar-segments">
+        {segmentItems.map(item => (
+          <Button
+            key={item.id}
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="jgis-story-title-bar-segment"
+            aria-current={item.index === currentIndex ? 'true' : undefined}
+            aria-label={`Go to ${item.layerName}`}
+            onClick={() => scrollToSegmentIndex(item.index)}
+          >
+            {item.layerName}
+          </Button>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -12,6 +12,11 @@ import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSeg
 import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
 import { buildStorySegmentViewItems } from '@/src/features/story/utils/storySegmentViewItems';
 import { Button } from '@/src/shared/components/Button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/src/shared/components/Popover';
 import { ChevronLeft, ChevronRight, Menu } from 'lucide-react';
 
 interface IListStoryTitleBarProps {
@@ -63,6 +68,7 @@ export function ListStoryTitleBar({
 }: IListStoryTitleBarProps): JSX.Element {
   const segmentsRef = useRef<HTMLDivElement>(null);
   const [hasOverflow, setHasOverflow] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const currentIndex = useCurrentSegmentIndex(model);
   const { scrollToSegmentIndex } = useListStoryScrollTrackContext();
 
@@ -90,6 +96,14 @@ export function ListStoryTitleBar({
       scrollToSegmentIndex(nextItem.index);
     },
     [currentPosition, segmentItems, scrollToSegmentIndex],
+  );
+
+  const handleMenuSegmentClick = useCallback(
+    (index: number): void => {
+      scrollToSegmentIndex(index);
+      setMenuOpen(false);
+    },
+    [scrollToSegmentIndex],
   );
 
   useLayoutEffect(() => {
@@ -144,14 +158,39 @@ export function ListStoryTitleBar({
       aria-label="Story segments"
     >
       {isMobile ? (
-        <Button
-          type="button"
-          variant="ghost"
-          className="jgis-story-title-bar-menu-btn"
-          aria-label="Open story menu"
-        >
-          <Menu />
-        </Button>
+        <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="jgis-story-title-bar-menu-btn"
+              aria-label="Open story menu"
+            >
+              <Menu />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="center"
+            side="bottom"
+            className="jgis-story-title-bar-segment-menu"
+          >
+            {segmentItems.map(item => {
+              const isActive = item.index === currentIndex;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  className="jGIS-layer-browser-category jgis-story-title-bar-segment-menu-item"
+                  data-state={isActive ? 'active' : 'inactive'}
+                  aria-current={isActive ? 'true' : undefined}
+                  onClick={() => handleMenuSegmentClick(item.index)}
+                >
+                  {item.layerName}
+                </button>
+              );
+            })}
+          </PopoverContent>
+        </Popover>
       ) : null}
       {!isMobile && hasOverflow ? (
         <Button

--- a/packages/base/src/features/story/components/ListStoryTitleBar.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBar.tsx
@@ -32,10 +32,7 @@ export function ListStoryTitleBar({
 
   const segmentItems = useMemo(
     () =>
-      buildStorySegmentViewItems(
-        model,
-        model.getSelectedStory().story ?? null,
-      ),
+      buildStorySegmentViewItems(model, model.getSelectedStory().story ?? null),
     [model],
   );
 
@@ -52,20 +49,22 @@ export function ListStoryTitleBar({
         ‹
       </Button>
       <div ref={segmentsRef} className="jgis-story-title-bar-segments">
-        {segmentItems.map(item => (
-          <Button
-            key={item.id}
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="jgis-story-title-bar-segment"
-            aria-current={item.index === currentIndex ? 'true' : undefined}
-            aria-label={`Go to ${item.layerName}`}
-            onClick={() => scrollToSegmentIndex(item.index)}
-          >
-            {item.layerName}
-          </Button>
-        ))}
+        {segmentItems.map(item => {
+          const isActive = item.index === currentIndex;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className="jGIS-layer-browser-category jgis-story-title-bar-segment"
+              data-state={isActive ? 'active' : 'inactive'}
+              aria-current={isActive ? 'true' : undefined}
+              aria-label={`Go to ${item.layerName}`}
+              onClick={() => scrollToSegmentIndex(item.index)}
+            >
+              {item.layerName}
+            </button>
+          );
+        })}
       </div>
       <Button
         type="button"

--- a/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
+import { Button } from '@/src/shared/components/Button';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+export interface IListStoryTitleBarDesktopProps {
+  segmentItems: IStorySegmentViewItem[];
+  currentIndex: number;
+  onSegmentClick: (index: number) => void;
+}
+
+export function ListStoryTitleBarDesktop({
+  segmentItems,
+  currentIndex,
+  onSegmentClick,
+}: IListStoryTitleBarDesktopProps): JSX.Element {
+  const segmentsRef = useRef<HTMLDivElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  const currentPosition = segmentItems.findIndex(
+    item => item.index === currentIndex,
+  );
+  const hasPrev = currentPosition > 0;
+  const hasNext =
+    currentPosition >= 0 && currentPosition < segmentItems.length - 1;
+
+  const goToAdjacentSegment = useCallback(
+    (direction: -1 | 1): void => {
+      const nextPosition = currentPosition + direction;
+      const nextItem = segmentItems[nextPosition];
+      if (!nextItem) {
+        return;
+      }
+
+      onSegmentClick(nextItem.index);
+    },
+    [currentPosition, segmentItems, onSegmentClick],
+  );
+
+  useLayoutEffect(() => {
+    const segments = segmentsRef.current;
+    if (!segments) {
+      return;
+    }
+
+    const update = (): void => {
+      setHasOverflow(segments.scrollWidth > segments.clientWidth);
+    };
+
+    update();
+
+    const ro = new ResizeObserver(update);
+    ro.observe(segments);
+
+    return () => {
+      ro.disconnect();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const segments = segmentsRef.current;
+    if (!segments) {
+      return;
+    }
+
+    const active = segments.querySelector(
+      '.jgis-story-title-bar-segment[data-state="active"]',
+    );
+    if (!(active instanceof HTMLElement)) {
+      return;
+    }
+
+    active.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  }, [currentIndex]);
+
+  return (
+    <nav className="jgis-story-title-bar" aria-label="Story segments">
+      {hasOverflow ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="jgis-story-title-bar-scroll-btn"
+          aria-label="Previous segment"
+          disabled={!hasPrev}
+          onClick={() => goToAdjacentSegment(-1)}
+        >
+          <ChevronLeft />
+        </Button>
+      ) : null}
+      <div ref={segmentsRef} className="jgis-story-title-bar-segments">
+        {segmentItems.map(item => {
+          const isActive = item.index === currentIndex;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className="jGIS-layer-browser-category jgis-story-title-bar-segment"
+              data-state={isActive ? 'active' : 'inactive'}
+              aria-current={isActive ? 'true' : undefined}
+              aria-label={`Go to ${item.layerName}`}
+              onClick={() => onSegmentClick(item.index)}
+            >
+              {item.layerName}
+            </button>
+          );
+        })}
+      </div>
+      {hasOverflow ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="jgis-story-title-bar-scroll-btn"
+          aria-label="Next segment"
+          disabled={!hasNext}
+          onClick={() => goToAdjacentSegment(1)}
+        >
+          <ChevronRight />
+        </Button>
+      ) : null}
+    </nav>
+  );
+}

--- a/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
@@ -1,20 +1,14 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
-import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
+import type { IListStoryTitleBarContentProps } from '@/src/features/story/types/types';
 import { Button } from '@/src/shared/components/Button';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-
-export interface IListStoryTitleBarDesktopProps {
-  segmentItems: IStorySegmentViewItem[];
-  currentIndex: number;
-  onSegmentClick: (index: number) => void;
-}
 
 export function ListStoryTitleBarDesktop({
   segmentItems,
   currentIndex,
   onSegmentClick,
-}: IListStoryTitleBarDesktopProps): JSX.Element {
+}: IListStoryTitleBarContentProps): JSX.Element {
   const segmentsRef = useRef<HTMLDivElement>(null);
   const [hasOverflow, setHasOverflow] = useState(false);
 
@@ -100,7 +94,7 @@ export function ListStoryTitleBarDesktop({
             <button
               key={item.id}
               type="button"
-              className="jGIS-layer-browser-category jgis-story-title-bar-segment"
+              className="jgis-story-title-bar-label jgis-story-title-bar-segment"
               data-state={isActive ? 'active' : 'inactive'}
               aria-current={isActive ? 'true' : undefined}
               aria-label={`Go to ${item.layerName}`}

--- a/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
@@ -83,7 +83,11 @@ export function ListStoryTitleBarDesktop({
           <ChevronLeft />
         </Button>
       ) : null}
-      <div ref={segmentsRef} className="jgis-story-title-bar-segments">
+      <div
+        ref={segmentsRef}
+        className="jgis-story-title-bar-segments"
+        onWheelCapture={event => event.stopPropagation()}
+      >
         {segmentItems.map(item => {
           const isActive = item.index === currentIndex;
           return (

--- a/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarDesktop.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 
 import type { IListStoryTitleBarContentProps } from '@/src/features/story/types/types';
 import { Button } from '@/src/shared/components/Button';
@@ -19,18 +19,15 @@ export function ListStoryTitleBarDesktop({
   const hasNext =
     currentPosition >= 0 && currentPosition < segmentItems.length - 1;
 
-  const goToAdjacentSegment = useCallback(
-    (direction: -1 | 1): void => {
-      const nextPosition = currentPosition + direction;
-      const nextItem = segmentItems[nextPosition];
-      if (!nextItem) {
-        return;
-      }
+  const goToAdjacentSegment = (direction: -1 | 1): void => {
+    const nextPosition = currentPosition + direction;
+    const nextItem = segmentItems[nextPosition];
+    if (!nextItem) {
+      return;
+    }
 
-      onSegmentClick(nextItem.index);
-    },
-    [currentPosition, segmentItems, onSegmentClick],
-  );
+    onSegmentClick(nextItem.index);
+  };
 
   useLayoutEffect(() => {
     const segments = segmentsRef.current;
@@ -61,14 +58,13 @@ export function ListStoryTitleBarDesktop({
     const active = segments.querySelector(
       '.jgis-story-title-bar-segment[data-state="active"]',
     );
-    if (!(active instanceof HTMLElement)) {
+
+    if (!active) {
       return;
     }
 
     active.scrollIntoView({
       behavior: 'smooth',
-      block: 'nearest',
-      inline: 'nearest',
     });
   }, [currentIndex]);
 

--- a/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
@@ -1,0 +1,107 @@
+import React, { useCallback, useRef, useState } from 'react';
+
+import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
+import { Button } from '@/src/shared/components/Button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/src/shared/components/Popover';
+import { Menu } from 'lucide-react';
+
+export interface IListStoryTitleBarMobileProps {
+  segmentItems: IStorySegmentViewItem[];
+  currentIndex: number;
+  onSegmentClick: (index: number) => void;
+}
+
+export function ListStoryTitleBarMobile({
+  segmentItems,
+  currentIndex,
+  onSegmentClick,
+}: IListStoryTitleBarMobileProps): JSX.Element {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const activeSegment = segmentItems.find(item => item.index === currentIndex);
+  const currentPosition = segmentItems.findIndex(
+    item => item.index === currentIndex,
+  );
+
+  const prevSegmentIdRef = useRef<string | undefined>(undefined);
+  const slideDirectionRef = useRef<'next' | 'prev' | undefined>(undefined);
+
+  if (activeSegment?.id !== prevSegmentIdRef.current) {
+    const prevId = prevSegmentIdRef.current;
+
+    if (prevId) {
+      const prevPosition = segmentItems.findIndex(item => item.id === prevId);
+
+      if (prevPosition >= 0 && currentPosition >= 0) {
+        slideDirectionRef.current =
+          currentPosition > prevPosition ? 'next' : 'prev';
+      } else {
+        slideDirectionRef.current = undefined;
+      }
+    } else {
+      slideDirectionRef.current = undefined;
+    }
+    prevSegmentIdRef.current = activeSegment?.id;
+  }
+
+  const handleMenuSegmentClick = useCallback(
+    (index: number): void => {
+      onSegmentClick(index);
+      setMenuOpen(false);
+    },
+    [onSegmentClick],
+  );
+
+  return (
+    <nav
+      className="jgis-story-title-bar jgis-story-title-bar--mobile"
+      aria-label="Story segments"
+    >
+      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            className="jgis-story-title-bar-menu-btn"
+            aria-label="Open story menu"
+          >
+            <Menu />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="center"
+          side="bottom"
+          className="jgis-story-title-bar-segment-menu"
+        >
+          {segmentItems.map(item => {
+            const isActive = item.index === currentIndex;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className="jGIS-layer-browser-category jgis-story-title-bar-segment-menu-item"
+                data-state={isActive ? 'active' : 'inactive'}
+                aria-current={isActive ? 'true' : undefined}
+                onClick={() => handleMenuSegmentClick(item.index)}
+              >
+                {item.layerName}
+              </button>
+            );
+          })}
+        </PopoverContent>
+      </Popover>
+      <span
+        key={activeSegment?.id}
+        className="jGIS-layer-browser-category jgis-story-title-bar-active-segment"
+        data-state="active"
+        data-slide-direction={slideDirectionRef.current}
+      >
+        {activeSegment?.layerName ?? ''}
+      </span>
+    </nav>
+  );
+}

--- a/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
@@ -9,6 +9,27 @@ import {
 } from '@/src/shared/components/Popover';
 import { Menu } from 'lucide-react';
 
+type TSlideDirection = 'next' | 'prev';
+
+function getSlideDirection(
+  prevSegmentId: string | undefined,
+  currentPosition: number,
+  segmentItems: IStorySegmentViewItem[],
+): TSlideDirection | undefined {
+  if (!prevSegmentId || currentPosition < 0) {
+    return undefined;
+  }
+
+  const prevPosition = segmentItems.findIndex(
+    item => item.id === prevSegmentId,
+  );
+  if (prevPosition < 0) {
+    return undefined;
+  }
+
+  return currentPosition > prevPosition ? 'next' : 'prev';
+}
+
 export interface IListStoryTitleBarMobileProps {
   segmentItems: IStorySegmentViewItem[];
   currentIndex: number;
@@ -28,24 +49,16 @@ export function ListStoryTitleBarMobile({
   );
 
   const prevSegmentIdRef = useRef<string | undefined>(undefined);
-  const slideDirectionRef = useRef<'next' | 'prev' | undefined>(undefined);
+  const slideDirectionRef = useRef<TSlideDirection | undefined>(undefined);
+  const activeSegmentId = activeSegment?.id;
 
-  if (activeSegment?.id !== prevSegmentIdRef.current) {
-    const prevId = prevSegmentIdRef.current;
-
-    if (prevId) {
-      const prevPosition = segmentItems.findIndex(item => item.id === prevId);
-
-      if (prevPosition >= 0 && currentPosition >= 0) {
-        slideDirectionRef.current =
-          currentPosition > prevPosition ? 'next' : 'prev';
-      } else {
-        slideDirectionRef.current = undefined;
-      }
-    } else {
-      slideDirectionRef.current = undefined;
-    }
-    prevSegmentIdRef.current = activeSegment?.id;
+  if (activeSegmentId !== prevSegmentIdRef.current) {
+    slideDirectionRef.current = getSlideDirection(
+      prevSegmentIdRef.current,
+      currentPosition,
+      segmentItems,
+    );
+    prevSegmentIdRef.current = activeSegmentId;
   }
 
   const handleMenuSegmentClick = useCallback(

--- a/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
@@ -12,13 +12,13 @@ import {
   PopoverTrigger,
 } from '@/src/shared/components/Popover';
 
-type TSlideDirection = 'next' | 'prev';
+type SlideDirection = 'next' | 'prev';
 
 function getSlideDirection(
   prevSegmentId: string | undefined,
   currentPosition: number,
   segmentItems: IStorySegmentViewItem[],
-): TSlideDirection | undefined {
+): SlideDirection | undefined {
   if (!prevSegmentId || currentPosition < 0) {
     return undefined;
   }
@@ -26,6 +26,7 @@ function getSlideDirection(
   const prevPosition = segmentItems.findIndex(
     item => item.id === prevSegmentId,
   );
+
   if (prevPosition < 0) {
     return undefined;
   }
@@ -47,7 +48,7 @@ export function ListStoryTitleBarMobile({
     currentPosition >= 0 ? segmentItems[currentPosition] : undefined;
 
   const prevSegmentIdRef = useRef<string | undefined>(undefined);
-  const slideDirectionRef = useRef<TSlideDirection | undefined>(undefined);
+  const slideDirectionRef = useRef<SlideDirection | undefined>(undefined);
   const activeSegmentId = activeSegment?.id;
 
   if (activeSegmentId !== prevSegmentIdRef.current) {
@@ -59,13 +60,10 @@ export function ListStoryTitleBarMobile({
     prevSegmentIdRef.current = activeSegmentId;
   }
 
-  const handleMenuSegmentClick = useCallback(
-    (index: number): void => {
-      onSegmentClick(index);
-      setMenuOpen(false);
-    },
-    [onSegmentClick],
-  );
+  const handleMenuSegmentClick = (index: number): void => {
+    onSegmentClick(index);
+    setMenuOpen(false);
+  };
 
   return (
     <nav

--- a/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
@@ -1,5 +1,5 @@
 import { Menu } from 'lucide-react';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import type {
   IListStoryTitleBarContentProps,

--- a/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
+++ b/packages/base/src/features/story/components/ListStoryTitleBarMobile.tsx
@@ -1,13 +1,16 @@
+import { Menu } from 'lucide-react';
 import React, { useCallback, useRef, useState } from 'react';
 
-import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
+import type {
+  IListStoryTitleBarContentProps,
+  IStorySegmentViewItem,
+} from '@/src/features/story/types/types';
 import { Button } from '@/src/shared/components/Button';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/src/shared/components/Popover';
-import { Menu } from 'lucide-react';
 
 type TSlideDirection = 'next' | 'prev';
 
@@ -30,23 +33,18 @@ function getSlideDirection(
   return currentPosition > prevPosition ? 'next' : 'prev';
 }
 
-export interface IListStoryTitleBarMobileProps {
-  segmentItems: IStorySegmentViewItem[];
-  currentIndex: number;
-  onSegmentClick: (index: number) => void;
-}
-
 export function ListStoryTitleBarMobile({
   segmentItems,
   currentIndex,
   onSegmentClick,
-}: IListStoryTitleBarMobileProps): JSX.Element {
+}: IListStoryTitleBarContentProps): JSX.Element {
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const activeSegment = segmentItems.find(item => item.index === currentIndex);
   const currentPosition = segmentItems.findIndex(
     item => item.index === currentIndex,
   );
+  const activeSegment =
+    currentPosition >= 0 ? segmentItems[currentPosition] : undefined;
 
   const prevSegmentIdRef = useRef<string | undefined>(undefined);
   const slideDirectionRef = useRef<TSlideDirection | undefined>(undefined);
@@ -96,7 +94,7 @@ export function ListStoryTitleBarMobile({
               <button
                 key={item.id}
                 type="button"
-                className="jGIS-layer-browser-category jgis-story-title-bar-segment-menu-item"
+                className="jgis-story-title-bar-label jgis-story-title-bar-segment-menu-item"
                 data-state={isActive ? 'active' : 'inactive'}
                 aria-current={isActive ? 'true' : undefined}
                 onClick={() => handleMenuSegmentClick(item.index)}
@@ -109,7 +107,7 @@ export function ListStoryTitleBarMobile({
       </Popover>
       <span
         key={activeSegment?.id}
-        className="jGIS-layer-browser-category jgis-story-title-bar-active-segment"
+        className="jgis-story-title-bar-active-segment"
         data-state="active"
         data-slide-direction={slideDirectionRef.current}
       >

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -258,7 +258,7 @@ export function ListStoryScrollTrackProvider({
         s => s.index === safeIndex,
       );
 
-      if (scroller && segment != null) {
+      if (scroller && segment !== undefined) {
         scroller.scrollTo({
           top: segment.start,
           behavior: options?.behavior ?? 'smooth',

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -23,7 +23,10 @@ interface IListStoryScrollTrackContextValue {
   scrollTrackLayout: IListStoryScrollTrackLayout | null;
   scrollTop: number;
   bindScrollTrackElement: (element: HTMLDivElement | null) => void;
-  scrollToSegmentIndex: (index: number) => void;
+  scrollToSegmentIndex: (
+    index: number,
+    options?: { behavior?: ScrollBehavior },
+  ) => void;
 }
 
 const ListStoryScrollTrackContext =
@@ -248,7 +251,7 @@ export function ListStoryScrollTrackProvider({
   }, [enabled, items, viewportHeight, heightsById, buildScrollTrackLayout]);
 
   const scrollToSegmentIndex = useCallback(
-    (index: number) => {
+    (index: number, options?: { behavior?: ScrollBehavior }) => {
       const safeIndex = Math.max(0, index);
       const scroller = scrollerRef.current;
       const segment = scrollTrackLayout?.segments.find(
@@ -256,8 +259,11 @@ export function ListStoryScrollTrackProvider({
       );
 
       if (scroller && segment != null) {
-        scroller.scrollTop = segment.start;
-        setScrollTop(segment.start);
+        scroller.scrollTo({
+          top: segment.start,
+          behavior: options?.behavior ?? 'smooth',
+        });
+        return;
       }
 
       model.setCurrentSegmentIndex(safeIndex);

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -23,6 +23,7 @@ interface IListStoryScrollTrackContextValue {
   scrollTrackLayout: IListStoryScrollTrackLayout | null;
   scrollTop: number;
   bindScrollTrackElement: (element: HTMLDivElement | null) => void;
+  scrollToSegmentIndex: (index: number) => void;
 }
 
 const ListStoryScrollTrackContext =
@@ -246,13 +247,37 @@ export function ListStoryScrollTrackProvider({
     return buildScrollTrackLayout(heightsById);
   }, [enabled, items, viewportHeight, heightsById, buildScrollTrackLayout]);
 
+  const scrollToSegmentIndex = useCallback(
+    (index: number) => {
+      const safeIndex = Math.max(0, index);
+      const scroller = scrollerRef.current;
+      const segment = scrollTrackLayout?.segments.find(
+        s => s.index === safeIndex,
+      );
+
+      if (scroller && segment != null) {
+        scroller.scrollTop = segment.start;
+        setScrollTop(segment.start);
+      }
+
+      model.setCurrentSegmentIndex(safeIndex);
+    },
+    [model, scrollTrackLayout],
+  );
+
   const value = useMemo(
     (): IListStoryScrollTrackContextValue => ({
       scrollTrackLayout,
       scrollTop,
       bindScrollTrackElement,
+      scrollToSegmentIndex,
     }),
-    [scrollTrackLayout, scrollTop, bindScrollTrackElement],
+    [
+      scrollTrackLayout,
+      scrollTop,
+      bindScrollTrackElement,
+      scrollToSegmentIndex,
+    ],
   );
 
   return (

--- a/packages/base/src/features/story/types/types.ts
+++ b/packages/base/src/features/story/types/types.ts
@@ -19,6 +19,12 @@ export interface IStorySegmentViewItem {
   activeSlide: IStorySegmentLayer['parameters'] | undefined;
 }
 
+export interface IListStoryTitleBarContentProps {
+  segmentItems: IStorySegmentViewItem[];
+  currentIndex: number;
+  onSegmentClick: (index: number) => void;
+}
+
 export interface IListStoryMarkdownSegment {
   id: string;
   index: number;

--- a/packages/base/src/mainview/components/MainViewStoryStage.tsx
+++ b/packages/base/src/mainview/components/MainViewStoryStage.tsx
@@ -2,6 +2,7 @@ import { IJupyterGISModel } from '@jupytergis/schema';
 import React, { RefObject } from 'react';
 
 import { ListStoryStageOverlay } from '@/src/features/story/components/ListStoryStageOverlay';
+import { ListStoryTitleBar } from '@/src/features/story/components/ListStoryTitleBar';
 import { ListStoryScrollTrackProvider } from '@/src/features/story/context/ListStoryScrollTrackContext';
 import type { IListStorySegmentTransition } from '@/src/features/story/types/types';
 
@@ -34,10 +35,13 @@ export function MainViewStoryStage({
     >
       <ListStoryScrollTrackProvider model={model} enabled={isListStory}>
         {isListStory ? (
-          <ListStoryStageOverlay
-            model={model}
-            segmentTransition={segmentTransition}
-          />
+          <>
+            <ListStoryTitleBar model={model} />
+            <ListStoryStageOverlay
+              model={model}
+              segmentTransition={segmentTransition}
+            />
+          </>
         ) : null}
         <div className="jgis-panels-wrapper">{panels}</div>
         <div ref={controlsToolbarRef} className="jgis-controls-toolbar"></div>

--- a/packages/base/src/mainview/components/MainViewStoryStage.tsx
+++ b/packages/base/src/mainview/components/MainViewStoryStage.tsx
@@ -9,6 +9,7 @@ import type { IListStorySegmentTransition } from '@/src/features/story/types/typ
 export interface IMainViewStoryStageProps {
   model: IJupyterGISModel;
   isListStory: boolean;
+  isMobile: boolean;
   segmentTransition: IListStorySegmentTransition | null;
   stageRef: RefObject<HTMLDivElement>;
   controlsToolbarRef: RefObject<HTMLDivElement>;
@@ -18,6 +19,7 @@ export interface IMainViewStoryStageProps {
 export function MainViewStoryStage({
   model,
   isListStory,
+  isMobile,
   segmentTransition,
   stageRef,
   controlsToolbarRef,
@@ -36,7 +38,7 @@ export function MainViewStoryStage({
       <ListStoryScrollTrackProvider model={model} enabled={isListStory}>
         {isListStory ? (
           <>
-            <ListStoryTitleBar model={model} />
+            <ListStoryTitleBar model={model} isMobile={isMobile} />
             <ListStoryStageOverlay
               model={model}
               segmentTransition={segmentTransition}

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2848,14 +2848,40 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this._clearStoryScrollGuard = clearGuard;
 
     let accumulatedDeltaY = 0;
-    let scrollContainer: HTMLDivElement | null =
-      this.storyViewerPanelRef.current?.getScrollContainer() ?? null;
+    let scrollContainer: HTMLDivElement | null = null;
+
+    const resolveStoryScrollContainer = (): HTMLDivElement | null => {
+      const fromPanel =
+        this.storyViewerPanelRef.current?.getScrollContainer() ?? null;
+
+      if (fromPanel && document.contains(fromPanel)) {
+        return fromPanel;
+      }
+
+      const mobileScroll = document.querySelector(
+        '.jgis-story-mobile-list-scroll',
+      );
+
+      if (mobileScroll instanceof HTMLDivElement) {
+        return mobileScroll;
+      }
+
+      return null;
+    };
+
+    scrollContainer = resolveStoryScrollContainer();
 
     const processStoryScrollFrame = (): void => {
       this._pendingStoryScrollRafId = null;
 
+      if (!scrollContainer || !document.contains(scrollContainer)) {
+        scrollContainer = resolveStoryScrollContainer();
+      }
+
       const currentPanelHandle = this.storyViewerPanelRef.current;
-      if (!currentPanelHandle || !scrollContainer) {
+      const storyType = this._model.getSelectedStory().story?.storyType;
+
+      if (!scrollContainer) {
         accumulatedDeltaY = 0;
         return;
       }
@@ -2863,10 +2889,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       const deltaY = accumulatedDeltaY;
       accumulatedDeltaY = 0;
 
-      const storyType = this._model.getSelectedStory().story?.storyType;
       // Don't want to handle next/prev logic in list mode
       if (storyType === STORY_TYPE.verticalScroll) {
         scrollContainer.scrollBy({ top: deltaY });
+        return;
+      }
+
+      if (!currentPanelHandle) {
         return;
       }
 
@@ -2903,8 +2932,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       event.preventDefault();
 
       if (!scrollContainer || !document.contains(scrollContainer)) {
-        scrollContainer =
-          this.storyViewerPanelRef.current?.getScrollContainer() ?? null;
+        scrollContainer = resolveStoryScrollContainer();
       }
       if (!scrollContainer) {
         return;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -460,22 +460,25 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       layer => layer.type !== 'StorySegmentLayer',
     ).length;
 
-    const scaleLine = new ScaleLine({
-      target: this.controlsToolbarRef.current || undefined,
-    });
+    const controlsToolbar = this.controlsToolbarRef.current || undefined;
+    const controls: Control[] = [new ScaleLine({ target: controlsToolbar })];
 
-    const fullScreen = new FullScreen({
-      target: this.controlsToolbarRef.current || undefined,
-    });
-
-    const controls: Control[] = [scaleLine, fullScreen];
-
-    if (this._model.jgisSettings.zoomButtonsEnabled) {
-      this._zoomControl = new Zoom({
-        target: this.controlsToolbarRef.current || undefined,
-      });
-      controls.push(this._zoomControl);
+    if (!this._model.isSpectaMode()) {
+      controls.push(new FullScreen({ target: controlsToolbar }));
     }
+
+    let zoomControl: Zoom | undefined;
+    if (this._model.jgisSettings.zoomButtonsEnabled) {
+      zoomControl = new Zoom({ target: controlsToolbar });
+      controls.push(zoomControl);
+    }
+
+    // const { controls, zoomControl } = buildMapToolbarControls({
+    //   toolbarElement: this.controlsToolbarRef.current,
+    //   isSpecta: this._model.isSpectaMode() ?? false,
+    //   includeZoom: this._model.jgisSettings.zoomButtonsEnabled ?? false,
+    // });
+    this._zoomControl = zoomControl;
 
     if (this.divRef.current) {
       this._Map = new OlMap({

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -3885,6 +3885,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
             <MainViewStoryStage
               model={this._model}
               isListStory={isListStory}
+              isMobile={isMobile}
               segmentTransition={segmentTransition}
               stageRef={this.divRef}
               controlsToolbarRef={this.controlsToolbarRef}

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -467,13 +467,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       controls.push(new FullScreen({ target: controlsToolbar }));
     }
 
-    let zoomControl: Zoom | undefined;
     if (this._model.jgisSettings.zoomButtonsEnabled) {
-      zoomControl = new Zoom({ target: controlsToolbar });
-      controls.push(zoomControl);
+      this._zoomControl = new Zoom({ target: controlsToolbar });
+      controls.push(this._zoomControl);
     }
-
-    this._zoomControl = zoomControl;
 
     if (this.divRef.current) {
       this._Map = new OlMap({
@@ -2902,26 +2899,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     const handleScroll = (event: Event) => {
       const wheelEvent = event as WheelEvent;
-      const titleBarSegments =
-        wheelEvent.target instanceof Element
-          ? wheelEvent.target.closest('.jgis-story-title-bar-segments')
-          : null;
-
-      if (titleBarSegments instanceof HTMLElement) {
-        const horizontalDelta =
-          wheelEvent.deltaX !== 0
-            ? wheelEvent.deltaX
-            : wheelEvent.shiftKey
-              ? wheelEvent.deltaY
-              : 0;
-
-        if (horizontalDelta !== 0) {
-          titleBarSegments.scrollLeft += horizontalDelta;
-        }
-
-        event.preventDefault();
-        return;
-      }
 
       event.preventDefault();
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2903,6 +2903,28 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     };
 
     const handleScroll = (event: Event) => {
+      const wheelEvent = event as WheelEvent;
+      const titleBarSegments =
+        wheelEvent.target instanceof Element
+          ? wheelEvent.target.closest('.jgis-story-title-bar-segments')
+          : null;
+
+      if (titleBarSegments instanceof HTMLElement) {
+        const horizontalDelta =
+          wheelEvent.deltaX !== 0
+            ? wheelEvent.deltaX
+            : wheelEvent.shiftKey
+              ? wheelEvent.deltaY
+              : 0;
+
+        if (horizontalDelta !== 0) {
+          titleBarSegments.scrollLeft += horizontalDelta;
+        }
+
+        event.preventDefault();
+        return;
+      }
+
       event.preventDefault();
 
       if (!scrollContainer || !document.contains(scrollContainer)) {
@@ -2916,7 +2938,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       // frames on slow hardware). We accumulate deltaY and run flush once per
       // frame via rAF—the frame boundary batches events without adding delay.
       // So one scroll means one segment/scroll decision.
-      accumulatedDeltaY += (event as WheelEvent).deltaY;
+      accumulatedDeltaY += wheelEvent.deltaY;
       if (this._pendingStoryScrollRafId === null) {
         this._pendingStoryScrollRafId = requestAnimationFrame(
           processStoryScrollFrame,

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -473,11 +473,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       controls.push(zoomControl);
     }
 
-    // const { controls, zoomControl } = buildMapToolbarControls({
-    //   toolbarElement: this.controlsToolbarRef.current,
-    //   isSpecta: this._model.isSpectaMode() ?? false,
-    //   includeZoom: this._model.jgisSettings.zoomButtonsEnabled ?? false,
-    // });
     this._zoomControl = zoomControl;
 
     if (this.divRef.current) {

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -253,6 +253,12 @@ button.jp-mod-styled.jp-mod-reject {
     bottom: unset;
     align-items: flex-start;
   }
+
+  body[data-notebook='specta'] .jgis-controls-toolbar {
+    top: unset;
+    bottom: 0.125rem;
+    align-items: flex-end;
+  }
 }
 
 .jgis-geometry-type-selector-overlay {

--- a/packages/base/style/layerBrowser.css
+++ b/packages/base/style/layerBrowser.css
@@ -125,7 +125,7 @@
 .jGIS-layer-browser-category {
   position: relative;
   opacity: 0.7;
-  padding: 4px 0 14px;
+  padding: 0.25rem 0;
   cursor: pointer;
   text-decoration: none;
 }

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -244,6 +244,7 @@
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
+  touch-action: pan-x;
   scrollbar-width: thin;
 }
 

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -448,7 +448,6 @@
 
 .jgis-story-map-overlay-content {
   width: 25%;
-  max-width: 30rem;
   max-height: 100%;
   overflow: auto;
   padding: 0.75rem;

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -208,6 +208,37 @@
   overscroll-behavior: contain;
 }
 
+.jgis-story-title-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  box-sizing: border-box;
+  background-color: color-mix(in srgb, var(--jp-layout-color1), transparent 8%);
+  border-bottom: 1px solid var(--jp-border-color2);
+  pointer-events: auto;
+}
+
+.jgis-story-title-bar-segments {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-width: 0;
+  width: 100%;
+}
+
+.jgis-story-title-bar-segment[aria-current='true'] {
+  font-weight: 600;
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color2);
+}
+
 .jgis-story-stage-overlay {
   position: absolute;
   inset: 0;

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -266,30 +266,22 @@
   font-weight: bold;
 }
 
+.jgis-story-title-bar-active-segment[data-slide-direction] {
+  animation: jgis-story-title-bar-active-segment-enter 0.5s ease-out both;
+}
+
 .jgis-story-title-bar-active-segment[data-slide-direction='next'] {
-  animation: jgis-story-title-bar-active-segment-enter-next 0.5s ease-out both;
+  --jgis-story-title-bar-slide-offset: 0.35rem;
 }
 
 .jgis-story-title-bar-active-segment[data-slide-direction='prev'] {
-  animation: jgis-story-title-bar-active-segment-enter-prev 0.5s ease-out both;
+  --jgis-story-title-bar-slide-offset: -0.35rem;
 }
 
-@keyframes jgis-story-title-bar-active-segment-enter-next {
+@keyframes jgis-story-title-bar-active-segment-enter {
   from {
     opacity: 0;
-    transform: translate(-50%, 0.35rem);
-  }
-
-  to {
-    opacity: 1;
-    transform: translate(-50%, 0);
-  }
-}
-
-@keyframes jgis-story-title-bar-active-segment-enter-prev {
-  from {
-    opacity: 0;
-    transform: translate(-50%, -0.35rem);
+    transform: translate(-50%, var(--jgis-story-title-bar-slide-offset));
   }
 
   to {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -239,10 +239,63 @@
 .jgis-story-title-bar--mobile {
   justify-content: flex-start;
   padding: 0.5rem 0;
+  overflow: visible;
 }
 
 .jgis-story-title-bar--mobile .jgis-story-title-bar-segments {
   flex: 1;
+  min-width: 0;
+}
+
+.jgis-story-title-bar--mobile .jgis-story-title-bar-menu-btn {
+  position: relative;
+  z-index: 1;
+}
+
+.jgis-story-title-bar-active-segment {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0);
+  max-width: calc(100% - 4rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+  pointer-events: none;
+  opacity: 1;
+  font-weight: bold;
+}
+
+.jgis-story-title-bar-active-segment[data-slide-direction='next'] {
+  animation: jgis-story-title-bar-active-segment-enter-next 0.5s ease-out both;
+}
+
+.jgis-story-title-bar-active-segment[data-slide-direction='prev'] {
+  animation: jgis-story-title-bar-active-segment-enter-prev 0.5s ease-out both;
+}
+
+@keyframes jgis-story-title-bar-active-segment-enter-next {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 0.35rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+@keyframes jgis-story-title-bar-active-segment-enter-prev {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -0.35rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
 }
 
 .jgis-story-title-bar-segments {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -209,10 +209,8 @@
 }
 
 .jgis-story-title-bar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
+  height: 2.5rem;
+  position: relative;
   z-index: 50;
   display: flex;
   align-items: center;
@@ -241,7 +239,8 @@
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
   touch-action: pan-x;
-  scrollbar-width: thin;
+  scrollbar-width: none;
+  overflow: hidden;
 }
 
 .jgis-story-title-bar-segment {
@@ -256,6 +255,7 @@
 .jgis-story-stage-overlay {
   position: absolute;
   inset: 0;
+  top: 2.5rem;
   z-index: 5;
 }
 

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -202,12 +202,6 @@
   max-height: 100%;
 }
 
-.jgis-story-viewer-panel-specta-mod.jgis-story-viewer-panel-specta-mod-vertical-scroll {
-  /* align-items: flex-start;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain; */
-}
-
 .jgis-mainview-stage {
   --jgis-story-title-bar-height: 2.5rem;
 }
@@ -240,11 +234,6 @@
   justify-content: flex-start;
   padding: 0.5rem 0;
   overflow: visible;
-}
-
-.jgis-story-title-bar--mobile .jgis-story-title-bar-segments {
-  flex: 1;
-  min-width: 0;
 }
 
 .jgis-story-title-bar--mobile .jgis-story-title-bar-menu-btn {
@@ -302,6 +291,38 @@
   overflow: hidden;
 }
 
+.jgis-story-title-bar-label {
+  position: relative;
+  opacity: 0.7;
+  padding: 0.25rem 0;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.jgis-story-title-bar-label::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 3px;
+  transition:
+    background-color 300ms ease-in,
+    width 300ms ease-in,
+    opacity 300ms ease-in;
+  background-color: transparent;
+}
+
+.jgis-story-title-bar-label[data-state='active']::after {
+  width: 100%;
+  background-color: var(--jp-inverse-layout-color2);
+}
+
+.jgis-story-title-bar-label[data-state='active'] {
+  opacity: 1;
+  font-weight: bold;
+}
+
 .jgis-story-title-bar-segment {
   flex-shrink: 0;
   white-space: nowrap;
@@ -326,7 +347,6 @@
 
 .jgis-story-title-bar-segment-menu-item {
   width: 100%;
-  /* text-align: left; */
   border: none;
   background: transparent;
   font: inherit;
@@ -482,8 +502,7 @@
 .jgis-story-mobile-list-scroll {
   position: fixed;
   inset: 0;
-  top: 2.5rem;
-  /* z-index: 6; */
+  top: var(--jgis-story-title-bar-height);
   width: 100%;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -220,7 +220,6 @@
   padding: 0.5rem 0.75rem;
   box-sizing: border-box;
   background-color: color-mix(in srgb, var(--jp-layout-color1), transparent 8%);
-  border-bottom: 1px solid var(--jp-border-color2);
   pointer-events: auto;
   min-width: 0;
   overflow: hidden;
@@ -237,11 +236,8 @@
   display: flex;
   flex: 1;
   flex-wrap: nowrap;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.25rem;
+  gap: 1.5rem;
   min-width: 0;
-  overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
   touch-action: pan-x;
@@ -251,12 +247,10 @@
 .jgis-story-title-bar-segment {
   flex-shrink: 0;
   white-space: nowrap;
-}
-
-.jgis-story-title-bar-segment[aria-current='true'] {
-  font-weight: 600;
-  color: var(--jp-ui-font-color1);
-  background-color: var(--jp-layout-color2);
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
 }
 
 .jgis-story-stage-overlay {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -220,7 +220,7 @@
   justify-content: space-around;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0 0.75rem;
   box-sizing: border-box;
   background-color: color-mix(in srgb, var(--jp-layout-color1), transparent 8%);
   pointer-events: auto;

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -213,24 +213,43 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 6;
+  z-index: 50;
   display: flex;
   align-items: center;
+  gap: 0.25rem;
   padding: 0.5rem 0.75rem;
   box-sizing: border-box;
   background-color: color-mix(in srgb, var(--jp-layout-color1), transparent 8%);
   border-bottom: 1px solid var(--jp-border-color2);
   pointer-events: auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.jgis-story-title-bar-scroll-btn {
+  flex-shrink: 0;
+  min-width: 2rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 .jgis-story-title-bar-segments {
   display: flex;
-  flex-wrap: wrap;
+  flex: 1;
+  flex-wrap: nowrap;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.25rem;
   min-width: 0;
-  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+}
+
+.jgis-story-title-bar-segment {
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .jgis-story-title-bar-segment[aria-current='true'] {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -202,6 +202,12 @@
   max-height: 100%;
 }
 
+.jgis-story-viewer-panel-specta-mod.jgis-story-viewer-panel-specta-mod-vertical-scroll {
+  align-items: flex-start;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
 .jgis-mainview-stage {
   --jgis-story-title-bar-height: 2.5rem;
 }

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -259,6 +259,7 @@
   pointer-events: none;
   opacity: 1;
   font-weight: bold;
+  margin-top: 3px;
 }
 
 .jgis-story-title-bar-active-segment[data-slide-direction] {
@@ -305,6 +306,7 @@
   text-decoration: none;
 }
 
+.jgis-story-title-bar-active-segment::after,
 .jgis-story-title-bar-label::after {
   content: '';
   position: absolute;
@@ -319,6 +321,7 @@
   background-color: transparent;
 }
 
+.jgis-story-title-bar-active-segment[data-state='active']::after,
 .jgis-story-title-bar-label[data-state='active']::after {
   width: 100%;
   background-color: var(--jp-inverse-layout-color2);

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -228,11 +228,21 @@
   overflow: hidden;
 }
 
-.jgis-story-title-bar-scroll-btn {
+.jgis-story-title-bar-scroll-btn,
+.jgis-story-title-bar-menu-btn {
   flex-shrink: 0;
   min-width: 2rem;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+}
+
+.jgis-story-title-bar--mobile {
+  justify-content: flex-start;
+  padding: 0.5rem 0;
+}
+
+.jgis-story-title-bar--mobile .jgis-story-title-bar-segments {
+  flex: 1;
 }
 
 .jgis-story-title-bar-segments {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -290,12 +290,14 @@
   display: flex;
   flex-wrap: nowrap;
   gap: 1.5rem;
+  margin-top: 3px;
   min-width: 0;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
   touch-action: pan-x;
   scrollbar-width: none;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .jgis-story-title-bar-label {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -208,8 +208,12 @@
   overscroll-behavior: contain;
 }
 
+.jgis-mainview-stage {
+  --jgis-story-title-bar-height: 2.5rem;
+}
+
 .jgis-story-title-bar {
-  height: 2.5rem;
+  height: var(--jgis-story-title-bar-height);
   position: relative;
   z-index: 50;
   display: flex;
@@ -255,7 +259,7 @@
 .jgis-story-stage-overlay {
   position: absolute;
   inset: 0;
-  top: 2.5rem;
+  top: var(--jgis-story-title-bar-height);
   z-index: 5;
 }
 

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -203,9 +203,9 @@
 }
 
 .jgis-story-viewer-panel-specta-mod.jgis-story-viewer-panel-specta-mod-vertical-scroll {
-  align-items: flex-start;
+  /* align-items: flex-start;
   -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
+  overscroll-behavior: contain; */
 }
 
 .jgis-mainview-stage {
@@ -264,6 +264,29 @@
   background: transparent;
   font: inherit;
   color: inherit;
+}
+
+.jgis-popover-content.jgis-story-title-bar-segment-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 12rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.5rem;
+  width: calc(var(--radix-popper-available-width) - 1rem);
+  margin: 0 0.5rem;
+  box-sizing: border-box;
+}
+
+.jgis-story-title-bar-segment-menu-item {
+  width: 100%;
+  /* text-align: left; */
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
 }
 
 .jgis-story-stage-overlay {
@@ -414,7 +437,8 @@
 .jgis-story-mobile-list-scroll {
   position: fixed;
   inset: 0;
-  z-index: 6;
+  top: 2.5rem;
+  /* z-index: 6; */
   width: 100%;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -217,6 +217,7 @@
   position: relative;
   z-index: 50;
   display: flex;
+  justify-content: space-around;
   align-items: center;
   gap: 0.25rem;
   padding: 0.5rem 0.75rem;
@@ -236,7 +237,6 @@
 
 .jgis-story-title-bar-segments {
   display: flex;
-  flex: 1;
   flex-wrap: nowrap;
   gap: 1.5rem;
   min-width: 0;


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
This adds a nav bar to vertical scroll stories.

Desktop:

https://github.com/user-attachments/assets/f74d2988-247a-4e08-abc4-f2d146fe88e5

Hides extra nav buttons if they're not needed:
<img width="1426" height="148" alt="image" src="https://github.com/user-attachments/assets/cb7eee19-0d33-4d14-aa11-021e70680610" />


Mobile:

https://github.com/user-attachments/assets/b8f3129f-1a8a-4f15-806f-ec4638e98332




## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1497.org.readthedocs.build/en/1497/
💡 JupyterLite preview: https://jupytergis--1497.org.readthedocs.build/en/1497/lite
💡 Specta preview: https://jupytergis--1497.org.readthedocs.build/en/1497/lite/specta

<!-- readthedocs-preview jupytergis end -->