### PR TITLE
Fix broken binder build

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # runtime dependencies
-  - python >=3.12,<3.14  # jupyter-tiler doesn't support Python 3.14
+  - python >=3.12,<3.14 # jupyter-tiler doesn't support Python 3.14
   - nodejs >=24,<25
   - yarn
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - jupyterlab >=4.5.1
 
   # Binder
-  - jupyterlab-link-share=0.2
+  - jupyterlab-link-share

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,6 +9,3 @@ dependencies:
 
   # Dependencies
   - jupyterlab >=4.5.1
-
-  # Binder
-  - jupyterlab-link-share

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   # runtime dependencies
-  - python >=3.12
+  - python >=3.12,<3.14  # jupyter-tiler doesn't support Python 3.14
   - nodejs >=24,<25
   - yarn
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -32,7 +32,7 @@ _("mamba", "uninstall", "-n", "notebook", "jupyter-resource-usage")
 _(sys.executable, "-m", "pip", "check")
 
 # install the labextension
-_(sys.executable, "-m", "pip", "install", ".")
+_(sys.executable, "scripts/dev-install.py")
 
 # verify the environment the extension didn't break anything
 _(sys.executable, "-m", "pip", "check")

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -26,7 +26,7 @@ def _(*args, **kwargs):
 
 
 # remove incompatible binder baseline packages
-_("mamba", "uninstall", "jupyter-resource-usage")
+_("mamba", "uninstall", "-n", "notebook", "jupyter-resource-usage")
 
 # verify the environment is self-consistent before even starting
 _(sys.executable, "-m", "pip", "check")


### PR DESCRIPTION
## Description

All versions of `jupyterlab-link-share` on conda-forge require JupyterLab 3.x. The latest release of the PyPI package does not have this constraint. Either way, we don't really need this.

The binder build is extremely slow. Tens of minutes. But I don't think we can avoid that. Bandwidth limitations are a clear component of the build time; `pushing layer` seems to be taking at least half of the total build.

I considered adding a binder link to our README but decided against it. I have mixed feelings. Some of our functionality can't be tested in a JupyterLite deployment, like the tiler. But testing the tiler features with the examples we currently have will require more than 2GB of memory and crash Binder. And our builds on Binder are very expensive. I don't want to waste Binder's resources.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself
