### PR TITLE
Renaming `to_py()` -> `_to_dict()`

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -260,7 +260,7 @@ class GISDocument(CommWidget):
         if isinstance(path, Path):
             path = str(path)
 
-        virtual_file = self.to_py()
+        virtual_file = self._to_dict()
         virtual_file["layerTree"] = reversed_tree(virtual_file["layerTree"])
         del virtual_file["metadata"]
 
@@ -1327,7 +1327,7 @@ class GISDocument(CommWidget):
             create_ydoc=path is None,
         )
 
-    def to_py(self) -> dict:
+    def _to_dict(self) -> dict:
         """Get the document structure as a Python dictionary."""
         return {
             "layers": self._layers.to_py(),


### PR DESCRIPTION
## Description

Renaming `to_py()` -> `_to_dict()` and turned into protected function.
 
- Closes #1498 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1508.org.readthedocs.build/en/1508/
💡 JupyterLite preview: https://jupytergis--1508.org.readthedocs.build/en/1508/lite
💡 Specta preview: https://jupytergis--1508.org.readthedocs.build/en/1508/lite/specta

<!-- readthedocs-preview jupytergis end -->