### PR TITLE
Differentiate symbology mappings as distinct "cards"

### DIFF
--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -316,6 +316,7 @@ select option {
   display: flex;
   flex-direction: row;
   align-items: stretch;
+  padding: 3px;
 }
 
 .jp-gis-grammar-drag-wrapper > .jp-gis-grammar-rule {

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -317,7 +317,7 @@ select option {
   flex-direction: row;
   align-items: stretch;
   padding-left: 5px;
-  padding-right: 8px;  /* A little more on the right because of the scroll bar */
+  padding-right: 8px; /* A little more on the right because of the scroll bar */
 }
 
 .jp-gis-grammar-drag-wrapper > .jp-gis-grammar-rule {

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -316,7 +316,8 @@ select option {
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  padding: 3px;
+  padding-left: 5px;
+  padding-right: 8px;  /* A little more on the right because of the scroll bar */
 }
 
 .jp-gis-grammar-drag-wrapper > .jp-gis-grammar-rule {


### PR DESCRIPTION
## Description

Resolves #1511 

Currently the mappings are hard to differentiate each other because the main differentiator is line thickness and color. This PR adds a touch of left and right padding so each mapping appears more clearly as a discrete "card" object.

<img width="2846" height="848" alt="image" src="https://github.com/user-attachments/assets/2334445b-6420-4b1a-8edc-24386e9d8e35" />

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1517.org.readthedocs.build/en/1517/
💡 JupyterLite preview: https://jupytergis--1517.org.readthedocs.build/en/1517/lite
💡 Specta preview: https://jupytergis--1517.org.readthedocs.build/en/1517/lite/specta

<!-- readthedocs-preview jupytergis end -->