### PR TITLE
Rename color ramp terminology to color map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - feat: add RGBA color picker to vector symbology dialogs [#1195](https://github.com/geojupyter/jupytergis/pull/1195) ([@MMesch](https://github.com/MMesch), [@arjxn-py](https://github.com/arjxn-py), [@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou))
 - Improve Graduated symbology: log breaks fix and vmin/vmax controls [#1193](https://github.com/geojupyter/jupytergis/pull/1193) ([@MMesch](https://github.com/MMesch), [@martinRenou](https://github.com/martinRenou))
 - Add Natural Earth and ESRI overlay layers to gallery [#1191](https://github.com/geojupyter/jupytergis/pull/1191) ([@MMesch](https://github.com/MMesch), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
-- Add D3 categorical color maps [#1186](https://github.com/geojupyter/jupytergis/pull/1186) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
+- Add D3 categorical color ramps [#1186](https://github.com/geojupyter/jupytergis/pull/1186) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
 - StopRow now supports strings values [#1183](https://github.com/geojupyter/jupytergis/pull/1183) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou))
 - Add support for WMS layers [#1178](https://github.com/geojupyter/jupytergis/pull/1178) ([@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou))
 
@@ -267,7 +267,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - Add keybinding class into toolbar section [#1156](https://github.com/geojupyter/jupytergis/pull/1156) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
 - Fix symbology value selection [#1153](https://github.com/geojupyter/jupytergis/pull/1153) ([@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
 - Symbology panel: Fix initial state by restoring nclasses correctly [#1149](https://github.com/geojupyter/jupytergis/pull/1149) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou))
-- Hydrate color map "reverse" state from project state [#1146](https://github.com/geojupyter/jupytergis/pull/1146) ([@nakul-py](https://github.com/nakul-py), [@mfisher87](https://github.com/mfisher87))
+- Hydrate color ramp "reverse" state from project state [#1146](https://github.com/geojupyter/jupytergis/pull/1146) ([@nakul-py](https://github.com/nakul-py), [@mfisher87](https://github.com/mfisher87))
 - Dont show segments in layer selection dropdown [#1143](https://github.com/geojupyter/jupytergis/pull/1143) ([@gjmooney](https://github.com/gjmooney), [@mfisher87](https://github.com/mfisher87))
 - Specta symbology override fix [#1134](https://github.com/geojupyter/jupytergis/pull/1134) ([@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou))
 
@@ -574,7 +574,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - Display side panels in full screen view [#979](https://github.com/geojupyter/jupytergis/pull/979) ([@gjmooney](https://github.com/gjmooney))
 - Resolve some browser errors [#971](https://github.com/geojupyter/jupytergis/pull/971) ([@gjmooney](https://github.com/gjmooney))
 - In graduated symbology mode, remove static fill color field and fix stroke color field [#952](https://github.com/geojupyter/jupytergis/pull/952) ([@nakul-py](https://github.com/nakul-py))
-- Fix color map gradient cut off, add labels [#950](https://github.com/geojupyter/jupytergis/pull/950) ([@nakul-py](https://github.com/nakul-py))
+- Fix color ramp gradient cut off, add labels [#950](https://github.com/geojupyter/jupytergis/pull/950) ([@nakul-py](https://github.com/nakul-py))
 
 ### Maintenance and upkeep improvements
 
@@ -655,7 +655,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 ### Enhancements made
 
 - Identify panel: try to infer the feature name instead of showing the default "Feature X" name [#906](https://github.com/geojupyter/jupytergis/pull/906) ([@martinRenou](https://github.com/martinRenou))
-- Adding Checkbox for reverse color map [#904](https://github.com/geojupyter/jupytergis/pull/904) ([@nakul-py](https://github.com/nakul-py))
+- Adding Checkbox for reverse Color Ramp [#904](https://github.com/geojupyter/jupytergis/pull/904) ([@nakul-py](https://github.com/nakul-py))
 - Lazy load gdal [#901](https://github.com/geojupyter/jupytergis/pull/901) ([@martinRenou](https://github.com/martinRenou))
 - Automatically switch to identify panel when identifying [#900](https://github.com/geojupyter/jupytergis/pull/900) ([@arjxn-py](https://github.com/arjxn-py))
 - Introduce settings to optionally disable some features (filtering/annotations etc) [#898](https://github.com/geojupyter/jupytergis/pull/898) ([@arjxn-py](https://github.com/arjxn-py))
@@ -1266,7 +1266,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - Open jgis files with json viewer [#210](https://github.com/geojupyter/jupytergis/pull/210) ([@gjmooney](https://github.com/gjmooney))
 - Add support for other projections [#199](https://github.com/geojupyter/jupytergis/pull/199) ([@gjmooney](https://github.com/gjmooney))
 - Symbology refactor [#193](https://github.com/geojupyter/jupytergis/pull/193) ([@gjmooney](https://github.com/gjmooney))
-- color maps and classification [#177](https://github.com/geojupyter/jupytergis/pull/177) ([@gjmooney](https://github.com/gjmooney))
+- Color ramps and classification [#177](https://github.com/geojupyter/jupytergis/pull/177) ([@gjmooney](https://github.com/gjmooney))
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - feat: add RGBA color picker to vector symbology dialogs [#1195](https://github.com/geojupyter/jupytergis/pull/1195) ([@MMesch](https://github.com/MMesch), [@arjxn-py](https://github.com/arjxn-py), [@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou))
 - Improve Graduated symbology: log breaks fix and vmin/vmax controls [#1193](https://github.com/geojupyter/jupytergis/pull/1193) ([@MMesch](https://github.com/MMesch), [@martinRenou](https://github.com/martinRenou))
 - Add Natural Earth and ESRI overlay layers to gallery [#1191](https://github.com/geojupyter/jupytergis/pull/1191) ([@MMesch](https://github.com/MMesch), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
-- Add D3 categorical color ramps [#1186](https://github.com/geojupyter/jupytergis/pull/1186) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
+- Add D3 categorical color maps [#1186](https://github.com/geojupyter/jupytergis/pull/1186) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
 - StopRow now supports strings values [#1183](https://github.com/geojupyter/jupytergis/pull/1183) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou))
 - Add support for WMS layers [#1178](https://github.com/geojupyter/jupytergis/pull/1178) ([@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou))
 
@@ -267,7 +267,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - Add keybinding class into toolbar section [#1156](https://github.com/geojupyter/jupytergis/pull/1156) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
 - Fix symbology value selection [#1153](https://github.com/geojupyter/jupytergis/pull/1153) ([@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou), [@mfisher87](https://github.com/mfisher87))
 - Symbology panel: Fix initial state by restoring nclasses correctly [#1149](https://github.com/geojupyter/jupytergis/pull/1149) ([@nakul-py](https://github.com/nakul-py), [@martinRenou](https://github.com/martinRenou))
-- Hydrate color ramp "reverse" state from project state [#1146](https://github.com/geojupyter/jupytergis/pull/1146) ([@nakul-py](https://github.com/nakul-py), [@mfisher87](https://github.com/mfisher87))
+- Hydrate color map "reverse" state from project state [#1146](https://github.com/geojupyter/jupytergis/pull/1146) ([@nakul-py](https://github.com/nakul-py), [@mfisher87](https://github.com/mfisher87))
 - Dont show segments in layer selection dropdown [#1143](https://github.com/geojupyter/jupytergis/pull/1143) ([@gjmooney](https://github.com/gjmooney), [@mfisher87](https://github.com/mfisher87))
 - Specta symbology override fix [#1134](https://github.com/geojupyter/jupytergis/pull/1134) ([@gjmooney](https://github.com/gjmooney), [@martinRenou](https://github.com/martinRenou))
 
@@ -574,7 +574,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - Display side panels in full screen view [#979](https://github.com/geojupyter/jupytergis/pull/979) ([@gjmooney](https://github.com/gjmooney))
 - Resolve some browser errors [#971](https://github.com/geojupyter/jupytergis/pull/971) ([@gjmooney](https://github.com/gjmooney))
 - In graduated symbology mode, remove static fill color field and fix stroke color field [#952](https://github.com/geojupyter/jupytergis/pull/952) ([@nakul-py](https://github.com/nakul-py))
-- Fix color ramp gradient cut off, add labels [#950](https://github.com/geojupyter/jupytergis/pull/950) ([@nakul-py](https://github.com/nakul-py))
+- Fix color map gradient cut off, add labels [#950](https://github.com/geojupyter/jupytergis/pull/950) ([@nakul-py](https://github.com/nakul-py))
 
 ### Maintenance and upkeep improvements
 
@@ -655,7 +655,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 ### Enhancements made
 
 - Identify panel: try to infer the feature name instead of showing the default "Feature X" name [#906](https://github.com/geojupyter/jupytergis/pull/906) ([@martinRenou](https://github.com/martinRenou))
-- Adding Checkbox for reverse Color Ramp [#904](https://github.com/geojupyter/jupytergis/pull/904) ([@nakul-py](https://github.com/nakul-py))
+- Adding Checkbox for reverse color map [#904](https://github.com/geojupyter/jupytergis/pull/904) ([@nakul-py](https://github.com/nakul-py))
 - Lazy load gdal [#901](https://github.com/geojupyter/jupytergis/pull/901) ([@martinRenou](https://github.com/martinRenou))
 - Automatically switch to identify panel when identifying [#900](https://github.com/geojupyter/jupytergis/pull/900) ([@arjxn-py](https://github.com/arjxn-py))
 - Introduce settings to optionally disable some features (filtering/annotations etc) [#898](https://github.com/geojupyter/jupytergis/pull/898) ([@arjxn-py](https://github.com/arjxn-py))
@@ -1266,7 +1266,7 @@ See [our definition of contributors](https://github-activity.readthedocs.io/en/l
 - Open jgis files with json viewer [#210](https://github.com/geojupyter/jupytergis/pull/210) ([@gjmooney](https://github.com/gjmooney))
 - Add support for other projections [#199](https://github.com/geojupyter/jupytergis/pull/199) ([@gjmooney](https://github.com/gjmooney))
 - Symbology refactor [#193](https://github.com/geojupyter/jupytergis/pull/193) ([@gjmooney](https://github.com/gjmooney))
-- Color ramps and classification [#177](https://github.com/geojupyter/jupytergis/pull/177) ([@gjmooney](https://github.com/gjmooney))
+- color maps and classification [#177](https://github.com/geojupyter/jupytergis/pull/177) ([@gjmooney](https://github.com/gjmooney))
 
 ### Bugs fixed
 

--- a/packages/base/src/features/layers/symbology/colorRampUtils.ts
+++ b/packages/base/src/features/layers/symbology/colorRampUtils.ts
@@ -182,7 +182,7 @@ export const useColorMapList = (setColorMaps: (maps: IColorMap[]) => void) => {
 
 /**
  * Get a color map by name.
- * Caches the full list on first call for efficiency, since generating color ramps is expensive.
+ * Caches the full list on first call for efficiency, since generating color maps is expensive.
  */
 let colorMapCache: IColorMap[] | null = null;
 
@@ -242,7 +242,7 @@ export function colorToRgba(color: unknown): RgbaColor {
 }
 
 /**
- * Draw a color ramp to a canvas.
+ * Draw a color map to a canvas.
  */
 export const drawColorRamp = (
   canvas: HTMLCanvasElement,

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -171,7 +171,7 @@ const SCHEME_OPTIONS: {
 }[] = [
   { value: 'constant_rgba', label: 'const (color)' },
   { value: 'constant_num', label: 'const (num)' },
-  { value: 'colorRamp', label: 'colorRamp' },
+  { value: 'colorRamp', label: 'color map' },
   { value: 'categorical', label: 'categorical' },
   { value: 'scalar', label: 'scalar' },
   { value: 'identity', label: 'identity' },

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -171,7 +171,7 @@ const SCHEME_OPTIONS: {
 }[] = [
   { value: 'constant_rgba', label: 'const (color)' },
   { value: 'constant_num', label: 'const (num)' },
-  { value: 'colorRamp', label: 'colormap' },
+  { value: 'colorRamp', label: 'color map' },
   { value: 'categorical', label: 'categorical' },
   { value: 'scalar', label: 'scalar' },
   { value: 'identity', label: 'identity' },

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -171,7 +171,7 @@ const SCHEME_OPTIONS: {
 }[] = [
   { value: 'constant_rgba', label: 'const (color)' },
   { value: 'constant_num', label: 'const (num)' },
-  { value: 'colorRamp', label: 'color map' },
+  { value: 'colorRamp', label: 'colormap' },
   { value: 'categorical', label: 'categorical' },
   { value: 'scalar', label: 'scalar' },
   { value: 'identity', label: 'identity' },

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -189,7 +189,7 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
   return (
     <div className="jp-gis-color-ramp-container">
       <div className="jp-gis-symbology-row">
-        <label>Ramp</label>
+        <label>Colormap</label>
         <ColorRampSelector
           selectedRamp={params.name as ColorRampName}
           setSelected={name => update({ name })}

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -189,7 +189,7 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
   return (
     <div className="jp-gis-color-ramp-container">
       <div className="jp-gis-symbology-row">
-        <label>Colormap</label>
+        <label>Color map</label>
         <ColorRampSelector
           selectedRamp={params.name as ColorRampName}
           setSelected={name => update({ name })}

--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampControls.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampControls.tsx
@@ -2,10 +2,10 @@
  * @module ColorRampControls
  *
  * This component provides the main UI controls for classifying raster layers
- * using different color ramps and classification modes.
+ * using different color maps and classification modes.
  *
  * Allows users to:
- * - Select a color ramp (`ColorRampSelector`)
+ * - Select a color map (`ColorRampSelector`)
  * - Choose classification mode and number of classes (`ModeSelectRow`)
  * - Run classification via `classifyFunc`, with loading state (`LoadingIcon`)
  *
@@ -117,7 +117,7 @@ const ColorRampControls: React.FC<IColorRampControlsProps> = ({
     <div className="jp-gis-color-ramp-container">
       {showRampSelector && (
         <div className="jp-gis-symbology-row">
-          <label htmlFor="color-ramp-select">Color Ramp:</label>
+          <label htmlFor="color-ramp-select">Color Map:</label>
           <ColorRampSelector
             selectedRamp={selectedRamp}
             setSelected={handleRampChange}

--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelector.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelector.tsx
@@ -1,13 +1,13 @@
 /**
  * @module ColorRampSelector
  *
- * Dropdown component for selecting a color ramp.
+ * Dropdown component for selecting a color map.
  * - Displays the currently selected ramp as a preview on a canvas.
  * - Expands to show a list of available ramps (`ColorRampSelectorEntry`).
  * - Updates the preview and notifies parent via `setSelected` when a ramp is chosen.
  *
  * Props:
- * - `selectedRamp`: Name of the currently selected color ramp.
+ * - `selectedRamp`: Name of the currently selected color map.
  * - `setSelected`: Callback fired with the new ramp when selected.
  */
 
@@ -77,7 +77,7 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
   };
 
   const updateCanvas = (rampName: string) => {
-    // update canvas for displayed color ramp
+    // update canvas for displayed color map
     const canvas = document.getElementById('cv') as HTMLCanvasElement;
     if (!canvas) {
       return;
@@ -143,7 +143,7 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
             checked={reverse}
             onChange={e => setReverse(e.target.checked)}
           />
-          Reverse Color Ramp
+          Reverse Color Map
         </label>
       </div>
     </div>

--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
@@ -1,7 +1,7 @@
 /**
  * @module ColorRampSelectorEntry
  *
- * Represents a single selectable color ramp option in the `ColorRampSelector`.
+ * Represents a single selectable color map option in the `ColorRampSelector`.
  * Renders a preview ColorRamp on a canvas and triggers `onClick` when selected.
  *
  * Props:

--- a/packages/base/src/features/layers/symbology/styleBuilder.ts
+++ b/packages/base/src/features/layers/symbology/styleBuilder.ts
@@ -169,7 +169,7 @@ export function computeCategorizedColorStops(
   }));
 }
 
-// Color ramp helpers
+// color map helpers
 
 function mapStopsToColors(
   stops: number[],

--- a/python/jupytergis_core/jupytergis_core/color_ramps.py
+++ b/python/jupytergis_core/jupytergis_core/color_ramps.py
@@ -1,4 +1,4 @@
-"""Shared color ramp utilities using branca.
+"""Shared color map utilities using branca.
 
 Maps the frontend colorRamp names (from colorRampUtils.ts) to branca
 LinearColormaps so that both the QGIS exporter and the notebook API can
@@ -58,7 +58,7 @@ def get_color_ramp(
     Parameters
     ----------
     name : str
-        A color ramp name as used by the frontend (e.g. ``"viridis"``,
+        A color map name as used by the frontend (e.g. ``"viridis"``,
         ``"YiGnBu"``, ``"schemeSet1"``).
     reverse : bool
         If ``True``, reverse the color order.

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -43,12 +43,12 @@ class GraduatedSymbology(BaseSymbology):
             ``data`` is just a kernel-side convenience.
         method: ``"color"`` drives fill/stroke colors; ``"radius"`` drives
             circle size for point layers.
-        color_ramp: Name of the color ramp (e.g. ``"viridis"``,
+        color_ramp: Name of the color map (e.g. ``"viridis"``,
             ``"plasma"``, ``"magma"``).
         n_classes: Number of classification bins. Must be ``>= 1``.
         mode: Classification method. One of ``"equal interval"``,
             ``"quantile"``, ``"jenks"``, ``"pretty"``, ``"logarithmic"``.
-        reverse: Reverse the color ramp.
+        reverse: Reverse the color map.
         vmin: Lower bound of the classification range. If omitted, derived
             from ``data`` when given, otherwise computed by the frontend
             from the source.

--- a/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
@@ -868,7 +868,7 @@ def jgis_layer_to_qgis(
         source_min = source_parameters["urls"][0]["min"]
         source_max = source_parameters["urls"][0]["max"]
 
-        # Create a color ramp shader
+        # Create a color map shader
         color_ramp_shader = QgsColorRampShader()
         color_stops = []
 


### PR DESCRIPTION
Fixes #1510

Updated user-facing terminology, comments, and documentation to use "color map" instead of "color ramp" where appropriate.

This change intentionally avoids renaming internal schema fields, persisted project properties, and API identifiers to avoid breaking compatibility.


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1518.org.readthedocs.build/en/1518/
💡 JupyterLite preview: https://jupytergis--1518.org.readthedocs.build/en/1518/lite
💡 Specta preview: https://jupytergis--1518.org.readthedocs.build/en/1518/lite/specta

<!-- readthedocs-preview jupytergis end -->