### PR TITLE
Fix: sharedModel.source should be a string, not JSON

### DIFF
--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -86,7 +86,7 @@ export class JupyterGISDoc
     this._initialSyncReadyResolve();
   }
 
-  getSource(): JSONObject {
+  getSource(): string {
     const layers = this._layers.toJSON();
     const layerTree = this._layerTree.toJSON();
     const options = this._options.toJSON();
@@ -95,15 +95,19 @@ export class JupyterGISDoc
     const viewState = this._viewState.toJSON();
     const metadata = this._metadata.toJSON();
 
-    return {
-      layers,
-      layerTree,
-      sources,
-      stories,
-      viewState,
-      options,
-      metadata,
-    };
+    return JSON.stringify(
+      {
+        layers,
+        layerTree,
+        sources,
+        stories,
+        viewState,
+        options,
+        metadata,
+      },
+      null,
+      '  ',
+    );
   }
 
   setSource(value: JSONObject | string): void {

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -188,7 +188,7 @@ export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
   readonly editable: boolean;
   readonly toJGISEndpoint?: string;
 
-  getSource(): JSONObject;
+  getSource(): string;
   setSource(value: JSONObject | string): void;
 
   layerExists(id: string): boolean;


### PR DESCRIPTION
## Description

Closes https://github.com/geojupyter/jupytergis/pull/1509

Even if our file format is indeed JSON, the jupyter-server contents manager only allow text or base64. So we must keep the text format.

The only issue is that `getSource` in the front-end was wrongly returning a JSON structure instead of string. Leading to some issues in jupyter-collaboration.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1520.org.readthedocs.build/en/1520/
💡 JupyterLite preview: https://jupytergis--1520.org.readthedocs.build/en/1520/lite
💡 Specta preview: https://jupytergis--1520.org.readthedocs.build/en/1520/lite/specta

<!-- readthedocs-preview jupytergis end -->