### PR TITLE
Upgrade minimum supported version of jupyter-tiler

### DIFF
--- a/python/jupytergis_lab/pyproject.toml
+++ b/python/jupytergis_lab/pyproject.toml
@@ -39,7 +39,7 @@ requires-python = ">=3.12"
 
 [project.optional-dependencies]
 tiler = [
-  "jupyter-tiler>=0.6.0",
+  "jupyter-tiler>=0.8.0",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
## Description

This version includes a fix for running in JupyterHub. 0.6.0 is technically incompatible with jupytergis, because that release predates the rename from jupyter-xarray-tiler -> jupyter-tiler

Woops!

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1536.org.readthedocs.build/en/1536/
💡 JupyterLite preview: https://jupytergis--1536.org.readthedocs.build/en/1536/lite
💡 Specta preview: https://jupytergis--1536.org.readthedocs.build/en/1536/lite/specta

<!-- readthedocs-preview jupytergis end -->