### PR TITLE
Don't overwrite values from file when loading jgis via notebook

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -145,7 +145,7 @@ class GISDocument(CommWidget):
             self.ydoc["layerTree"] = self._layerTree = Array()
             self.ydoc["metadata"] = self._metadata = Map()
         else:
-            # Bind to the synced document loaded from the file. 
+            # Bind to the synced document loaded from the file.
             # Replacing these wipes the options before the map renders.
             self._layers = self.ydoc["layers"]
             self._sources = self.ydoc["sources"]

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -144,14 +144,6 @@ class GISDocument(CommWidget):
             )
             self.ydoc["layerTree"] = self._layerTree = Array()
             self.ydoc["metadata"] = self._metadata = Map()
-        else:
-            # Bind to the synced document loaded from the file.
-            # Replacing these wipes the options before the map renders.
-            self._layers = self.ydoc["layers"]
-            self._sources = self.ydoc["sources"]
-            self._options = self.ydoc["options"]
-            self._layerTree = self.ydoc["layerTree"]
-            self._metadata = self.ydoc["metadata"]
 
         if latitude is not None:
             self._options["latitude"] = latitude

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -124,21 +124,34 @@ class GISDocument(CommWidget):
             },
         )
 
-        self.ydoc["layers"] = self._layers = Map()
-        self.ydoc["sources"] = self._sources = Map()
-        self.ydoc["options"] = self._options = Map(
-            {
-                "latitude": 0,
-                "longitude": 0,
-                "zoom": 0,
-                "bearing": 0,
-                "pitch": 0,
-                "projection": "EPSG:3857",
-                "storyMapPresentationMode": False,
-            },
-        )
-        self.ydoc["layerTree"] = self._layerTree = Array()
-        self.ydoc["metadata"] = self._metadata = Map()
+        if path is None:
+            self.ydoc["layers"] = self._layers = Map()
+            self.ydoc["sources"] = self._sources = Map()
+            self.ydoc["options"] = self._options = Map[
+                float | str | bool | None | list[float]
+            ](
+                {
+                    "latitude": 0,
+                    "longitude": 0,
+                    "zoom": 0,
+                    "bearing": 0,
+                    "pitch": 0,
+                    "extent": None,
+                    "projection": "EPSG:3857",
+                    "useExtent": False,
+                    "storyMapPresentationMode": False,
+                },
+            )
+            self.ydoc["layerTree"] = self._layerTree = Array()
+            self.ydoc["metadata"] = self._metadata = Map()
+        else:
+            # Bind to the synced document loaded from the file. 
+            # Replacing these wipes the options before the map renders.
+            self._layers = self.ydoc["layers"]
+            self._sources = self.ydoc["sources"]
+            self._options = self.ydoc["options"]
+            self._layerTree = self.ydoc["layerTree"]
+            self._metadata = self.ydoc["metadata"]
 
         if latitude is not None:
             self._options["latitude"] = latitude


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Turns out that flaky test wasn't flaky. Loading a `.jgis` file from a notebook would overwrite the values from the file.



## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1543.org.readthedocs.build/en/1543/
💡 JupyterLite preview: https://jupytergis--1543.org.readthedocs.build/en/1543/lite
💡 Specta preview: https://jupytergis--1543.org.readthedocs.build/en/1543/lite/specta

<!-- readthedocs-preview jupytergis end -->