### PR TITLE
Revert "Fix CI missing qt dep" -- the upstream problem is fixed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,11 +147,6 @@ jobs:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
 
     steps:
-      - name: Install QGIS runtime deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libqca-qt5-2 libqca-qt5-2-plugins
-
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/unit-test-python.yml
+++ b/.github/workflows/unit-test-python.yml
@@ -22,11 +22,6 @@ jobs:
         python-version: ['3.12', '3.13']
 
     steps:
-      - name: Install QGIS runtime deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libqca-qt5-2 libqca-qt5-2-plugins
-
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@d7c9bd84e824b79d2af72a2d4196c7f4300d3476 # v3.0.0
         with:

--- a/.github/workflows/update_galata_references.yaml
+++ b/.github/workflows/update_galata_references.yaml
@@ -20,11 +20,6 @@ jobs:
     if: github.event.issue.pull_request && contains(github.event.comment.body, 'please update snapshots')
 
     steps:
-      - name: Install QGIS runtime deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libqca-qt5-2 libqca-qt5-2-plugins
-
       - uses: jupyterlab/maintainer-tools/.github/actions/update-snapshots-checkout@95d85449e4f3f352e261221f6529f8ed307f5728
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts geojupyter/jupytergis#1534

This issue is ~~being~~ fixed upstream. qt5 is supposed to be packaged with qgis, but some releases were made that included qt6 instead due to a change in a transitive dependency. Those packages were marked broken and the transitive dependency will instead produce a separate output for qt6 to avoid breaking every old version of QGIS on conda-forge!

Upstream report: https://github.com/conda-forge/qgis-feedstock/issues/596

~~Do not merge until https://github.com/conda-forge/admin-requests/pull/2160 is merged and confirmed that broken markers are applied on anaconda.org or wherever -- at this point all the releases that caused our build to fail in the first place should be marked broken.~~

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1547.org.readthedocs.build/en/1547/
💡 JupyterLite preview: https://jupytergis--1547.org.readthedocs.build/en/1547/lite
💡 Specta preview: https://jupytergis--1547.org.readthedocs.build/en/1547/lite/specta

<!-- readthedocs-preview jupytergis end -->