### PR TITLE
Ensure that `InfoTip` tooltips render on top of dialogs

### DIFF
--- a/packages/base/style/shared/hoverCard.css
+++ b/packages/base/style/shared/hoverCard.css
@@ -26,7 +26,7 @@
 
 .jgis-hover-card-content {
   position: relative;
-  z-index: 50;
+  z-index: 99999;
   width: 16rem;
   padding: 0.625rem;
   border-radius: 0.5rem;


### PR DESCRIPTION
## Description

Previously, they would render behind dialogs, e.g. the symbology dialog.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1551.org.readthedocs.build/en/1551/
💡 JupyterLite preview: https://jupytergis--1551.org.readthedocs.build/en/1551/lite
💡 Specta preview: https://jupytergis--1551.org.readthedocs.build/en/1551/lite/specta

<!-- readthedocs-preview jupytergis end -->