### PR TITLE
Add tooltips to symbology pane

### DIFF
--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -48,6 +48,8 @@ import {
   NativeSelectOption,
 } from '@/src/shared/components/NativeSelect';
 
+import {InfoTip} from '@/src/shared/components/InfoTip';
+
 const DEFAULT_CHANNELS: Encoding[] = ['fill-color', 'circle-fill-color'];
 const DEFAULT_RGBA: RGBA = [128, 128, 128, 1];
 
@@ -313,6 +315,23 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
       {/* Layer header */}
       <div className="jp-gis-grammar-layer-header">
         <span className="jp-gis-grammar-layer-label">
+          <InfoTip text="Groups Symbolizers to define a visual output, rendered in order.">
+            A
+            <a href="https://jupytergis.readthedocs.io/en/latest/about/glossary.html#term-Symbology-Rule"
+               target="_blank"
+               rel="noopener noreferrer">
+              Symbology Rule
+            </a>
+            is a set of
+            <a href="https://jupytergis.readthedocs.io/en/latest/about/glossary.html#term-Symbolizer"
+               target="_blank"
+               rel="noopener noreferrer">
+              Symbolizers
+            </a>
+            that define a single representation of a data layer.
+            Symbology rules are ordered; a higher rule will appear “above” a lower rule when rendered.
+            A Rule can have a pre-processor, for example Kernel Density Estimation (KDE), which is applied before its Symbolizers.
+          </InfoTip>
           Layer {layerIndex + 1}
         </span>
         {layer.transforms.length === 0 && (


### PR DESCRIPTION
## Description

adds tooltips to symbology pane

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1553.org.readthedocs.build/en/1553/
💡 JupyterLite preview: https://jupytergis--1553.org.readthedocs.build/en/1553/lite
💡 Specta preview: https://jupytergis--1553.org.readthedocs.build/en/1553/lite/specta

<!-- readthedocs-preview jupytergis end -->