### PR TITLE
Add in-lab story presentation previews

### DIFF
--- a/examples/geoZarr.jGIS
+++ b/examples/geoZarr.jGIS
@@ -48,7 +48,6 @@
     "longitude": -19.952643100704634,
     "pitch": 0.0,
     "projection": "EPSG:3857",
-    "storyMapPresentationMode": false,
     "zoom": 8.544160986142069
   },
   "schemaVersion": "0.6.0",

--- a/examples/wms-tile.jGIS
+++ b/examples/wms-tile.jGIS
@@ -26,7 +26,6 @@
     "longitude": 0.0,
     "pitch": 0.0,
     "projection": "EPSG:3857",
-    "storyMapPresentationMode": false,
     "zoom": 2.100662339005199
   },
   "schemaVersion": "0.5.0",

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1886,6 +1886,7 @@ export function addCommands(
       const session = StoryEditorSession.getInstance();
       if (session.isActiveFor(current.model)) {
         if (session.isMapInteractionMode()) {
+          commands.notifyCommandChanged(CommandIDs.openStoryEditor);
           session.restoreEditor();
         } else {
           session.focusDialog();

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1893,7 +1893,7 @@ export function addCommands(
         return;
       }
 
-      await Private.launchStoryEditor(
+      await Private.createStoryEditor(
         current.model,
         commands,
         formSchemaRegistry,
@@ -1945,7 +1945,7 @@ export function addCommands(
     },
   });
 
-  /* Enabled during story presentation (Specta embed or in-lab preview). */
+  /* Enabled during story presentation (Specta or lab preview). */
   originalAddCommand(CommandIDs.storyPrev, {
     label: trans.__('Previous Story Segment'),
     isEnabled: () => {
@@ -2064,7 +2064,7 @@ export function addCommands(
 }
 
 namespace Private {
-  export async function launchStoryEditor(
+  export async function createStoryEditor(
     model: IJupyterGISModel,
     commands: CommandRegistry,
     formSchemaRegistry: IJGISFormSchemaRegistry,

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -2083,7 +2083,7 @@ namespace Private {
       dialog,
       model,
       commands,
-      resolveMainViewContainer(tracker, model),
+      Private.resolveMainViewContainer(tracker, model),
     );
 
     try {
@@ -2271,7 +2271,7 @@ namespace Private {
     return `${cleanBase} Copy_${nextNumber}`;
   }
 
-  function resolveMainViewContainer(
+  export function resolveMainViewContainer(
     tracker: JupyterGISTracker,
     model: IJupyterGISModel,
   ): HTMLElement | null {

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1946,7 +1946,7 @@ export function addCommands(
     },
   });
 
-  /* Needs to be enabled in Specta mode, so add without Specta-aware wrapper */
+  /* Enabled during story presentation (Specta embed or in-lab preview). */
   originalAddCommand(CommandIDs.storyPrev, {
     label: trans.__('Previous Story Segment'),
     isEnabled: () => {
@@ -1962,7 +1962,7 @@ export function addCommands(
         return false;
       }
 
-      if (!model.isSpectaMode()) {
+      if (!model.isStoryPresentationActive()) {
         return false;
       }
 
@@ -1999,8 +1999,7 @@ export function addCommands(
         return false;
       }
 
-      const isSpecta = model.isSpectaMode();
-      if (!isSpecta) {
+      if (!model.isStoryPresentationActive()) {
         return false;
       }
 
@@ -2024,6 +2023,12 @@ export function addCommands(
     },
   });
 
+  const notifyStoryPresentationCommandsChanged = () => {
+    commands.notifyCommandChanged(CommandIDs.openStoryEditor);
+    commands.notifyCommandChanged(CommandIDs.storyPrev);
+    commands.notifyCommandChanged(CommandIDs.storyNext);
+  };
+
   const notifyCommandsChanged = () => {
     for (const command of Object.values(CommandIDs)) {
       try {
@@ -2042,9 +2047,15 @@ export function addCommands(
 
     const model = tracker.currentWidget?.model;
     model?.selectedChanged.connect(notifyCommandsChanged);
+    model?.storyPreviewActiveChanged.connect(
+      notifyStoryPresentationCommandsChanged,
+    );
 
     cleanup = () => {
       model?.selectedChanged.disconnect(notifyCommandsChanged);
+      model?.storyPreviewActiveChanged.disconnect(
+        notifyStoryPresentationCommandsChanged,
+      );
     };
 
     notifyCommandsChanged();

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1878,6 +1878,39 @@ export function addCommands(
     ...icons.get(CommandIDs.openStoryEditor),
   });
 
+  commands.addCommand(CommandIDs.toggleStoryPresentationMode, {
+    label: trans.__('Toggle Story Presentation Mode'),
+    isToggled: () => {
+      const current = tracker.currentWidget;
+      if (!current) {
+        return false;
+      }
+
+      return current.model.isStoryPreviewActive();
+    },
+    isEnabled: () => {
+      const model = tracker.currentWidget?.model;
+      if (!model) {
+        return false;
+      }
+
+      return model.canUseStoryPreview();
+    },
+    execute: () => {
+      const current = tracker.currentWidget;
+      if (!current) {
+        return;
+      }
+
+      StoryEditorSession.getInstance().toggleStoryPreview(current.model);
+    },
+    ...icons.get(CommandIDs.toggleStoryPresentationMode),
+  });
+
+  StoryEditorSession.setPreviewChangeNotifier(() => {
+    commands.notifyCommandChanged(CommandIDs.toggleStoryPresentationMode);
+  });
+
   commands.addCommand(CommandIDs.createStorySegmentFromLayer, {
     label: trans.__('Create Story Segment for Layer'),
 

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -47,7 +47,7 @@ import {
   STORY_TYPE,
   SYMBOLOGY_VALID_LAYER_TYPES,
 } from '../types';
-import { JupyterGISDocumentWidget } from '../workspace/widget';
+import { JupyterGISDocumentWidget, JupyterGISPanel } from '../workspace/widget';
 
 const POINT_SELECTION_TOOL_CLASS = 'jGIS-point-selection-tool';
 
@@ -1898,6 +1898,7 @@ export function addCommands(
         commands,
         formSchemaRegistry,
         state,
+        tracker,
       );
     },
     ...icons.get(CommandIDs.openStoryEditor),
@@ -2069,6 +2070,7 @@ namespace Private {
     commands: CommandRegistry,
     formSchemaRegistry: IJGISFormSchemaRegistry,
     state: IStateDB,
+    tracker: JupyterGISTracker,
   ): Promise<void> {
     const session = StoryEditorSession.getInstance();
     const dialog = new StoryEditorWidget({
@@ -2077,7 +2079,12 @@ namespace Private {
       state,
       formSchemaRegistry,
     });
-    session.attachDialog(dialog, model, commands);
+    session.attachDialog(
+      dialog,
+      model,
+      commands,
+      resolveMainViewContainer(tracker, model),
+    );
 
     try {
       await dialog.launch();
@@ -2262,5 +2269,22 @@ namespace Private {
     const nextNumber = numbers.length > 0 ? Math.max(...numbers) + 1 : 1;
 
     return `${cleanBase} Copy_${nextNumber}`;
+  }
+
+  function resolveMainViewContainer(
+    tracker: JupyterGISTracker,
+    model: IJupyterGISModel,
+  ): HTMLElement | null {
+    const widget = tracker.find(w => w.model === model);
+    const panel = widget?.content;
+    if (!(panel instanceof JupyterGISPanel)) {
+      return null;
+    }
+
+    return (
+      panel.jupyterGISMainViewPanel?.node.querySelector<HTMLElement>(
+        '.jGIS-Mainview-Container',
+      ) ?? null
+    );
   }
 }

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1886,7 +1886,6 @@ export function addCommands(
       const session = StoryEditorSession.getInstance();
       if (session.isActiveFor(current.model)) {
         if (session.isMapInteractionMode()) {
-          commands.notifyCommandChanged(CommandIDs.openStoryEditor);
           session.restoreEditor();
         } else {
           session.focusDialog();

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -2066,7 +2066,7 @@ namespace Private {
       state,
       formSchemaRegistry,
     });
-    session.attachDialog(dialog, model);
+    session.attachDialog(dialog, model, commands);
 
     try {
       await dialog.launch();

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1869,17 +1869,6 @@ export function addCommands(
 
       return !current.model.jgisSettings.storyMapsDisabled;
     },
-    execute: Private.createStoryEditor(
-      tracker,
-      commands,
-      formSchemaRegistry,
-      state,
-    ),
-    ...icons.get(CommandIDs.openStoryEditor),
-  });
-
-  commands.addCommand(CommandIDs.toggleStoryPresentationMode, {
-    label: trans.__('Toggle Story Presentation Mode'),
     isToggled: () => {
       const current = tracker.currentWidget;
       if (!current) {
@@ -1888,27 +1877,30 @@ export function addCommands(
 
       return current.model.isStoryPreviewActive();
     },
-    isEnabled: () => {
-      const model = tracker.currentWidget?.model;
-      if (!model) {
-        return false;
-      }
-
-      return model.canUseStoryPreview();
-    },
-    execute: () => {
+    execute: async () => {
       const current = tracker.currentWidget;
       if (!current) {
         return;
       }
 
-      StoryEditorSession.getInstance().toggleStoryPreview(current.model);
-    },
-    ...icons.get(CommandIDs.toggleStoryPresentationMode),
-  });
+      const session = StoryEditorSession.getInstance();
+      if (session.isActiveFor(current.model)) {
+        if (session.isMapInteractionMode()) {
+          session.restoreEditor();
+        } else {
+          session.focusDialog();
+        }
+        return;
+      }
 
-  StoryEditorSession.setPreviewChangeNotifier(() => {
-    commands.notifyCommandChanged(CommandIDs.toggleStoryPresentationMode);
+      await Private.launchStoryEditor(
+        current.model,
+        commands,
+        formSchemaRegistry,
+        state,
+      );
+    },
+    ...icons.get(CommandIDs.openStoryEditor),
   });
 
   commands.addCommand(CommandIDs.createStorySegmentFromLayer, {
@@ -2061,43 +2053,26 @@ export function addCommands(
 }
 
 namespace Private {
-  export function createStoryEditor(
-    tracker: JupyterGISTracker,
+  export async function launchStoryEditor(
+    model: IJupyterGISModel,
     commands: CommandRegistry,
     formSchemaRegistry: IJGISFormSchemaRegistry,
     state: IStateDB,
-  ) {
-    return async () => {
-      const current = tracker.currentWidget;
+  ): Promise<void> {
+    const session = StoryEditorSession.getInstance();
+    const dialog = new StoryEditorWidget({
+      model,
+      commands,
+      state,
+      formSchemaRegistry,
+    });
+    session.attachDialog(dialog, model);
 
-      if (!current) {
-        return;
-      }
-
-      const session = StoryEditorSession.getInstance();
-      if (session.isActiveFor(current.model)) {
-        if (session.isMapInteractionMode()) {
-          session.restoreEditor();
-        } else {
-          session.focusDialog();
-        }
-        return;
-      }
-
-      const dialog = new StoryEditorWidget({
-        model: current.model,
-        commands,
-        state,
-        formSchemaRegistry,
-      });
-      session.attachDialog(dialog, current.model, commands);
-
-      try {
-        await dialog.launch();
-      } finally {
-        session.clear();
-      }
-    };
+    try {
+      await dialog.launch();
+    } finally {
+      session.clear();
+    }
   }
 
   export function createLayerBrowser(

--- a/packages/base/src/features/layers/symbology/symbologyUtils.ts
+++ b/packages/base/src/features/layers/symbology/symbologyUtils.ts
@@ -54,6 +54,8 @@ export type IEffectiveSymbologyParams =
 
 const GRAMMAR_SYMBOLOGY_METADATA_KEYS = new Set(['id']);
 
+const GRAMMAR_SYMBOLOGY_METADATA_KEYS = new Set(['id']);
+
 /**
  * Resolve the effective symbology params for this dialog: either the layer's
  * parameters or the matching segment override when editing a story-segment override.

--- a/packages/base/src/features/layers/symbology/symbologyUtils.ts
+++ b/packages/base/src/features/layers/symbology/symbologyUtils.ts
@@ -159,6 +159,77 @@ export function symbologyStatesEqual(
   return JSON.stringify(baseSymbology) === JSON.stringify(overrideSymbology);
 }
 
+const GRAMMAR_SYMBOLOGY_METADATA_KEYS = new Set(['id']);
+
+function isGrammarSymbologyState(
+  value: unknown,
+): value is IGrammarSymbologyState {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as IGrammarSymbologyState).layers)
+  );
+}
+
+/** True when a symbology value carries renderable content (not just ids/empties). */
+function symbologyValueHasContent(value: unknown, key?: string): boolean {
+  if (key && GRAMMAR_SYMBOLOGY_METADATA_KEYS.has(key)) {
+    return false;
+  }
+
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 0;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(item => symbologyValueHasContent(item));
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value).some(([entryKey, entryValue]) =>
+      symbologyValueHasContent(entryValue, entryKey),
+    );
+  }
+
+  return true;
+}
+
+export function hasMeaningfulGrammarSymbologyState(
+  symbologyState: unknown,
+): boolean {
+  if (!symbologyState || typeof symbologyState !== 'object') {
+    return false;
+  }
+
+  if (!isGrammarSymbologyState(symbologyState)) {
+    return symbologyValueHasContent(symbologyState);
+  }
+
+  if (symbologyState.layers.length === 0) {
+    return false;
+  }
+
+  return symbologyState.layers.some(layer => {
+    const { id: _id, ...content } = layer;
+    return symbologyValueHasContent(content);
+  });
+}
+
+export function symbologyStatesEqual(
+  baseSymbology: unknown,
+  overrideSymbology: unknown,
+): boolean {
+  return JSON.stringify(baseSymbology) === JSON.stringify(overrideSymbology);
+}
+
 export function saveSymbology(options: ISaveSymbologyOptions): void {
   const {
     model,

--- a/packages/base/src/features/layers/symbology/symbologyUtils.ts
+++ b/packages/base/src/features/layers/symbology/symbologyUtils.ts
@@ -54,8 +54,6 @@ export type IEffectiveSymbologyParams =
 
 const GRAMMAR_SYMBOLOGY_METADATA_KEYS = new Set(['id']);
 
-const GRAMMAR_SYMBOLOGY_METADATA_KEYS = new Set(['id']);
-
 /**
  * Resolve the effective symbology params for this dialog: either the layer's
  * parameters or the matching segment override when editing a story-segment override.
@@ -152,77 +150,6 @@ export function hasMeaningfulGrammarSymbologyState(
   }
 
   return symbologyState.layers.some(layer => symbologyValueHasContent(layer));
-}
-
-export function symbologyStatesEqual(
-  baseSymbology: unknown,
-  overrideSymbology: unknown,
-): boolean {
-  return JSON.stringify(baseSymbology) === JSON.stringify(overrideSymbology);
-}
-
-const GRAMMAR_SYMBOLOGY_METADATA_KEYS = new Set(['id']);
-
-function isGrammarSymbologyState(
-  value: unknown,
-): value is IGrammarSymbologyState {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    Array.isArray((value as IGrammarSymbologyState).layers)
-  );
-}
-
-/** True when a symbology value carries renderable content (not just ids/empties). */
-function symbologyValueHasContent(value: unknown, key?: string): boolean {
-  if (key && GRAMMAR_SYMBOLOGY_METADATA_KEYS.has(key)) {
-    return false;
-  }
-
-  if (value === undefined || value === null) {
-    return false;
-  }
-
-  if (typeof value === 'string') {
-    return value.length > 0;
-  }
-
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    return value.some(item => symbologyValueHasContent(item));
-  }
-
-  if (typeof value === 'object') {
-    return Object.entries(value).some(([entryKey, entryValue]) =>
-      symbologyValueHasContent(entryValue, entryKey),
-    );
-  }
-
-  return true;
-}
-
-export function hasMeaningfulGrammarSymbologyState(
-  symbologyState: unknown,
-): boolean {
-  if (!symbologyState || typeof symbologyState !== 'object') {
-    return false;
-  }
-
-  if (!isGrammarSymbologyState(symbologyState)) {
-    return symbologyValueHasContent(symbologyState);
-  }
-
-  if (symbologyState.layers.length === 0) {
-    return false;
-  }
-
-  return symbologyState.layers.some(layer => {
-    const { id: _id, ...content } = layer;
-    return symbologyValueHasContent(content);
-  });
 }
 
 export function symbologyStatesEqual(

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -271,6 +271,7 @@ export function StoryEditorDialogBody({
   return (
     <div ref={portalContainerRef} className="jgis-story-editor">
       <StoryEditorHeaderBar
+        model={model}
         story={story}
         segmentCount={segments.length}
         onUpdateStory={updateStory}

--- a/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
+++ b/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
@@ -32,6 +32,8 @@ jest.mock('@/src/constants', () => ({
   },
 }));
 
+import { STORY_TYPE } from '@/src/types';
+import { StoryMapInteractionBarWidget } from '../components/StoryMapInteractionBarWidget';
 import { StoryEditorSession } from '../storyEditorSession';
 import { updateSegmentMapView } from '../utils/storySegmentMapView';
 import {
@@ -55,6 +57,9 @@ function createModel(overrides: Record<string, unknown> = {}) {
     canUseStoryPreview: jest.fn(() => true),
     isStoryPreviewActive: jest.fn(() => false),
     setStoryPreviewActive: jest.fn(),
+    getSelectedStory: jest.fn(() => ({
+      story: { storyType: STORY_TYPE.guided },
+    })),
     ...overrides,
   };
 }
@@ -157,6 +162,9 @@ describe('StoryEditorSession', () => {
     expect(session.isPreviewingStory()).toBe(true);
     expect(model.setStoryPreviewActive).toHaveBeenCalledWith(true);
     expect(dialog.minimize).toHaveBeenCalled();
+    expect(StoryMapInteractionBarWidget).toHaveBeenCalledWith(
+      expect.objectContaining({ placement: 'main-top-left' }),
+    );
     expect(commands.execute).not.toHaveBeenCalled();
 
     session.restoreEditor();
@@ -165,5 +173,22 @@ describe('StoryEditorSession', () => {
     expect(dialog.restore).toHaveBeenCalled();
     expect(session.isMapInteractionMode()).toBe(false);
     expect(commands.execute).not.toHaveBeenCalled();
+  });
+
+  it('uses bottom-center bar placement for non-guided story preview', () => {
+    const dialog = createDialog();
+    const model = createModel({
+      getSelectedStory: jest.fn(() => ({
+        story: { storyType: STORY_TYPE.verticalScroll },
+      })),
+    });
+    const commands = createCommands();
+
+    session.attachDialog(dialog as never, model as never, commands);
+    session.enterStoryPreviewMode();
+
+    expect(StoryMapInteractionBarWidget).toHaveBeenCalledWith(
+      expect.objectContaining({ placement: 'overlay-bottom' }),
+    );
   });
 });

--- a/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
+++ b/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
@@ -97,7 +97,7 @@ describe('StoryEditorSession', () => {
     const model = createModel();
     const commands = createCommands();
 
-    session.attachDialog(dialog as never, model as never, commands);
+    session.attachDialog(dialog as never, model as never, commands, null);
     session.enterMapViewMode('segment-1');
 
     expect(session.isMapViewMode()).toBe(true);
@@ -117,7 +117,7 @@ describe('StoryEditorSession', () => {
     const model = createModel();
     const commands = createCommands();
 
-    session.attachDialog(dialog as never, model as never, commands);
+    session.attachDialog(dialog as never, model as never, commands, null);
     session.enterPreviewMode('segment-2');
 
     expect(session.isPreviewingSegment()).toBe(true);
@@ -141,7 +141,7 @@ describe('StoryEditorSession', () => {
     const model = createModel();
     const commands = createCommands();
 
-    session.attachDialog(dialog as never, model as never, commands);
+    session.attachDialog(dialog as never, model as never, commands, null);
     session.enterPreviewMode('segment-3');
     session.clear();
 
@@ -156,7 +156,7 @@ describe('StoryEditorSession', () => {
     });
     const commands = createCommands();
 
-    session.attachDialog(dialog as never, model as never, commands);
+    session.attachDialog(dialog as never, model as never, commands, null);
     session.enterStoryPreviewMode();
 
     expect(session.isPreviewingStory()).toBe(true);
@@ -184,7 +184,7 @@ describe('StoryEditorSession', () => {
     });
     const commands = createCommands();
 
-    session.attachDialog(dialog as never, model as never, commands);
+    session.attachDialog(dialog as never, model as never, commands, null);
     session.enterStoryPreviewMode();
 
     expect(StoryMapInteractionBarWidget).toHaveBeenCalledWith(

--- a/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
+++ b/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
@@ -32,13 +32,14 @@ jest.mock('@/src/constants', () => ({
   },
 }));
 
-import { CommandIDs } from '@/src/constants';
 import { StoryEditorSession } from '../storyEditorSession';
 import { updateSegmentMapView } from '../utils/storySegmentMapView';
 import {
   applySegmentLayerOverrides,
   clearSegmentLayerOverrideEntries,
 } from '../utils/storySegmentOverrides';
+
+const TOGGLE_PANEL_COMMAND = 'jupytergis:togglePanel';
 
 function createDialog() {
   return {
@@ -97,7 +98,7 @@ describe('StoryEditorSession', () => {
     expect(session.isMapViewMode()).toBe(true);
     expect(model.centerOnPosition).toHaveBeenCalledWith('segment-1');
     expect(dialog.minimize).toHaveBeenCalled();
-    expect(commands.execute).toHaveBeenCalledWith(CommandIDs.togglePanel);
+    expect(commands.execute).toHaveBeenCalledWith(TOGGLE_PANEL_COMMAND);
 
     session.applyMapView();
 
@@ -121,7 +122,7 @@ describe('StoryEditorSession', () => {
       [],
     );
     expect(dialog.minimize).toHaveBeenCalled();
-    expect(commands.execute).toHaveBeenCalledWith(CommandIDs.togglePanel);
+    expect(commands.execute).toHaveBeenCalledWith(TOGGLE_PANEL_COMMAND);
 
     session.restoreEditor();
 

--- a/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
+++ b/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
@@ -28,6 +28,7 @@ jest.mock('@lumino/widgets', () => ({
 jest.mock('@/src/constants', () => ({
   CommandIDs: {
     togglePanel: 'jupytergis:togglePanel',
+    openStoryEditor: 'jupytergis:openStoryEditor',
   },
 }));
 
@@ -61,6 +62,7 @@ function createCommands() {
   return {
     execute: jest.fn(),
     isToggled: jest.fn(() => false),
+    notifyCommandChanged: jest.fn(),
   } as unknown as import('@lumino/commands').CommandRegistry;
 }
 
@@ -146,18 +148,21 @@ describe('StoryEditorSession', () => {
     const model = createModel({
       isStoryPreviewActive: jest.fn(() => true),
     });
+    const commands = createCommands();
 
-    session.attachDialog(dialog as never, model as never);
+    session.attachDialog(dialog as never, model as never, commands);
     session.enterStoryPreviewMode();
 
     expect(session.isPreviewingStory()).toBe(true);
     expect(model.setStoryPreviewActive).toHaveBeenCalledWith(true);
     expect(dialog.minimize).toHaveBeenCalled();
+    expect(commands.execute).not.toHaveBeenCalled();
 
     session.restoreEditor();
 
     expect(model.setStoryPreviewActive).toHaveBeenCalledWith(false);
     expect(dialog.restore).toHaveBeenCalled();
     expect(session.isMapInteractionMode()).toBe(false);
+    expect(commands.execute).not.toHaveBeenCalled();
   });
 });

--- a/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
+++ b/packages/base/src/features/story/__tests__/storyEditorSession.spec.ts
@@ -47,9 +47,13 @@ function createDialog() {
   };
 }
 
-function createModel() {
+function createModel(overrides: Record<string, unknown> = {}) {
   return {
     centerOnPosition: jest.fn(),
+    canUseStoryPreview: jest.fn(() => true),
+    isStoryPreviewActive: jest.fn(() => false),
+    setStoryPreviewActive: jest.fn(),
+    ...overrides,
   };
 }
 
@@ -135,5 +139,25 @@ describe('StoryEditorSession', () => {
 
     expect(clearSegmentLayerOverrideEntries).toHaveBeenCalledWith(model, []);
     expect(session.isActiveFor(model as never)).toBe(false);
+  });
+
+  it('enters story preview mode and restores the editor when preview ends', () => {
+    const dialog = createDialog();
+    const model = createModel({
+      isStoryPreviewActive: jest.fn(() => true),
+    });
+
+    session.attachDialog(dialog as never, model as never);
+    session.enterStoryPreviewMode();
+
+    expect(session.isPreviewingStory()).toBe(true);
+    expect(model.setStoryPreviewActive).toHaveBeenCalledWith(true);
+    expect(dialog.minimize).toHaveBeenCalled();
+
+    session.restoreEditor();
+
+    expect(model.setStoryPreviewActive).toHaveBeenCalledWith(false);
+    expect(dialog.restore).toHaveBeenCalled();
+    expect(session.isMapInteractionMode()).toBe(false);
   });
 });

--- a/packages/base/src/features/story/__tests__/storySegmentLayerOverrides.spec.ts
+++ b/packages/base/src/features/story/__tests__/storySegmentLayerOverrides.spec.ts
@@ -48,6 +48,22 @@ describe('storySegmentLayerOverrides', () => {
     ).toBe(false);
   });
 
+  it('ignores empty symbology overrides', () => {
+    expect(
+      isLayerOverrideChanged(targetLayer as never, {
+        targetLayer: 'layer-1',
+        symbologyState: {
+          layers: [
+            {
+              id: 'ec1ba238-0a8a-48fe-8540-60ae1d5f9d7f',
+              rules: [],
+            },
+          ],
+        },
+      } as never),
+    ).toBe(false);
+  });
+
   it('builds rows from the layer tree', () => {
     const model = {
       getLayerTree: () => ['layer-1'],

--- a/packages/base/src/features/story/__tests__/storySegmentLayerOverrides.spec.ts
+++ b/packages/base/src/features/story/__tests__/storySegmentLayerOverrides.spec.ts
@@ -50,17 +50,20 @@ describe('storySegmentLayerOverrides', () => {
 
   it('ignores empty symbology overrides', () => {
     expect(
-      isLayerOverrideChanged(targetLayer as never, {
-        targetLayer: 'layer-1',
-        symbologyState: {
-          layers: [
-            {
-              id: 'ec1ba238-0a8a-48fe-8540-60ae1d5f9d7f',
-              rules: [],
-            },
-          ],
-        },
-      } as never),
+      isLayerOverrideChanged(
+        targetLayer as never,
+        {
+          targetLayer: 'layer-1',
+          symbologyState: {
+            layers: [
+              {
+                id: 'ec1ba238-0a8a-48fe-8540-60ae1d5f9d7f',
+                rules: [],
+              },
+            ],
+          },
+        } as never,
+      ),
     ).toBe(false);
   });
 

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -1,8 +1,9 @@
 import { faGear } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import type { IJGISStoryMap } from '@jupytergis/schema';
+import type { IJGISStoryMap, IJupyterGISModel } from '@jupytergis/schema';
 import React, { useEffect, useState, type RefObject } from 'react';
 
+import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import { resolveStoryPresentationColorForInput } from '@/src/features/story/utils/spectaPresentation';
 import {
   formatGradientLabel,
@@ -26,6 +27,7 @@ import { Switch } from '@/src/shared/components/Switch';
 import { STORY_TYPE } from '@/src/types';
 
 export interface IStoryEditorHeaderBarProps {
+  model: IJupyterGISModel;
   story: IJGISStoryMap | null;
   segmentCount: number;
   onUpdateStory: (patch: Partial<IJGISStoryMap>) => void;
@@ -174,11 +176,14 @@ function StorySettingsPopover({
 }
 
 export function StoryEditorHeaderBar({
+  model,
   story,
   segmentCount,
   onUpdateStory,
   portalContainerRef,
 }: IStoryEditorHeaderBarProps): JSX.Element {
+  const canPreview = model.canUseStoryPreview();
+
   return (
     <div className="jgis-story-editor-context-bar">
       <StoryTitleInput
@@ -199,6 +204,18 @@ export function StoryEditorHeaderBar({
           <span className="jgis-story-editor-context-meta">
             {formatGradientLabel(story.showGradient)}
           </span>
+        ) : null}
+        {story && canPreview ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              StoryEditorSession.getInstance().enterStoryPreviewMode();
+            }}
+          >
+            Preview story
+          </Button>
         ) : null}
         {story && (
           <StorySettingsPopover

--- a/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
+++ b/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
@@ -10,8 +10,7 @@ export type StoryMapInteractionBarPlacement =
   | 'overlay-bottom'
   | 'main-top-left';
 
-export interface IStoryMapInteractionBarWidgetOptions
-  extends IStoryMapInteractionBarProps {
+export interface IStoryMapInteractionBarWidgetOptions extends IStoryMapInteractionBarProps {
   placement?: StoryMapInteractionBarPlacement;
 }
 

--- a/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
+++ b/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
@@ -6,13 +6,29 @@ import {
   type IStoryMapInteractionBarProps,
 } from './StoryMapInteractionBar';
 
+export type StoryMapInteractionBarPlacement =
+  | 'overlay-bottom'
+  | 'main-top-left';
+
+export interface IStoryMapInteractionBarWidgetOptions
+  extends IStoryMapInteractionBarProps {
+  placement?: StoryMapInteractionBarPlacement;
+}
+
 export class StoryMapInteractionBarWidget extends ReactWidget {
-  constructor(private readonly _props: IStoryMapInteractionBarProps) {
+  private readonly _barProps: IStoryMapInteractionBarProps;
+
+  constructor(options: IStoryMapInteractionBarWidgetOptions) {
+    const { placement = 'overlay-bottom', ...barProps } = options;
     super();
+    this._barProps = barProps;
     this.addClass('jgis-story-map-interaction-bar-root');
+    if (placement === 'main-top-left') {
+      this.addClass('jgis-story-map-interaction-bar-root--main-top-left');
+    }
   }
 
   render(): JSX.Element {
-    return <StoryMapInteractionBar {...this._props} />;
+    return <StoryMapInteractionBar {...this._barProps} />;
   }
 }

--- a/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
+++ b/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
@@ -1,11 +1,11 @@
 import { ReactWidget } from '@jupyterlab/apputils';
 import React from 'react';
 
-import type { StoryMapInteractionBarPlacement } from '../types/types';
 import {
   StoryMapInteractionBar,
   type IStoryMapInteractionBarProps,
 } from '@/src/features/story/components/StoryMapInteractionBar';
+import type { StoryMapInteractionBarPlacement } from '../types/types';
 
 interface IStoryMapInteractionBarWidgetOptions extends IStoryMapInteractionBarProps {
   placement?: StoryMapInteractionBarPlacement;

--- a/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
+++ b/packages/base/src/features/story/components/StoryMapInteractionBarWidget.tsx
@@ -1,16 +1,13 @@
 import { ReactWidget } from '@jupyterlab/apputils';
 import React from 'react';
 
+import type { StoryMapInteractionBarPlacement } from '../types/types';
 import {
   StoryMapInteractionBar,
   type IStoryMapInteractionBarProps,
-} from './StoryMapInteractionBar';
+} from '@/src/features/story/components/StoryMapInteractionBar';
 
-export type StoryMapInteractionBarPlacement =
-  | 'overlay-bottom'
-  | 'main-top-left';
-
-export interface IStoryMapInteractionBarWidgetOptions extends IStoryMapInteractionBarProps {
+interface IStoryMapInteractionBarWidgetOptions extends IStoryMapInteractionBarProps {
   placement?: StoryMapInteractionBarPlacement;
 }
 

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -9,12 +9,12 @@ import {
   MapPreviewBarActions,
   MapViewBarActions,
 } from './components/MapInteractionBarActions';
-import {
-  StoryMapInteractionBarWidget,
-} from './components/StoryMapInteractionBarWidget';
-import type { StoryMapInteractionBarPlacement } from './types/types';
+import { StoryMapInteractionBarWidget } from './components/StoryMapInteractionBarWidget';
 import type { StoryEditorWidget } from './storyEditorDialog';
-import type { IOverrideLayerEntry } from './types/types';
+import type {
+  IOverrideLayerEntry,
+  StoryMapInteractionBarPlacement,
+} from './types/types';
 import { updateSegmentMapView } from './utils/storySegmentMapView';
 import {
   applySegmentLayerOverrides,

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -126,32 +126,6 @@ export class StoryEditorSession {
     this._notifyPreviewChanged();
   }
 
-  public toggleStoryPreview(model: IJupyterGISModel): void {
-    if (!model.canUseStoryPreview()) {
-      return;
-    }
-
-    const editorAttached = this._dialog !== null && this._model === model;
-
-    if (model.isStoryPreviewActive()) {
-      if (editorAttached && this.isPreviewingStory()) {
-        this.restoreEditor();
-      } else {
-        model.setStoryPreviewActive(false);
-        this._notifyPreviewChanged();
-      }
-      return;
-    }
-
-    if (editorAttached) {
-      this.enterStoryPreviewMode();
-      return;
-    }
-
-    model.setStoryPreviewActive(true);
-    this._notifyPreviewChanged();
-  }
-
   public applyMapView(): void {
     if (!this._model || !this._mapViewSegmentId) {
       return;

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -36,6 +36,7 @@ export class StoryEditorSession {
   private _mapInteractionMode: StoryEditorMapInteractionMode | null = null;
   private _mapBar: StoryMapInteractionBarWidget | null = null;
   private _overrideEntries: IOverrideLayerEntry[] = [];
+  private _mainViewContainer: HTMLElement | null = null;
 
   public static getInstance(): StoryEditorSession {
     if (!StoryEditorSession.instance) {
@@ -48,10 +49,12 @@ export class StoryEditorSession {
     dialog: StoryEditorWidget,
     model: IJupyterGISModel,
     commands: CommandRegistry,
+    mainViewContainer: HTMLElement | null,
   ): void {
     this._dialog = dialog;
     this._model = model;
     this._commands = commands;
+    this._mainViewContainer = mainViewContainer;
     this._mapInteractionMode = null;
   }
 
@@ -182,6 +185,7 @@ export class StoryEditorSession {
     this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
     this._overrideEntries = [];
+    this._mainViewContainer = null;
   }
 
   private _notifyPreviewChanged(): void {
@@ -253,12 +257,11 @@ export class StoryEditorSession {
   private _resolveMapBarParent(
     placement: StoryMapInteractionBarPlacement,
   ): HTMLElement {
-    const mapBarParent =
-      placement === 'main-top-left'
-        ? document.querySelector<HTMLElement>('.jGIS-Mainview-Container')
-        : null;
+    if (placement === 'main-top-left' && this._mainViewContainer) {
+      return this._mainViewContainer;
+    }
 
-    return mapBarParent ?? document.body;
+    return document.body;
   }
 
   private _hideMapBar(): void {

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -24,7 +24,6 @@ type StoryEditorMapInteractionMode =
 
 export class StoryEditorSession {
   private static instance: StoryEditorSession;
-  private static _previewChangeNotifier: (() => void) | null = null;
 
   private _dialog: StoryEditorWidget | null = null;
   private _model: IJupyterGISModel | null = null;
@@ -33,10 +32,6 @@ export class StoryEditorSession {
   private _mapInteractionMode: StoryEditorMapInteractionMode | null = null;
   private _mapBar: StoryMapInteractionBarWidget | null = null;
   private _overrideEntries: IOverrideLayerEntry[] = [];
-
-  public static setPreviewChangeNotifier(notifier: (() => void) | null): void {
-    StoryEditorSession._previewChangeNotifier = notifier;
-  }
 
   public static getInstance(): StoryEditorSession {
     if (!StoryEditorSession.instance) {
@@ -200,7 +195,7 @@ export class StoryEditorSession {
   }
 
   private _notifyPreviewChanged(): void {
-    StoryEditorSession._previewChangeNotifier?.();
+    this._commands?.notifyCommandChanged(CommandIDs.openStoryEditor);
   }
 
   private _exitCurrentMapInteractionMode(): void {

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -17,10 +17,14 @@ import {
   clearSegmentLayerOverrideEntries,
 } from './utils/storySegmentOverrides';
 
-type StoryEditorMapInteractionMode = 'map-view' | 'previewing-segment';
+type StoryEditorMapInteractionMode =
+  | 'map-view'
+  | 'previewing-segment'
+  | 'previewing-story';
 
 export class StoryEditorSession {
   private static instance: StoryEditorSession;
+  private static _previewChangeNotifier: (() => void) | null = null;
 
   private _dialog: StoryEditorWidget | null = null;
   private _model: IJupyterGISModel | null = null;
@@ -29,6 +33,10 @@ export class StoryEditorSession {
   private _mapInteractionMode: StoryEditorMapInteractionMode | null = null;
   private _mapBar: StoryMapInteractionBarWidget | null = null;
   private _overrideEntries: IOverrideLayerEntry[] = [];
+
+  public static setPreviewChangeNotifier(notifier: (() => void) | null): void {
+    StoryEditorSession._previewChangeNotifier = notifier;
+  }
 
   public static getInstance(): StoryEditorSession {
     if (!StoryEditorSession.instance) {
@@ -58,6 +66,10 @@ export class StoryEditorSession {
 
   public isPreviewingSegment(): boolean {
     return this._mapInteractionMode === 'previewing-segment';
+  }
+
+  public isPreviewingStory(): boolean {
+    return this._mapInteractionMode === 'previewing-story';
   }
 
   public isMapInteractionMode(): boolean {
@@ -107,6 +119,44 @@ export class StoryEditorSession {
     );
   }
 
+  public enterStoryPreviewMode(): void {
+    if (!this._dialog || !this._model || !this._model.canUseStoryPreview()) {
+      return;
+    }
+
+    this._clearSegmentInteractionState();
+    this._mapInteractionMode = 'previewing-story';
+    this._model.setStoryPreviewActive(true);
+    this._dialog.minimize();
+    this._notifyPreviewChanged();
+  }
+
+  public toggleStoryPreview(model: IJupyterGISModel): void {
+    if (!model.canUseStoryPreview()) {
+      return;
+    }
+
+    const editorAttached = this._dialog !== null && this._model === model;
+
+    if (model.isStoryPreviewActive()) {
+      if (editorAttached && this.isPreviewingStory()) {
+        this.restoreEditor();
+      } else {
+        model.setStoryPreviewActive(false);
+        this._notifyPreviewChanged();
+      }
+      return;
+    }
+
+    if (editorAttached) {
+      this.enterStoryPreviewMode();
+      return;
+    }
+
+    model.setStoryPreviewActive(true);
+    this._notifyPreviewChanged();
+  }
+
   public applyMapView(): void {
     if (!this._model || !this._mapViewSegmentId) {
       return;
@@ -117,10 +167,6 @@ export class StoryEditorSession {
   }
 
   public restoreEditor(): void {
-    if (this.isPreviewingSegment() && this._model) {
-      clearSegmentLayerOverrideEntries(this._model, this._overrideEntries);
-    }
-
     this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
     this._togglePanels();
@@ -134,8 +180,15 @@ export class StoryEditorSession {
   }
 
   public clear(): void {
-    if (this.isPreviewingSegment() && this._model) {
-      clearSegmentLayerOverrideEntries(this._model, this._overrideEntries);
+    if (this._model) {
+      this._clearSegmentInteractionState();
+      if (
+        this._mapInteractionMode === 'previewing-story' ||
+        this._model.isStoryPreviewActive()
+      ) {
+        this._model.setStoryPreviewActive(false);
+        this._notifyPreviewChanged();
+      }
     }
 
     this._disposeMapBar();
@@ -145,7 +198,23 @@ export class StoryEditorSession {
     this._commands = null;
     this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
+    this._mapViewSegmentId = null;
+    this._mapInteractionMode = null;
     this._overrideEntries = [];
+  }
+
+  private _notifyPreviewChanged(): void {
+    StoryEditorSession._previewChangeNotifier?.();
+  }
+
+  private _clearSegmentInteractionState(): void {
+    if (this._mapInteractionMode === 'previewing-segment' && this._model) {
+      clearSegmentLayerOverrideEntries(this._model, this._overrideEntries);
+    }
+
+    this._pickingSegmentId = null;
+    this._previewSegmentId = null;
+    this._mapInteractionMode = null;
   }
 
   private _focusSegmentOnMap(segmentId: string): void {

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -124,7 +124,7 @@ export class StoryEditorSession {
       return;
     }
 
-    this._clearSegmentInteractionState();
+    this._clearMapInteractionState();
     this._mapInteractionMode = 'previewing-story';
     this._model.setStoryPreviewActive(true);
     this._dialog.minimize();
@@ -167,6 +167,7 @@ export class StoryEditorSession {
   }
 
   public restoreEditor(): void {
+    this._exitCurrentMapInteractionMode();
     this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
     this._togglePanels();
@@ -181,11 +182,8 @@ export class StoryEditorSession {
 
   public clear(): void {
     if (this._model) {
-      this._clearSegmentInteractionState();
-      if (
-        this._mapInteractionMode === 'previewing-story' ||
-        this._model.isStoryPreviewActive()
-      ) {
+      this._exitCurrentMapInteractionMode();
+      if (this._model.isStoryPreviewActive()) {
         this._model.setStoryPreviewActive(false);
         this._notifyPreviewChanged();
       }
@@ -198,8 +196,6 @@ export class StoryEditorSession {
     this._commands = null;
     this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
-    this._mapViewSegmentId = null;
-    this._mapInteractionMode = null;
     this._overrideEntries = [];
   }
 
@@ -207,14 +203,30 @@ export class StoryEditorSession {
     StoryEditorSession._previewChangeNotifier?.();
   }
 
-  private _clearSegmentInteractionState(): void {
-    if (this._mapInteractionMode === 'previewing-segment' && this._model) {
-      clearSegmentLayerOverrideEntries(this._model, this._overrideEntries);
+  private _exitCurrentMapInteractionMode(): void {
+    if (!this._model) {
+      return;
     }
 
-    this._pickingSegmentId = null;
-    this._previewSegmentId = null;
+    switch (this._mapInteractionMode) {
+      case 'previewing-segment':
+        clearSegmentLayerOverrideEntries(this._model, this._overrideEntries);
+        break;
+      case 'previewing-story':
+        this._model.setStoryPreviewActive(false);
+        this._notifyPreviewChanged();
+        break;
+      case 'map-view':
+      case null:
+        break;
+    }
+  }
+
+  private _clearMapInteractionState(): void {
+    this._exitCurrentMapInteractionMode();
+    this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
+    this._hideMapBar();
   }
 
   private _focusSegmentOnMap(segmentId: string): void {

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -11,8 +11,8 @@ import {
 } from './components/MapInteractionBarActions';
 import {
   StoryMapInteractionBarWidget,
-  type StoryMapInteractionBarPlacement,
 } from './components/StoryMapInteractionBarWidget';
+import type { StoryMapInteractionBarPlacement } from './types/types';
 import type { StoryEditorWidget } from './storyEditorDialog';
 import type { IOverrideLayerEntry } from './types/types';
 import { updateSegmentMapView } from './utils/storySegmentMapView';

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -162,10 +162,16 @@ export class StoryEditorSession {
   }
 
   public restoreEditor(): void {
+    const previousMode = this._mapInteractionMode;
     this._exitCurrentMapInteractionMode();
     this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
-    this._togglePanels();
+    if (
+      previousMode === 'map-view' ||
+      previousMode === 'previewing-segment'
+    ) {
+      this._togglePanels();
+    }
     this._hideMapBar();
     this._dialog?.restore();
   }

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -4,11 +4,15 @@ import { Widget } from '@lumino/widgets';
 import React from 'react';
 
 import { CommandIDs } from '@/src/constants';
+import { STORY_TYPE } from '@/src/types';
 import {
   MapPreviewBarActions,
   MapViewBarActions,
 } from './components/MapInteractionBarActions';
-import { StoryMapInteractionBarWidget } from './components/StoryMapInteractionBarWidget';
+import {
+  StoryMapInteractionBarWidget,
+  type StoryMapInteractionBarPlacement,
+} from './components/StoryMapInteractionBarWidget';
 import type { StoryEditorWidget } from './storyEditorDialog';
 import type { IOverrideLayerEntry } from './types/types';
 import { updateSegmentMapView } from './utils/storySegmentMapView';
@@ -124,6 +128,15 @@ export class StoryEditorSession {
     this._model.setStoryPreviewActive(true);
     this._dialog.minimize();
     this._notifyPreviewChanged();
+    this._showMapBar(
+      'Previewing the story.',
+      React.createElement(MapPreviewBarActions, {
+        onBack: () => {
+          this.restoreEditor();
+        },
+      }),
+      this._getStoryPreviewBarPlacement(),
+    );
   }
 
   public applyMapView(): void {
@@ -140,10 +153,7 @@ export class StoryEditorSession {
     this._exitCurrentMapInteractionMode();
     this._mapViewSegmentId = null;
     this._mapInteractionMode = null;
-    if (
-      previousMode === 'map-view' ||
-      previousMode === 'previewing-segment'
-    ) {
+    if (previousMode === 'map-view' || previousMode === 'previewing-segment') {
       this._togglePanels();
     }
     this._hideMapBar();
@@ -216,11 +226,39 @@ export class StoryEditorSession {
     void this._commands.execute(CommandIDs.togglePanel);
   }
 
-  private _showMapBar(message: string, children: React.ReactNode): void {
+  private _showMapBar(
+    message: string,
+    children: React.ReactNode,
+    placement: StoryMapInteractionBarPlacement = 'overlay-bottom',
+  ): void {
     this._disposeMapBar();
-    this._mapBar = new StoryMapInteractionBarWidget({ message, children });
-    Widget.attach(this._mapBar, document.body);
+    this._mapBar = new StoryMapInteractionBarWidget({
+      message,
+      children,
+      placement,
+    });
+    Widget.attach(this._mapBar, this._resolveMapBarParent(placement));
     this._mapBar.show();
+  }
+
+  private _getStoryPreviewBarPlacement(): StoryMapInteractionBarPlacement {
+    const storyType = this._model?.getSelectedStory().story?.storyType;
+    if (storyType === STORY_TYPE.guided) {
+      return 'main-top-left';
+    }
+
+    return 'overlay-bottom';
+  }
+
+  private _resolveMapBarParent(
+    placement: StoryMapInteractionBarPlacement,
+  ): HTMLElement {
+    const mapBarParent =
+      placement === 'main-top-left'
+        ? document.querySelector<HTMLElement>('.jGIS-Mainview-Container')
+        : null;
+
+    return mapBarParent ?? document.body;
   }
 
   private _hideMapBar(): void {

--- a/packages/base/src/features/story/types/types.ts
+++ b/packages/base/src/features/story/types/types.ts
@@ -2,6 +2,10 @@ import type { IStorySegmentLayer } from '@jupytergis/schema';
 
 export type StorySegmentDisplayMode = 'map' | 'markdown';
 
+export type StoryMapInteractionBarPlacement =
+  | 'overlay-bottom'
+  | 'main-top-left';
+
 export interface IOverrideLayerEntry {
   layerId: string;
   action: 'remove' | 'restore';

--- a/packages/base/src/features/story/utils/storySegmentLayerOverrides.ts
+++ b/packages/base/src/features/story/utils/storySegmentLayerOverrides.ts
@@ -96,6 +96,10 @@ function hasStyleOverrideFieldsForLayer(
     return true;
   }
 
+  if (shouldPersistSymbologyOverride(layer, override.symbologyState)) {
+    return true;
+  }
+
   if (override.color && Object.keys(override.color).length > 0) {
     return true;
   }
@@ -172,7 +176,6 @@ function upsertLayerOverride(
   const index = overrides.findIndex(
     entry => entry.targetLayer === targetLayerId,
   );
-
   const draft =
     index >= 0
       ? mutate({ ...overrides[index] })

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -327,6 +327,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this._model.settingsChanged.connect(this._onSettingsChanged, this);
     this._model.updateLayerSignal.connect(this._triggerLayerUpdate, this);
     this._model.addFeatureAsMsSignal.connect(this._convertFeatureToMs, this);
+    this._model.storyPreviewActiveChanged.connect(
+      this._onStoryPreviewActiveChanged,
+      this,
+    );
 
     // After a user signs in to an OpenEO server, rebuild any of this
     // document's OpenEO tile sources whose serverUrl matches — they
@@ -369,7 +373,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       editingVectorLayer: false,
       drawGeometryLabel: '',
       jgisSettings: this._model.jgisSettings,
-      isSpectaPresentation: this._model.isSpectaMode(),
+      isSpectaPresentation: this._model.isStoryPresentationActive(),
       initialLayersReady: false,
       identifyFeatureFloatersVersion: 0,
       segmentTransition: null,
@@ -405,19 +409,33 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this._handleTemporalControllerActiveChanged();
     this._handleSelectedChanged();
     this._mainViewModel.initSignal();
+    if (
+      this.state.isSpectaPresentation &&
+      this._model.isSpectaMode() &&
+      !this._spectaModeSetupDone
+    ) {
+      this._setupSpectaMode();
+      this._spectaModeSetupDone = true;
+    }
     if (window.jupytergisMaps !== undefined && this._documentPath) {
       window.jupytergisMaps[this._documentPath] = this._Map;
     }
   }
 
   componentDidUpdate(prevProps: IMainViewProps, prevState: IStates): void {
-    // Run setup when isSpectaPresentation changes from false/undefined to true
-    if (
-      this.state.isSpectaPresentation &&
-      !this._isSpectaPresentationInitialized
-    ) {
+    const enteredPresentation =
+      !prevState.isSpectaPresentation && this.state.isSpectaPresentation;
+    const exitedPresentation =
+      prevState.isSpectaPresentation && !this.state.isSpectaPresentation;
+
+    if (enteredPresentation && this._model.isSpectaMode()) {
       this._setupSpectaMode();
-      this._isSpectaPresentationInitialized = true;
+      this._spectaModeSetupDone = true;
+    }
+
+    if (exitedPresentation && this._spectaModeSetupDone) {
+      this._teardownSpectaMode();
+      this._spectaModeSetupDone = false;
     }
   }
 
@@ -458,6 +476,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this._model.selectedChanged.disconnect(this._handleSelectedChanged, this);
     this._model.identifiedFeaturesChanged.disconnect(
       this._handleIdentifiedFeaturesChanged,
+      this,
+    );
+    this._model.storyPreviewActiveChanged.disconnect(
+      this._onStoryPreviewActiveChanged,
       this,
     );
     // Clean up story scroll listener
@@ -2509,24 +2531,22 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this.setState(old => ({ ...old, clientPointers }));
   }
 
+  private _onStoryPreviewActiveChanged = (): void => {
+    this.setState({
+      isSpectaPresentation: this._model.isStoryPresentationActive(),
+    });
+  };
+
   private _onSharedOptionsChanged(): void {
     if (!this._Map) {
       return;
     }
 
-    // ! would prefer a model ready signal or something, this feels hacky
-    const enableSpectaPresentation = this._model.isSpectaMode();
-
-    // Handle initialization based on specta presentation state
-    if (!this._isSpectaPresentationInitialized) {
-      if (enableSpectaPresentation) {
-        // _setupSpectaMode will be called in componentDidUpdate when state changes
-        this.setState(old => ({ ...old, isSpectaPresentation: true }));
-      } else {
-        // Add context menu when not in specta mode
+    if (!this._contextMenuAttached) {
+      if (!this._model.isSpectaMode()) {
         this.addContextMenu();
-        this._isSpectaPresentationInitialized = true;
       }
+      this._contextMenuAttached = true;
     }
 
     if (!this._isPositionInitialized) {
@@ -3026,6 +3046,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       }
       this._storyScrollHandler = null;
     }
+  };
+
+  private _teardownSpectaMode = (): void => {
+    this._cleanupStoryScrollListener();
   };
 
   private _onSharedMetadataChanged = (
@@ -4061,7 +4085,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   }
 
   private _featurePropertyCache: Map<string | number, any> = new Map();
-  private _isSpectaPresentationInitialized = false;
+  private _contextMenuAttached = false;
+  private _spectaModeSetupDone = false;
   private _storyScrollHandler: ((e: Event) => void) | null = null;
   private _clearStoryScrollGuard: () => void;
   private _pendingStoryScrollRafId: number | null = null;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -409,11 +409,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this._handleTemporalControllerActiveChanged();
     this._handleSelectedChanged();
     this._mainViewModel.initSignal();
-    if (
-      this.state.isSpectaPresentation &&
-      this._model.isSpectaMode() &&
-      !this._spectaModeSetupDone
-    ) {
+    if (this.state.isSpectaPresentation && !this._spectaModeSetupDone) {
       this._setupSpectaMode();
       this._spectaModeSetupDone = true;
     }
@@ -428,7 +424,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     const exitedPresentation =
       prevState.isSpectaPresentation && !this.state.isSpectaPresentation;
 
-    if (enteredPresentation && this._model.isSpectaMode()) {
+    if (enteredPresentation && !this._spectaModeSetupDone) {
       this._setupSpectaMode();
       this._spectaModeSetupDone = true;
     }
@@ -2874,6 +2870,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
    * Updates specta state and presentation colors when story data becomes available.
    */
   private _setupSpectaMode = (): void => {
+    this._cleanupStoryScrollListener();
     this._removeAllInteractions();
     this._setupStoryScrollListener();
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -84,6 +84,7 @@ import {
   DoubleClickZoom,
   Select,
 } from 'ol/interaction';
+import type Interaction from 'ol/interaction/Interaction';
 import Draw, { DrawEvent } from 'ol/interaction/Draw';
 import Modify from 'ol/interaction/Modify';
 import Snap from 'ol/interaction/Snap';
@@ -2881,6 +2882,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   };
 
   private _removeAllInteractions = (): void => {
+    if (!this._Map) {
+      return;
+    }
+
     // Remove all default interactions
     const interactions = this._Map.getInteractions();
     const interactionArray = interactions.getArray();
@@ -2900,16 +2905,40 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       Select,
     ];
 
-    this._zoomControl && this._Map.removeControl(this._zoomControl);
+    this._spectaRemovedInteractions = [];
 
     interactionsToRemove.forEach(InteractionClass => {
       const interaction = interactionArray.find(
         interaction => interaction instanceof InteractionClass,
       );
       if (interaction) {
+        this._spectaRemovedInteractions.push(interaction);
         this._Map.removeInteraction(interaction);
       }
     });
+
+    if (this._zoomControl) {
+      this._spectaZoomControlWasRemoved = true;
+      this._Map.removeControl(this._zoomControl);
+    } else {
+      this._spectaZoomControlWasRemoved = false;
+    }
+  };
+
+  private _restoreMapInteractions = (): void => {
+    if (!this._Map) {
+      return;
+    }
+
+    for (const interaction of this._spectaRemovedInteractions) {
+      this._Map.addInteraction(interaction);
+    }
+    this._spectaRemovedInteractions = [];
+
+    if (this._spectaZoomControlWasRemoved && this._zoomControl) {
+      this._Map.addControl(this._zoomControl);
+      this._spectaZoomControlWasRemoved = false;
+    }
   };
 
   private _setupStoryScrollListener = (): void => {
@@ -3047,6 +3076,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
   private _teardownSpectaMode = (): void => {
     this._cleanupStoryScrollListener();
+    this._restoreMapInteractions();
   };
 
   private _onSharedMetadataChanged = (
@@ -4084,6 +4114,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _featurePropertyCache: Map<string | number, any> = new Map();
   private _contextMenuAttached = false;
   private _spectaModeSetupDone = false;
+  private _spectaRemovedInteractions: Interaction[] = [];
+  private _spectaZoomControlWasRemoved = false;
   private _storyScrollHandler: ((e: Event) => void) | null = null;
   private _clearStoryScrollGuard: () => void;
   private _pendingStoryScrollRafId: number | null = null;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -84,8 +84,8 @@ import {
   DoubleClickZoom,
   Select,
 } from 'ol/interaction';
-import type Interaction from 'ol/interaction/Interaction';
 import Draw, { DrawEvent } from 'ol/interaction/Draw';
+import type Interaction from 'ol/interaction/Interaction';
 import Modify from 'ol/interaction/Modify';
 import Snap from 'ol/interaction/Snap';
 import {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -3052,8 +3052,9 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     };
 
     this._storyScrollHandler = handleScroll;
-    const container = document.querySelector('.jGIS-Mainview-Container');
+    const container = this.props.containerRef?.current;
     if (container) {
+      this._storyScrollContainerEl = container;
       container.addEventListener('wheel', handleScroll, { passive: false });
     }
   };
@@ -3063,14 +3064,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       cancelAnimationFrame(this._pendingStoryScrollRafId);
       this._pendingStoryScrollRafId = null;
     }
-    if (this._storyScrollHandler) {
-      const containerElement = document.querySelector(
-        '.jGIS-Mainview-Container',
+    if (this._storyScrollHandler && this._storyScrollContainerEl) {
+      this._storyScrollContainerEl.removeEventListener(
+        'wheel',
+        this._storyScrollHandler,
       );
-      if (containerElement) {
-        containerElement.removeEventListener('wheel', this._storyScrollHandler);
-      }
       this._storyScrollHandler = null;
+      this._storyScrollContainerEl = null;
     }
   };
 
@@ -4117,6 +4117,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _spectaRemovedInteractions: Interaction[] = [];
   private _spectaZoomControlWasRemoved = false;
   private _storyScrollHandler: ((e: Event) => void) | null = null;
+  private _storyScrollContainerEl: HTMLDivElement | null = null;
   private _clearStoryScrollGuard: () => void;
   private _pendingStoryScrollRafId: number | null = null;
   private _initialLayersCount: number;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2539,10 +2539,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return;
     }
 
-    if (!this._contextMenuAttached) {
-      if (!this._model.isSpectaMode()) {
-        this.addContextMenu();
-      }
+    if (!this._contextMenuAttached && !this._model.isSpectaMode()) {
+      this.addContextMenu();
       this._contextMenuAttached = true;
     }
 

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -492,6 +492,21 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   pointer-events: auto;
 }
 
+.jgis-story-map-interaction-bar-root--main-top-left {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  bottom: auto;
+  transform: none;
+  z-index: 50;
+}
+
+.jGIS-Mainview-Container:has(
+  .jgis-story-map-interaction-bar-root--main-top-left
+) {
+  position: relative;
+}
+
 .jgis-story-map-interaction-bar {
   display: flex;
   align-items: center;

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -36,7 +36,7 @@ export const DEFAULT_JGIS_DOCUMENT_CONTENT = `{
 	"sources": {},
   "stories": {},
   "viewState": {},
-	"options": {"latitude": 0, "longitude": 0, "zoom": 0, "bearing": 0, "pitch": 0, "projection": "${DEFAULT_PROJECTION}", "storyMapPresentationMode": false},
+	"options": {"latitude": 0, "longitude": 0, "zoom": 0, "bearing": 0, "pitch": 0, "projection": "${DEFAULT_PROJECTION}"},
 	"layerTree": [],
 	"metadata": {}
 }`;

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -422,6 +422,11 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   createStorySegmentFromLayer(layerId: string): IStorySegmentRef | null;
   segmentAdded: ISignal<IJupyterGISModel, IStorySegmentRef>;
   isSpectaMode(): boolean;
+  isStoryPreviewActive(): boolean;
+  isStoryPresentationActive(): boolean;
+  canUseStoryPreview(): boolean;
+  setStoryPreviewActive(active: boolean): void;
+  storyPreviewActiveChanged: ISignal<IJupyterGISModel, boolean>;
 
   setUIState(value: Partial<IJGISUIState>): void;
   getUIState(): IJGISUIState;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -741,7 +741,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   /**
-   * Whether the story viewer presentation UI should be shown (Specta embed or
+   * Whether the story viewer presentation UI should be shown (Specta or
    * in-lab preview).
    */
   isStoryPresentationActive(): boolean {

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -783,9 +783,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   private _isStoryTypeSupportedForPresentation(
     storyType: IJGISStoryMap['storyType'] | undefined,
   ): boolean {
-    return (
-      storyType !== undefined && SPECTA_STORY_TYPES.includes(storyType)
-    );
+    return storyType !== undefined && SPECTA_STORY_TYPES.includes(storyType);
   }
 
   /**

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -367,6 +367,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   dispose(): void {
+    this._storyPreviewActive = false;
     if (this._isDisposed) {
       return;
     }
@@ -730,6 +731,61 @@ export class JupyterGISModel implements IJupyterGISModel {
       storyType !== undefined && SPECTA_STORY_TYPES.includes(storyType);
 
     return isSpecta && hasStories && isModeForSpecta;
+  }
+
+  /**
+   * Whether the in-lab story presentation preview is active (session-only).
+   */
+  isStoryPreviewActive(): boolean {
+    return this._storyPreviewActive;
+  }
+
+  /**
+   * Whether the story viewer presentation UI should be shown (Specta embed or
+   * in-lab preview).
+   */
+  isStoryPresentationActive(): boolean {
+    return this.isSpectaMode() || this._storyPreviewActive;
+  }
+
+  /**
+   * Whether the current story supports presentation preview.
+   */
+  canUseStoryPreview(): boolean {
+    const storySegments = this.getSelectedStory().story?.storySegments;
+    return (
+      !this.jgisSettings.storyMapsDisabled &&
+      !!storySegments &&
+      storySegments.length >= 1 &&
+      this._isStoryTypeSupportedForPresentation(
+        this.getSelectedStory().story?.storyType,
+      )
+    );
+  }
+
+  setStoryPreviewActive(active: boolean): void {
+    if (active && !this.canUseStoryPreview()) {
+      return;
+    }
+
+    if (this._storyPreviewActive === active) {
+      return;
+    }
+
+    this._storyPreviewActive = active;
+    this._storyPreviewActiveChanged.emit(active);
+  }
+
+  get storyPreviewActiveChanged(): ISignal<this, boolean> {
+    return this._storyPreviewActiveChanged;
+  }
+
+  private _isStoryTypeSupportedForPresentation(
+    storyType: IJGISStoryMap['storyType'] | undefined,
+  ): boolean {
+    return (
+      storyType !== undefined && SPECTA_STORY_TYPES.includes(storyType)
+    );
   }
 
   /**
@@ -1394,6 +1450,8 @@ export class JupyterGISModel implements IJupyterGISModel {
   private _tileFeatureCache: Map<string, Set<FeatureLike>> = new Map();
   private _currentSegmentIndex: number;
   private _currentSegmentIndexChanged = new Signal<this, number>(this);
+  private _storyPreviewActive = false;
+  private _storyPreviewActiveChanged = new Signal<this, boolean>(this);
   stories: Map<string, IJGISStoryMap> = new Map();
 
   private _localUIState: Partial<IJGISUIState> = {};

--- a/packages/schema/src/schema/project/jgis.json
+++ b/packages/schema/src/schema/project/jgis.json
@@ -278,11 +278,6 @@
         "useExtent": {
           "type": "boolean",
           "default": false
-        },
-        "storyMapPresentationMode": {
-          "type": "boolean",
-          "title": "Whether presentation mode is active",
-          "default": false
         }
       }
     },

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -136,7 +136,6 @@ class GISDocument(CommWidget):
                 "bearing": 0,
                 "pitch": 0,
                 "projection": "EPSG:3857",
-                "storyMapPresentationMode": False,
             },
         )
         self.ydoc["layerTree"] = self._layerTree = Array()


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Adds in-lab story previews accessible from the editor. 

https://github.com/user-attachments/assets/474eed43-18bf-4929-a8e0-725a473fb2ea


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1557.org.readthedocs.build/en/1557/
💡 JupyterLite preview: https://jupytergis--1557.org.readthedocs.build/en/1557/lite
💡 Specta preview: https://jupytergis--1557.org.readthedocs.build/en/1557/lite/specta

<!-- readthedocs-preview jupytergis end -->