### PR TITLE
Remove `hex_to_rgba` python function

### DIFF
--- a/python/jupytergis_core/jupytergis_core/colors.py
+++ b/python/jupytergis_core/jupytergis_core/colors.py
@@ -16,23 +16,6 @@ import webcolors
 RGBA = tuple[float, float, float, float]
 
 
-def hex_to_rgba(hex_color: str) -> tuple[int, int, int, float]:
-    """Convert a CSS hex string (``#rgb``, ``#rrggbb``, ``#rrggbbaa``) to an
-    ``(r, g, b, a)`` tuple with r/g/b in 0-255 and a in 0-1.
-
-    :raises ValueError: if the input is not a supported hex length.
-    """
-    s = hex_color.lstrip("#")
-    if len(s) == 3:
-        r, g, b = (int(c * 2, 16) for c in s)
-        return r, g, b, 1.0
-    if len(s) == 6:
-        r, g, b = (int(s[i : i + 2], 16) for i in (0, 2, 4))
-        return r, g, b, 1.0
-    if len(s) == 8:
-        r, g, b, a = (int(s[i : i + 2], 16) for i in (0, 2, 4, 6))
-        return r, g, b, a / 255
-    raise ValueError(f"Invalid hex color: {hex_color}")
 
 
 def rgb_to_hex(rgb_str: str) -> str:

--- a/python/jupytergis_core/jupytergis_core/tests/test_colors.py
+++ b/python/jupytergis_core/jupytergis_core/tests/test_colors.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jupytergis_core.colors import coerce_rgba
+from jupytergis_core.colors import coerce_rgba, rgb_to_hex
 
 
 @pytest.mark.parametrize(
@@ -18,3 +18,15 @@ def test_colors(input, output):
 def test_invalid_color():
     with pytest.raises(ValueError, match="Invalid color"):
         coerce_rgba("blabla")
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        pytest.param("255,0,0", "#ff0000", id="red"),
+        pytest.param("0,255,0,255", "#00ff00", id="green_with_alpha"),
+        pytest.param("0,0,255,128", "#0000ff", id="blue_with_alpha"),
+    ],
+)
+def test_rgb_to_hex(input, output):
+    assert rgb_to_hex(input) == output

--- a/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/qgis_loader.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote
 from uuid import uuid4
 
 from jupytergis_core.color_ramps import sample_colors
-from jupytergis_core.colors import hex_to_rgba, rgb_to_hex
+from jupytergis_core.colors import coerce_rgba, rgb_to_hex
 from PyQt5.QtGui import QColor
 from qgis.core import (  # type: ignore[import-untyped]
     Qgis,
@@ -205,7 +205,7 @@ def qgis_layer_to_jgis(
                     .properties()
                     .get("outline_color", "0,0,0,255")
                 )
-                stroke_rgba = hex_to_rgba(rgb_to_hex(outline_color_str))
+                stroke_rgba = coerce_rgba(rgb_to_hex(outline_color_str))
                 symb_state["strokeColor"] = list(stroke_rgba)
 
                 if isinstance(cat_symbol, QgsMarkerSymbol):
@@ -242,7 +242,7 @@ def qgis_layer_to_jgis(
                         .properties()
                         .get("outline_color", "0,0,0,255")
                     )
-                    stroke_rgba = hex_to_rgba(rgb_to_hex(outline_color_str))
+                    stroke_rgba = coerce_rgba(rgb_to_hex(outline_color_str))
                     symb_state["strokeColor"] = list(stroke_rgba)
                     symb_state["geometryType"] = "circle"
                 elif isinstance(range_symbol, QgsLineSymbol):
@@ -257,12 +257,12 @@ def qgis_layer_to_jgis(
                         .properties()
                         .get("outline_color", "0,0,0,255")
                     )
-                    stroke_rgba = hex_to_rgba(rgb_to_hex(outline_color_str))
+                    stroke_rgba = coerce_rgba(rgb_to_hex(outline_color_str))
                     symb_state["strokeColor"] = list(stroke_rgba)
                     symb_state["geometryType"] = "fill"
 
         if symbol:
-            r, g, b, a = hex_to_rgba(symbol.color().name())
+            r, g, b, a = coerce_rgba(symbol.color().name())
             fill_color = [r, g, b, a]
 
             if isinstance(symbol, QgsMarkerSymbol):
@@ -283,7 +283,7 @@ def qgis_layer_to_jgis(
                 outline_color_str = (
                     symbol.symbolLayer(0).properties().get("outline_color", "0,0,0,255")
                 )
-                stroke_rgba = hex_to_rgba(rgb_to_hex(outline_color_str))
+                stroke_rgba = coerce_rgba(rgb_to_hex(outline_color_str))
                 symb_state["strokeColor"] = list(stroke_rgba)
                 symb_state["geometryType"] = "fill"
 
@@ -500,7 +500,7 @@ def import_project_from_qgis(path: str | Path):
 def _rgba_to_qcolor(rgba):
     """Convert an [r,g,b,a] list (a in 0-1) to QColor."""
     if isinstance(rgba, str) and rgba.startswith("#"):
-        r, g, b, a = hex_to_rgba(rgba)
+        r, g, b, a = coerce_rgba(rgba)
         return QColor(int(r), int(g), int(b), int(a * 255))
     if isinstance(rgba, list) and len(rgba) == 4:
         r, g, b, a = rgba


### PR DESCRIPTION
#1530

- Removed \hex_to_rgba\ from \colors.py\.
- Replaced usages in \qgis_loader.py\ with \coerce_rgba\.
- Added unit tests for \
gb_to_hex\.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1558.org.readthedocs.build/en/1558/
💡 JupyterLite preview: https://jupytergis--1558.org.readthedocs.build/en/1558/lite
💡 Specta preview: https://jupytergis--1558.org.readthedocs.build/en/1558/lite/specta

<!-- readthedocs-preview jupytergis end -->