### PR TITLE
Improve Vega Expressions UI

### DIFF
--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -5,7 +5,7 @@
 
 import { javascript } from '@codemirror/lang-javascript';
 import { EditorState } from '@codemirror/state';
-import { EditorView } from '@codemirror/view';
+import { EditorView, placeholder } from '@codemirror/view';
 import {
   ClassificationMode,
   ICategoricalScale,
@@ -413,6 +413,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
         javascript(),
         jupyterTheme,
         EditorView.lineWrapping,
+        placeholder("e.g. datum.value > 10 ? 'red' : 'blue'"),
         EditorView.updateListener.of(updateView => {
           if (updateView.docChanged) {
             const value = updateView.state.doc.toString();
@@ -454,7 +455,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
   return (
     <div className="jp-gis-color-ramp-container">
       <div className="jp-gis-symbology-row">
-        <label>Expression</label>
+        <label>Vega Expression</label>
         <div
           ref={editorRef}
           style={{

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -34,6 +34,7 @@ import {
   IComputedStop,
 } from '@/src/features/layers/symbology/styleBuilder';
 import { IStopRow } from '@/src/features/layers/symbology/symbologyDialog';
+import { InfoTip } from '@/src/shared/components/InfoTip';
 
 function stopsToRows(
   stops: Array<{ stop: number | string; color: RGBA }>,
@@ -455,7 +456,26 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
   return (
     <div className="jp-gis-color-ramp-container">
       <div className="jp-gis-symbology-row">
-        <label>Vega Expression</label>
+        <label>
+          Vega Expression{' '}
+          <InfoTip text="Use Vega expressions to style features dynamically (e.g. conditional colors based on attributes like datum.population).">
+            <ul style={{ paddingLeft: 16, margin: 0 }}>
+              <li>
+                Access fields with <code>datum.fieldName</code>
+              </li>
+              <li>
+                Use ternary logic: <code>condition ? a : b</code>
+              </li>
+            </ul>
+            <a
+              href="https://vega.github.io/vega/docs/expressions/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Full Vega Expression Docs
+            </a>
+          </InfoTip>
+        </label>
         <div
           ref={editorRef}
           style={{


### PR DESCRIPTION
## Description


https://github.com/user-attachments/assets/dcb4d6c2-d0a3-4756-8ed9-ec25d25b1369



- [x] We should show a placeholder expression in the UI
- [x] We should rename Expression -> Vega Expression in the UI to not be confused between Python and Vega
- [x] We should make use of the new help `infotip` to point to vega expressions doc

- Closes #1554

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1559.org.readthedocs.build/en/1559/
💡 JupyterLite preview: https://jupytergis--1559.org.readthedocs.build/en/1559/lite
💡 Specta preview: https://jupytergis--1559.org.readthedocs.build/en/1559/lite/specta

<!-- readthedocs-preview jupytergis end -->