### PR TITLE
Make story segments reorderable

### DIFF
--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -259,6 +259,7 @@ export function StoryEditorDialogBody({
     addSegment,
     removeSegment,
     canRemoveSegment,
+    reorderSegments,
     updateStory,
     updateSegmentContentMode,
     updateSegmentContent,
@@ -283,6 +284,7 @@ export function StoryEditorDialogBody({
           selectedSegmentId={selectedSegmentId}
           onSelectSegment={selectSegment}
           onAddSegment={addSegment}
+          onReorderSegments={reorderSegments}
         />
 
         <main className="jgis-story-editor-workspace">

--- a/packages/base/src/features/story/__tests__/useStoryEditorSegmentList.spec.ts
+++ b/packages/base/src/features/story/__tests__/useStoryEditorSegmentList.spec.ts
@@ -220,4 +220,20 @@ describe('useStoryEditorSegmentList', () => {
 
     expect(model.removeLayer).not.toHaveBeenCalled();
   });
+
+  it('reorders story segments', () => {
+    const story = createStory();
+    const { model } = createModel({ story, currentIndex: 0 });
+    const view = mountHook(model, commands);
+
+    act(() => {
+      view.current.reorderSegments(0, 1);
+    });
+
+    expect(model.sharedModel.updateStoryMap).toHaveBeenCalledWith('story-1', {
+      ...story,
+      storySegments: ['segment-2', 'segment-1'],
+    });
+    expect(model.setCurrentSegmentIndex).toHaveBeenCalledWith(1);
+  });
 });

--- a/packages/base/src/features/story/components/StoryEditorSegmentList.tsx
+++ b/packages/base/src/features/story/components/StoryEditorSegmentList.tsx
@@ -1,6 +1,6 @@
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faGripVertical, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
 import { getSegmentDisplayMode } from '@/src/features/story/utils/listStoryScrollTrack';
@@ -12,37 +12,58 @@ export interface IStoryEditorSegmentListProps {
   selectedSegmentId: string | null;
   onSelectSegment: (segmentId: string) => void;
   onAddSegment: () => void;
+  onReorderSegments: (fromIndex: number, toIndex: number) => void;
 }
 
 function SegmentListItem({
   segment,
   selected,
   onSelect,
+  index,
+  canReorder,
+  onDragStart,
 }: {
   segment: IStorySegmentViewItem;
   selected: boolean;
   onSelect: () => void;
+  index: number;
+  canReorder: boolean;
+  onDragStart: (index: number, event: React.DragEvent) => void;
 }): JSX.Element {
   const segmentMode = getSegmentDisplayMode(segment.activeSlide);
   const title = getStorySegmentDisplayTitle(segment);
 
   return (
-    <button
-      type="button"
-      className={`jgis-story-editor-segment-item${
-        selected ? ' jgis-story-editor-segment-item--selected' : ''
-      }`}
-      onClick={onSelect}
-      aria-current={selected ? 'true' : undefined}
-    >
-      <span className="jgis-story-editor-segment-item-index">
-        {segment.index + 1}.
-      </span>
-      <span className="jgis-story-editor-segment-item-title">{title}</span>
-      <span className="jgis-story-editor-segment-item-type">
-        {segmentMode === 'map' ? 'Map' : 'Text'}
-      </span>
-    </button>
+    <div className="jgis-story-editor-segment-row">
+      {canReorder && (
+        <div
+          className="jgis-story-editor-segment-drag-handle"
+          draggable
+          onDragStart={event => {
+            onDragStart(index, event);
+          }}
+          title="Drag to reorder"
+        >
+          <FontAwesomeIcon icon={faGripVertical} />
+        </div>
+      )}
+      <button
+        type="button"
+        className={`jgis-story-editor-segment-item${
+          selected ? ' jgis-story-editor-segment-item--selected' : ''
+        }`}
+        onClick={onSelect}
+        aria-current={selected ? 'true' : undefined}
+      >
+        <span className="jgis-story-editor-segment-item-index">
+          {segment.index + 1}.
+        </span>
+        <span className="jgis-story-editor-segment-item-title">{title}</span>
+        <span className="jgis-story-editor-segment-item-type">
+          {segmentMode === 'map' ? 'Map' : 'Text'}
+        </span>
+      </button>
+    </div>
   );
 }
 
@@ -51,25 +72,116 @@ export function StoryEditorSegmentList({
   selectedSegmentId,
   onSelectSegment,
   onAddSegment,
+  onReorderSegments,
 }: IStoryEditorSegmentListProps): JSX.Element {
+  const dragIndexRef = useRef<number | null>(null);
+  const dragOverRef = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const canReorder = segments.length > 1;
+
+  const clearDragState = useCallback((): void => {
+    dragIndexRef.current = null;
+    dragOverRef.current = null;
+    setDragOverIndex(null);
+  }, []);
+
+  const handleDragStart = useCallback(
+    (index: number, event: React.DragEvent): void => {
+      dragIndexRef.current = index;
+      const wrapper = event.currentTarget.closest(
+        '.jgis-story-editor-segment-drag-wrapper',
+      );
+
+      if (wrapper instanceof HTMLElement) {
+        event.dataTransfer.setDragImage(wrapper, 0, 0);
+      }
+    },
+    [],
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>): void => {
+      if (!canReorder) {
+        return;
+      }
+
+      event.preventDefault();
+      const wrappers = Array.from(
+        event.currentTarget.querySelectorAll(
+          ':scope > .jgis-story-editor-segment-drag-wrapper',
+        ),
+      );
+
+      let index = segments.length;
+      for (let i = 0; i < wrappers.length; i++) {
+        const rect = wrappers[i].getBoundingClientRect();
+        const midY = rect.top + rect.height / 2;
+        if (event.clientY < midY) {
+          index = i;
+          break;
+        }
+      }
+
+      dragOverRef.current = index;
+      setDragOverIndex(index);
+    },
+    [canReorder, segments.length],
+  );
+
+  const handleDrop = useCallback((): void => {
+    const over = dragOverRef.current;
+    const from = dragIndexRef.current;
+
+    if (from !== null && over !== null) {
+      const to = over > from ? over - 1 : over;
+      onReorderSegments(from, to);
+    }
+
+    clearDragState();
+  }, [clearDragState, onReorderSegments]);
+
   return (
     <aside className="jgis-story-editor-segment-list">
       <div className="jgis-story-editor-segment-list-header jgis-story-editor-eyebrow">
         Segments
       </div>
-      <div className="jgis-story-editor-segment-list-items">
+      <div
+        className="jgis-story-editor-segment-list-items"
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        onDragEnd={clearDragState}
+      >
         {segments.length === 0 ? (
           <p className="jgis-story-editor-segment-list-empty jgis-story-editor-help">
             No segments yet. Add one from the current map view.
           </p>
         ) : (
-          segments.map(segment => (
-            <SegmentListItem
+          segments.map((segment, index) => (
+            <div
               key={segment.id}
-              segment={segment}
-              selected={segment.id === selectedSegmentId}
-              onSelect={() => onSelectSegment(segment.id)}
-            />
+              className="jgis-story-editor-segment-drag-wrapper"
+              style={{
+                borderTop:
+                  dragOverIndex === index && dragIndexRef.current !== index
+                    ? '2px solid var(--jp-brand-color1)'
+                    : '2px solid transparent',
+                borderBottom:
+                  dragOverIndex === segments.length &&
+                  index === segments.length - 1 &&
+                  dragIndexRef.current !== index
+                    ? '2px solid var(--jp-brand-color1)'
+                    : '2px solid transparent',
+              }}
+            >
+              <SegmentListItem
+                segment={segment}
+                selected={segment.id === selectedSegmentId}
+                onSelect={() => onSelectSegment(segment.id)}
+                index={index}
+                canReorder={canReorder}
+                onDragStart={handleDragStart}
+              />
+            </div>
           ))
         )}
       </div>

--- a/packages/base/src/features/story/hooks/useStoryEditorSegmentList.ts
+++ b/packages/base/src/features/story/hooks/useStoryEditorSegmentList.ts
@@ -28,6 +28,7 @@ interface IUseStoryEditorSegmentListResult {
   addSegment: () => void;
   removeSegment: () => void;
   canRemoveSegment: boolean;
+  reorderSegments: (fromIndex: number, toIndex: number) => void;
   updateStory: (patch: Partial<IJGISStoryMap>) => void;
   updateSegmentContentMode: (
     segmentId: string,
@@ -164,6 +165,47 @@ export function useStoryEditorSegmentList(
     );
   }, [model, selectedSegmentId, story]);
 
+  const reorderSegments = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      if (
+        !storyId ||
+        !story?.storySegments ||
+        story.storySegments.length <= 1 ||
+        fromIndex === toIndex
+      ) {
+        return;
+      }
+
+      const segmentIds = story.storySegments;
+
+      if (
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= segmentIds.length ||
+        toIndex >= segmentIds.length
+      ) {
+        return;
+      }
+
+      const nextSegmentIds = [...segmentIds];
+      const [movedId] = nextSegmentIds.splice(fromIndex, 1);
+      nextSegmentIds.splice(toIndex, 0, movedId);
+
+      model.sharedModel.updateStoryMap(storyId, {
+        ...story,
+        storySegments: nextSegmentIds,
+      });
+
+      const currentIndex = model.getCurrentSegmentIndex() ?? 0;
+      const currentId = segmentIds[currentIndex];
+      const nextIndex = nextSegmentIds.indexOf(currentId);
+      if (nextIndex >= 0) {
+        model.setCurrentSegmentIndex(nextIndex);
+      }
+    },
+    [model, storyId, story],
+  );
+
   const updateSegmentContentMode = useCallback(
     (segmentId: string, mode: StorySegmentDisplayMode) => {
       applySegmentContentMode(model, segmentId, mode);
@@ -195,6 +237,7 @@ export function useStoryEditorSegmentList(
     addSegment,
     removeSegment,
     canRemoveSegment,
+    reorderSegments,
     updateStory,
     updateSegmentContentMode,
     updateSegmentContent,

--- a/packages/base/src/workspace/panels/hooks/useLayerTree.ts
+++ b/packages/base/src/workspace/panels/hooks/useLayerTree.ts
@@ -6,16 +6,11 @@ import {
 import * as React from 'react';
 
 /**
- * Subscribes to the model's layer tree and splits it into two derived trees:
- * - `layerTree`: regular map layers (excludes StorySegmentLayers)
- * - `segmentTree`: story segment layers only
- *
- * Also pre-selects the last item on first load, and syncs segment order back
- * to the story map whenever the segment tree changes.
+ * Subscribes to the model's layer tree and returns a display tree that excludes
+ * story segment layers. Also pre-selects the last item on first load.
  */
 export function useLayerTree(model: IJupyterGISModel): {
   layerTree: IJGISLayerTree;
-  segmentTree: IJGISLayerTree;
 } {
   const [rawLayerTree, setRawLayerTree] = React.useState<IJGISLayerTree>(
     model.getLayerTree(),
@@ -55,72 +50,32 @@ export function useLayerTree(model: IJupyterGISModel): {
     };
   }, [model]);
 
-  // Split the raw tree into regular layers and story segment layers
-  const { layerTree, segmentTree } = React.useMemo(() => {
+  const layerTree = React.useMemo(() => {
     const layers: IJGISLayerTree = [];
-    const segments: IJGISLayerTree = [];
 
-    const processLayer = (
-      layer: IJGISLayerItem,
-    ): {
-      layer: IJGISLayerItem | null;
-      segment: IJGISLayerItem | null;
-    } => {
+    const processLayer = (layer: IJGISLayerItem): IJGISLayerItem | null => {
       if (typeof layer === 'string') {
         const layerData = model.getLayer(layer);
-        const isStorySegment = layerData?.type === 'StorySegmentLayer';
-        return {
-          layer: isStorySegment ? null : layer,
-          segment: isStorySegment ? layer : null,
-        };
+        return layerData?.type === 'StorySegmentLayer' ? null : layer;
       }
 
-      const groupLayers: IJGISLayerItem[] = [];
-      const groupSegments: IJGISLayerItem[] = [];
+      const groupLayers = layer.layers
+        .map(processLayer)
+        .filter((item): item is IJGISLayerItem => item !== null);
 
-      for (const groupLayer of layer.layers) {
-        const result = processLayer(groupLayer);
-        if (result.layer !== null) {
-          groupLayers.push(result.layer);
-        }
-        if (result.segment !== null) {
-          groupSegments.push(result.segment);
-        }
-      }
-
-      return {
-        layer:
-          groupLayers.length > 0 ? { ...layer, layers: groupLayers } : null,
-        segment:
-          groupSegments.length > 0 ? { ...layer, layers: groupSegments } : null,
-      };
+      return groupLayers.length > 0 ? { ...layer, layers: groupLayers } : null;
     };
 
     for (const item of rawLayerTree) {
-      const result = processLayer(item);
-      if (result.layer !== null) {
-        layers.push(result.layer);
-      }
-      if (result.segment !== null) {
-        segments.push(result.segment);
+      const layer = processLayer(item);
+      if (layer !== null) {
+        layers.push(layer);
       }
     }
 
     layers.reverse();
-    return { layerTree: layers, segmentTree: segments };
-  }, [rawLayerTree]);
+    return layers;
+  }, [model, rawLayerTree]);
 
-  // Sync segment order back to the story map when it changes
-  React.useEffect(() => {
-    const { storyId, story } = model.getSelectedStory();
-    if (!story) {
-      return;
-    }
-    model.sharedModel.updateStoryMap(storyId, {
-      ...story,
-      storySegments: segmentTree as string[],
-    });
-  }, [segmentTree]);
-
-  return { layerTree, segmentTree };
+  return { layerTree };
 }

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -316,6 +316,41 @@
   gap: 0.25rem;
 }
 
+.jgis-story-editor-segment-drag-wrapper {
+  border-radius: var(--jp-border-radius);
+}
+
+.jgis-story-editor-segment-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.125rem;
+}
+
+.jgis-story-editor-segment-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  flex-shrink: 0;
+  cursor: grab;
+  color: var(--jp-ui-font-color3);
+  border-radius: var(--jp-border-radius);
+}
+
+.jgis-story-editor-segment-drag-handle:hover {
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color2);
+}
+
+.jgis-story-editor-segment-drag-handle:active {
+  cursor: grabbing;
+}
+
+.jgis-story-editor-segment-row .jgis-story-editor-segment-item {
+  flex: 1;
+  min-width: 0;
+}
+
 .jgis-story-editor-segment-list-empty {
   margin: 0.5rem;
   font-size: 0.75rem;
@@ -387,9 +422,7 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   font-size: 0.82rem;
   font-weight: 500;
   color: var(--jp-ui-font-color1);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: break-spaces;
 }
 
 .jgis-story-editor-segment-item-type {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
This makes the segments reorderable in the editor. 

https://github.com/user-attachments/assets/db780544-fdd7-4dbb-aec2-7b7f20d59c1d


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1560.org.readthedocs.build/en/1560/
💡 JupyterLite preview: https://jupytergis--1560.org.readthedocs.build/en/1560/lite
💡 Specta preview: https://jupytergis--1560.org.readthedocs.build/en/1560/lite/specta

<!-- readthedocs-preview jupytergis end -->