### PR TITLE
Disable UI Features for QGIS file editing

### DIFF
--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -118,18 +118,39 @@ export function addCommands(
     command: CommandRegistry.ICommandOptions,
   ): CommandRegistry.ICommandOptions => {
     const originalIsEnabled = command.isEnabled;
+    const originalCaption = command.caption;
+    const originalLabel = command.label;
+
+    // True when the command is unsupported by QGIS and a QGIS file is open.
+    const isQgisRestricted = () => {
+      const currentModel = tracker.currentWidget?.model;
+      return (
+        !!currentModel?.isQgisDocument && QGIS_UNSUPPORTED_COMMANDS.has(id)
+      );
+    };
+
+    const resolveLabel = (args?: ReadonlyPartialJSONObject): string =>
+      typeof originalLabel === 'function'
+        ? originalLabel(args ?? {})
+        : (originalLabel ?? '');
 
     return {
       ...command,
+      label: (args?: ReadonlyPartialJSONObject) => {
+        const label = resolveLabel(args);
+        if (isQgisRestricted() && label) {
+          return trans.__('%1 (convert to .jGIS to enable)', label);
+        }
+        return label;
+      },
       isEnabled: (args?: ReadonlyPartialJSONObject) => {
-        const currentModel = tracker.currentWidget?.model;
         // Disable everything in Specta mode.
-        if (currentModel?.isSpectaMode()) {
+        if (tracker.currentWidget?.model?.isSpectaMode()) {
           return false;
         }
         // Disable features unsupported by QGIS while a QGIS file is open,
         // since they cannot be round-tripped through the QGIS format.
-        if (currentModel?.isQgisDocument && QGIS_UNSUPPORTED_COMMANDS.has(id)) {
+        if (isQgisRestricted()) {
           return false;
         }
         // Then check the original isEnabled if it exists
@@ -138,6 +159,17 @@ export function addCommands(
         }
         // Default to enabled if no original check
         return true;
+      },
+      caption: (args?: ReadonlyPartialJSONObject) => {
+        // Hint the user how to regain access to the disabled feature.
+        if (isQgisRestricted()) {
+          return trans.__(
+            '(convert to .jGIS to enable)',
+          );
+        }
+        return typeof originalCaption === 'function'
+          ? originalCaption(args ?? {})
+          : (originalCaption ?? '');
       },
     };
   };

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -51,6 +51,25 @@ import { JupyterGISDocumentWidget, JupyterGISPanel } from '../workspace/widget';
 
 const POINT_SELECTION_TOOL_CLASS = 'jGIS-point-selection-tool';
 
+/**
+ * Commands for JupyterGIS-only features that cannot be round-tripped through
+ * the QGIS format. They are disabled while a QGIS document (`.qgs`/`.qgz`) is
+ * open so users don't create work that would be lost on save.
+ */
+const QGIS_UNSUPPORTED_COMMANDS = new Set<string>([
+  // OpenEO layers
+  CommandIDs.openNewOpenEODialog,
+  CommandIDs.editOpenEOLayer,
+  // GeoZarr layers
+  CommandIDs.openNewGeoZarrDialog,
+  // Story maps
+  CommandIDs.addStorySegment,
+  CommandIDs.openStoryEditor,
+  CommandIDs.createStorySegmentFromLayer,
+  CommandIDs.storyPrev,
+  CommandIDs.storyNext,
+]);
+
 interface ICreateEntry {
   tracker: JupyterGISTracker;
   formSchemaRegistry: IJGISFormSchemaRegistry;
@@ -90,9 +109,12 @@ export function addCommands(
 
   addLayerCreationCommands({ tracker, commands, trans });
   /**
-   * Wraps a command definition to automatically disable it in Specta mode
+   * Wraps a command definition to automatically disable it when the active
+   * document does not support it: in Specta mode, or for JupyterGIS-only
+   * features (see QGIS_UNSUPPORTED_COMMANDS) while a QGIS document is open.
    */
-  const createSpectaAwareCommand = (
+  const createRestrictedCommand = (
+    id: string,
     command: CommandRegistry.ICommandOptions,
   ): CommandRegistry.ICommandOptions => {
     const originalIsEnabled = command.isEnabled;
@@ -100,9 +122,14 @@ export function addCommands(
     return {
       ...command,
       isEnabled: (args?: ReadonlyPartialJSONObject) => {
-        // First check if we're in Specta mode
         const currentModel = tracker.currentWidget?.model;
+        // Disable everything in Specta mode.
         if (currentModel?.isSpectaMode()) {
+          return false;
+        }
+        // Disable features unsupported by QGIS while a QGIS file is open,
+        // since they cannot be round-tripped through the QGIS format.
+        if (currentModel?.isQgisDocument && QGIS_UNSUPPORTED_COMMANDS.has(id)) {
           return false;
         }
         // Then check the original isEnabled if it exists
@@ -121,7 +148,7 @@ export function addCommands(
     id: string,
     options: CommandRegistry.ICommandOptions,
   ) => {
-    return originalAddCommand(id, createSpectaAwareCommand(options));
+    return originalAddCommand(id, createRestrictedCommand(id, options));
   };
 
   commands.addCommand(CommandIDs.symbology, {

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -163,9 +163,7 @@ export function addCommands(
       caption: (args?: ReadonlyPartialJSONObject) => {
         // Hint the user how to regain access to the disabled feature.
         if (isQgisRestricted()) {
-          return trans.__(
-            '(convert to .jGIS to enable)',
-          );
+          return trans.__('(convert to .jGIS to enable)');
         }
         return typeof originalCaption === 'function'
           ? originalCaption(args ?? {})

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -193,6 +193,7 @@ interface ILayerSectionProps {
   availableFields: IFieldOption[];
   featureValues: Record<string, Set<any>>;
   isRasterLayer?: boolean;
+  allowExpression?: boolean;
   onChange: (layer: ILayerUIState) => void;
   onDelete: () => void;
   onMoveUp?: () => void;
@@ -206,6 +207,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
   availableFields,
   featureValues,
   isRasterLayer = false,
+  allowExpression = true,
   onChange,
   onDelete,
   onMoveUp,
@@ -516,6 +518,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
               availableFields={encodingFields}
               featureValues={featureValues}
               isRaster={isRaster}
+              allowExpression={allowExpression}
               onChange={updated => updateRow(i, updated)}
               onDelete={() => removeRow(i)}
             />
@@ -704,6 +707,7 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
           availableFields={availableFields}
           featureValues={selectableAttributesAndValues}
           isRasterLayer={isRasterLayer}
+          allowExpression={!model.isQgisDocument}
           onChange={updated =>
             setLayers(prev => prev.map((l, j) => (j === i ? updated : l)))
           }

--- a/packages/base/src/features/layers/symbology/Grammar.tsx
+++ b/packages/base/src/features/layers/symbology/Grammar.tsx
@@ -20,6 +20,7 @@ import {
   IGrammarLayer,
   IGrammarSymbologyState,
   IPredicate,
+  IScale,
   ITransform,
   Encoding,
   RGBA,
@@ -50,6 +51,10 @@ import {
 
 const DEFAULT_CHANNELS: Encoding[] = ['fill-color', 'circle-fill-color'];
 const DEFAULT_RGBA: RGBA = [128, 128, 128, 1];
+
+// Scale schemes that cannot be round-tripped through the QGIS format, and are
+// therefore hidden from the picker while a QGIS document is open.
+const QGIS_UNSUPPORTED_SCHEMES: IScale['scheme'][] = ['expression'];
 
 // ---------------------------------------------------------------------------
 // Layer UI state
@@ -193,7 +198,7 @@ interface ILayerSectionProps {
   availableFields: IFieldOption[];
   featureValues: Record<string, Set<any>>;
   isRasterLayer?: boolean;
-  allowExpression?: boolean;
+  disabledSchemes?: IScale['scheme'][];
   onChange: (layer: ILayerUIState) => void;
   onDelete: () => void;
   onMoveUp?: () => void;
@@ -207,7 +212,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
   availableFields,
   featureValues,
   isRasterLayer = false,
-  allowExpression = true,
+  disabledSchemes = [],
   onChange,
   onDelete,
   onMoveUp,
@@ -518,7 +523,7 @@ const LayerSection: React.FC<ILayerSectionProps> = ({
               availableFields={encodingFields}
               featureValues={featureValues}
               isRaster={isRaster}
-              allowExpression={allowExpression}
+              disabledSchemes={disabledSchemes}
               onChange={updated => updateRow(i, updated)}
               onDelete={() => removeRow(i)}
             />
@@ -707,7 +712,7 @@ const Grammar: React.FC<ISymbologyDialogProps> = ({
           availableFields={availableFields}
           featureValues={selectableAttributesAndValues}
           isRasterLayer={isRasterLayer}
-          allowExpression={!model.isQgisDocument}
+          disabledSchemes={model.isQgisDocument ? QGIS_UNSUPPORTED_SCHEMES : []}
           onChange={updated =>
             setLayers(prev => prev.map((l, j) => (j === i ? updated : l)))
           }

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -694,7 +694,7 @@ interface IMappingRowProps {
   availableFields: IFieldOption[];
   featureValues: Record<string, Set<any>>;
   isRaster?: boolean;
-  allowExpression?: boolean;
+  disabledSchemes?: IScale['scheme'][];
   onChange: (row: IGrammarRow) => void;
   onDelete: () => void;
 }
@@ -708,7 +708,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
   availableFields,
   featureValues,
   isRaster = false,
-  allowExpression = true,
+  disabledSchemes = [],
   onChange,
   onDelete,
 }) => {
@@ -843,7 +843,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
           >
             {SCHEME_OPTIONS.filter(
               ({ value, disabled }) =>
-                !disabled && (allowExpression || value !== 'expression'),
+                !disabled && !disabledSchemes.includes(value),
             ).map(({ value, label }) => (
               <NativeSelectOption key={value} value={value}>
                 {label}

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -694,6 +694,7 @@ interface IMappingRowProps {
   availableFields: IFieldOption[];
   featureValues: Record<string, Set<any>>;
   isRaster?: boolean;
+  allowExpression?: boolean;
   onChange: (row: IGrammarRow) => void;
   onDelete: () => void;
 }
@@ -707,6 +708,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
   availableFields,
   featureValues,
   isRaster = false,
+  allowExpression = true,
   onChange,
   onDelete,
 }) => {
@@ -839,13 +841,14 @@ const MappingRow: React.FC<IMappingRowProps> = ({
               handleSchemeChange(e.target.value as IScale['scheme'])
             }
           >
-            {SCHEME_OPTIONS.filter(({ disabled }) => !disabled).map(
-              ({ value, label }) => (
-                <NativeSelectOption key={value} value={value}>
-                  {label}
-                </NativeSelectOption>
-              ),
-            )}
+            {SCHEME_OPTIONS.filter(
+              ({ value, disabled }) =>
+                !disabled && (allowExpression || value !== 'expression'),
+            ).map(({ value, label }) => (
+              <NativeSelectOption key={value} value={value}>
+                {label}
+              </NativeSelectOption>
+            ))}
           </NativeSelect>
           <button
             type="button"

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -323,6 +323,11 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   contentsManager: Contents.IManager | undefined;
   filePath: string;
 
+  /**
+   * Whether the document is backed by a QGIS file (`.qgs`/`.qgz`).
+   */
+  readonly isQgisDocument: boolean;
+
   pathChanged: ISignal<IJupyterGISModel, string>;
 
   stories: Map<string, IJGISStoryMap>;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -481,6 +481,14 @@ export class JupyterGISModel implements IJupyterGISModel {
     this._pathChanged.emit(path);
   }
 
+  /**
+   * Whether the document is backed by a QGIS file (`.qgs`/`.qgz`).
+   */
+  get isQgisDocument(): boolean {
+    const path = this._filePath?.toLowerCase() ?? '';
+    return path.endsWith('.qgs') || path.endsWith('.qgz');
+  }
+
   getLayers(): IJGISLayers {
     return this.sharedModel.layers;
   }


### PR DESCRIPTION
## Description

#1565 

Disabled:

- **OpenEO layers** — add/edit OpenEO layer actions.
- **GeoZarr layers** — add GeoZarr layer action.
- **Story Maps** — add segment, open editor, create segment from layer, prev/next.
- **Vega-expression symbology** — `expression` option removed from the symbology scale picker.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1567.org.readthedocs.build/en/1567/
💡 JupyterLite preview: https://jupytergis--1567.org.readthedocs.build/en/1567/lite
💡 Specta preview: https://jupytergis--1567.org.readthedocs.build/en/1567/lite/specta

<!-- readthedocs-preview jupytergis end -->