### PR TITLE
Block QGIS unsupported features in the Python API

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -181,7 +181,7 @@ class GISDocument(CommWidget):
         return self._layerTree.to_py()
 
     @property
-    def is_qgis_document(self) -> bool:
+    def _is_qgis_document(self) -> bool:
         """Whether the document is backed by a QGIS (`.qgs`/`.qgz`) file."""
         return str(self._path or "").lower().endswith((".qgs", ".qgz"))
 
@@ -189,10 +189,33 @@ class GISDocument(CommWidget):
         """Raise if ``object_type`` cannot be round-tripped through QGIS while a
         QGIS file is open. Mirrors the features disabled in the UI.
         """
-        if self.is_qgis_document and object_type in QGIS_UNSUPPORTED_TYPES:
+        if self._is_qgis_document and object_type in QGIS_UNSUPPORTED_TYPES:
             name = getattr(object_type, "value", object_type)
             raise RuntimeError(
                 f"'{name}' is not possible in QGIS files. Convert it to jGIS first.",
+            )
+
+    def _ensure_symbology_qgis_supported(self, symbology_state) -> None:
+        """Raise if ``symbology_state`` relies on render-time expressions while a
+        QGIS file is open. Expression-based symbology has no QGIS equivalent and
+        cannot be round-tripped, mirroring the feature disabled in the UI.
+        """
+        if not self._is_qgis_document or symbology_state is None:
+            return
+
+        def _has_expression(value) -> bool:
+            if isinstance(value, dict):
+                if value.get("scheme") == "expression":
+                    return True
+                return any(_has_expression(v) for v in value.values())
+            if isinstance(value, (list, tuple)):
+                return any(_has_expression(v) for v in value)
+            return False
+
+        if _has_expression(symbology_state):
+            raise RuntimeError(
+                "Expression-based symbology is not possible in QGIS files. "
+                "Convert it to jGIS first.",
             )
 
     def sidecar(
@@ -1040,6 +1063,9 @@ class GISDocument(CommWidget):
         self._ensure_qgis_supported(new_object.type)
         _id = str(uuid4()) if id is None else id
         obj_dict = json.loads(new_object.json())
+        self._ensure_symbology_qgis_supported(
+            obj_dict.get("parameters", {}).get("symbologyState"),
+        )
         self._layers[_id] = obj_dict
         self._layerTree.append(_id)
         return _id
@@ -1094,6 +1120,8 @@ class GISDocument(CommWidget):
         symbology_state = to_symbology_state(symbology)
         if symbology_state is None:
             raise ValueError("Symbology cannot be None")
+
+        self._ensure_symbology_qgis_supported(symbology_state)
 
         params = layer.setdefault("parameters", {})
         params["symbologyState"] = symbology_state

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -404,7 +404,6 @@ class GISDocument(CommWidget):
         name: str | None = None,
         opacity: float = 1,
     ):
-        self._ensure_qgis_supported(LayerType.OpenEOTileLayer)
         # Persist the bearer token alongside the server url so a connection
         # opened here from the notebook is reused by the frontend without the
         # user having to sign in a second time from the UI. The bearer is a
@@ -541,7 +540,6 @@ class GISDocument(CommWidget):
         :param wrap_x: Render tiles beyond the tile grid extent, defaults to False
         :param symbology: The symbology configuration to persist with the layer.
         """
-        self._ensure_qgis_supported(LayerType.GeoZarrLayer)
         source = {
             "type": SourceType.GeoZarrSource,
             "name": f"{name} Source",

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -57,6 +57,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__file__)
 
+# Layer/source types that have no QGIS equivalent and so cannot be round-tripped
+# through the QGIS format. Adding them is blocked while a QGIS file is open,
+# mirroring the features disabled in the UI.
+QGIS_UNSUPPORTED_TYPES = {
+    LayerType.OpenEOTileLayer,
+    LayerType.GeoZarrLayer,
+    LayerType.StorySegmentLayer,
+    SourceType.OpenEOTileSource,
+    SourceType.GeoZarrSource,
+}
+
 
 def reversed_tree(root):
     if isinstance(root, list):
@@ -118,6 +129,8 @@ class GISDocument(CommWidget):
         if isinstance(path, Path):
             path = str(path)
 
+        self._path = path
+
         super().__init__(
             comm_metadata={
                 "ymodel_name": "@jupytergis:widget",
@@ -166,6 +179,21 @@ class GISDocument(CommWidget):
     def layer_tree(self) -> list[str | dict]:
         """Get the layer tree"""
         return self._layerTree.to_py()
+
+    @property
+    def is_qgis_document(self) -> bool:
+        """Whether the document is backed by a QGIS (`.qgs`/`.qgz`) file."""
+        return str(self._path or "").lower().endswith((".qgs", ".qgz"))
+
+    def _ensure_qgis_supported(self, object_type) -> None:
+        """Raise if ``object_type`` cannot be round-tripped through QGIS while a
+        QGIS file is open. Mirrors the features disabled in the UI.
+        """
+        if self.is_qgis_document and object_type in QGIS_UNSUPPORTED_TYPES:
+            name = getattr(object_type, "value", object_type)
+            raise RuntimeError(
+                f"'{name}' is not possible in QGIS files. Convert it to jGIS first.",
+            )
 
     def sidecar(
         self,
@@ -376,6 +404,7 @@ class GISDocument(CommWidget):
         name: str | None = None,
         opacity: float = 1,
     ):
+        self._ensure_qgis_supported(LayerType.OpenEOTileLayer)
         # Persist the bearer token alongside the server url so a connection
         # opened here from the notebook is reused by the frontend without the
         # user having to sign in a second time from the UI. The bearer is a
@@ -512,6 +541,7 @@ class GISDocument(CommWidget):
         :param wrap_x: Render tiles beyond the tile grid extent, defaults to False
         :param symbology: The symbology configuration to persist with the layer.
         """
+        self._ensure_qgis_supported(LayerType.GeoZarrLayer)
         source = {
             "type": SourceType.GeoZarrSource,
             "name": f"{name} Source",
@@ -1002,12 +1032,14 @@ class GISDocument(CommWidget):
             del self._sources[source_id]
 
     def _add_source(self, new_object, id: str | None = None) -> str:
+        self._ensure_qgis_supported(new_object.type)
         _id = str(uuid4()) if id is None else id
         obj_dict = json.loads(new_object.json())
         self._sources[_id] = obj_dict
         return _id
 
     def _add_layer(self, new_object, id: str | None = None) -> str:
+        self._ensure_qgis_supported(new_object.type)
         _id = str(uuid4()) if id is None else id
         obj_dict = json.loads(new_object.json())
         self._layers[_id] = obj_dict

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -8,6 +8,7 @@ from jupytergis_lab.notebook.symbology import (
     field,
     heatmap,
     to_symbology_state,
+    vega_expr,
     when,
 )
 
@@ -246,14 +247,14 @@ class TestGeoJSONGrammarSymbology(TestDocument):
 
 class TestQgisUnsupportedFeatures(TestDocument):
     def test_jgis_document_allows_unsupported_layers(self):
-        assert not self.doc.is_qgis_document
+        assert not self.doc._is_qgis_document
         layer_id = self.doc.add_geoZarr_layer(url="http://example.com/data.zarr")
         assert self.doc.layers[layer_id]
 
     @pytest.mark.parametrize("ext", [".qgz", ".qgs", ".QGZ"])
     def test_qgis_document_is_detected(self, ext):
         self.doc._path = f"project{ext}"
-        assert self.doc.is_qgis_document
+        assert self.doc._is_qgis_document
 
     def test_geozarr_layer_blocked_on_qgis_document(self):
         self.doc._path = "project.qgz"
@@ -272,6 +273,34 @@ class TestQgisUnsupportedFeatures(TestDocument):
     def test_unsupported_types_are_allowed_on_jgis_document(self):
         for object_type in QGIS_UNSUPPORTED_TYPES:
             self.doc._ensure_qgis_supported(object_type)  # does not raise
+
+    def test_expression_symbology_blocked_on_add_layer(self):
+        self.doc._path = "project.qgz"
+        with pytest.raises(RuntimeError, match="Convert it to jGIS first"):
+            self.doc.add_geojson_layer(
+                data=SAMPLE_GEOJSON,
+                name="Quakes",
+                symbology=[[vega_expr("datum.mag * 2").encoding("radius")]],
+            )
+        # Nothing should have been added.
+        assert len(self.doc.layers) == 0
+
+    def test_expression_symbology_blocked_on_apply(self):
+        layer_id = self.doc.add_geojson_layer(data=SAMPLE_GEOJSON, name="Quakes")
+        self.doc._path = "project.qgz"
+        with pytest.raises(RuntimeError, match="Convert it to jGIS first"):
+            self.doc.apply_symbology(
+                layer_id,
+                [[vega_expr("datum.mag * 2").encoding("radius")]],
+            )
+
+    def test_expression_symbology_allowed_on_jgis_document(self):
+        layer_id = self.doc.add_geojson_layer(
+            data=SAMPLE_GEOJSON,
+            name="Quakes",
+            symbology=[[vega_expr("datum.mag * 2").encoding("radius")]],
+        )
+        assert self.doc.layers[layer_id]
 
 
 class TestLayerManipulation(TestDocument):

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 
 from jupytergis_lab import GISDocument
+from jupytergis_lab.notebook.gis_document import QGIS_UNSUPPORTED_TYPES
 from jupytergis_lab.notebook.symbology import (
     cluster,
     constant,
@@ -262,12 +263,15 @@ class TestQgisUnsupportedFeatures(TestDocument):
         assert len(self.doc.layers) == 0
         assert len(self.doc._sources) == 0
 
-    def test_openeo_layer_blocked_on_qgis_document(self):
+    @pytest.mark.parametrize("object_type", sorted(QGIS_UNSUPPORTED_TYPES, key=str))
+    def test_unsupported_types_are_blocked_on_qgis_document(self, object_type):
         self.doc._path = "project.qgz"
         with pytest.raises(RuntimeError, match="Convert it to jGIS first"):
-            self.doc.add_openeo_tile_layer(graph=None)
-        assert len(self.doc.layers) == 0
-        assert len(self.doc._sources) == 0
+            self.doc._ensure_qgis_supported(object_type)
+
+    def test_unsupported_types_are_allowed_on_jgis_document(self):
+        for object_type in QGIS_UNSUPPORTED_TYPES:
+            self.doc._ensure_qgis_supported(object_type)  # does not raise
 
 
 class TestLayerManipulation(TestDocument):

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -243,6 +243,33 @@ class TestGeoJSONGrammarSymbology(TestDocument):
             )
 
 
+class TestQgisUnsupportedFeatures(TestDocument):
+    def test_jgis_document_allows_unsupported_layers(self):
+        assert not self.doc.is_qgis_document
+        layer_id = self.doc.add_geoZarr_layer(url="http://example.com/data.zarr")
+        assert self.doc.layers[layer_id]
+
+    @pytest.mark.parametrize("ext", [".qgz", ".qgs", ".QGZ"])
+    def test_qgis_document_is_detected(self, ext):
+        self.doc._path = f"project{ext}"
+        assert self.doc.is_qgis_document
+
+    def test_geozarr_layer_blocked_on_qgis_document(self):
+        self.doc._path = "project.qgz"
+        with pytest.raises(RuntimeError, match="Convert it to jGIS first"):
+            self.doc.add_geoZarr_layer(url="http://example.com/data.zarr")
+        # Nothing should have been added.
+        assert len(self.doc.layers) == 0
+        assert len(self.doc._sources) == 0
+
+    def test_openeo_layer_blocked_on_qgis_document(self):
+        self.doc._path = "project.qgz"
+        with pytest.raises(RuntimeError, match="Convert it to jGIS first"):
+            self.doc.add_openeo_tile_layer(graph=None)
+        assert len(self.doc.layers) == 0
+        assert len(self.doc._sources) == 0
+
+
 class TestLayerManipulation(TestDocument):
     def test_add_and_remove_layer_and_source(self):
         layer_id = self.doc.add_geotiff_layer(url=TEST_TIF)


### PR DESCRIPTION
## Description

Shall close #1570 

Adding OpenEO/GeoZarr/Story-map layers to a .qgs/.qgz-backed GISDocument now raises a RuntimeError instead of silently producing a file that can't be saved back to QGIS, mirroring the disabled buttons in the UI.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1572.org.readthedocs.build/en/1572/
💡 JupyterLite preview: https://jupytergis--1572.org.readthedocs.build/en/1572/lite
💡 Specta preview: https://jupytergis--1572.org.readthedocs.build/en/1572/lite/specta

<!-- readthedocs-preview jupytergis end -->