### PR TITLE
Dispose underlying GIS model to fix multiple cursors

### DIFF
--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -52,7 +52,7 @@ export class YJupyterGISModel extends JupyterYModel {
       return;
     }
     // Dispose the underlying collaborative model so its RTC provider is torn
-    // down. See issue https://github.com/geojupyter/jupytergis/issues/1561
+    // down.
     this.jupyterGISModel?.dispose();
     super.dispose();
   }

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -46,6 +46,16 @@ export class YJupyterGISModel extends JupyterYModel {
   get awareness() {
     return this.jupyterGISModel?.sharedModel?.awareness;
   }
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    // Dispose the underlying collaborative model so its RTC provider is torn
+    // down. See issue https://github.com/geojupyter/jupytergis/issues/1561
+    this.jupyterGISModel?.dispose();
+    super.dispose();
+  }
 }
 
 export class YJupyterGISLuminoWidget extends Panel {


### PR DESCRIPTION
## Description

Shall fix #1561

Override YJupyterGISModel.dispose() to dispose the underlying collaborative model, ensuring its RTC provider is torn down and stale awareness/cursors don't linger.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1575.org.readthedocs.build/en/1575/
💡 JupyterLite preview: https://jupytergis--1575.org.readthedocs.build/en/1575/lite
💡 Specta preview: https://jupytergis--1575.org.readthedocs.build/en/1575/lite/specta

<!-- readthedocs-preview jupytergis end -->