### PR TITLE
Add projection parameter to tiffs

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -1203,11 +1203,39 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
             }),
           );
 
+          const sourceProjection = sourceParameters.projection;
+          if (sourceProjection && !proj4.defs(sourceProjection)) {
+            const proj4Definition = proj4list[sourceProjection];
+            if (!proj4Definition) {
+              this._log(
+                'warning',
+                `Projection code '${sourceProjection}' not found in proj4list`,
+              );
+            } else {
+              try {
+                if (Array.isArray(proj4Definition)) {
+                  proj4.defs([proj4Definition]);
+                } else {
+                  proj4.defs(sourceProjection, proj4Definition);
+                }
+                register(proj4 as any);
+              } catch (error: any) {
+                this._log(
+                  'warning',
+                  `Failed to register projection '${sourceProjection}'. Error: ${error.message}`,
+                );
+              }
+            }
+          } else if (sourceProjection) {
+            register(proj4 as any);
+          }
+
           newSource = new GeoTIFFSource({
             interpolate: sourceParameters.interpolate,
             sources,
             normalize: sourceParameters.normalize,
             wrapX: sourceParameters.wrapX,
+            projection: sourceParameters.projection,
           });
 
           break;
@@ -1784,10 +1812,11 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     const projectionCode = sourceProjection.getCode();
 
-    const isProjectionRegistered = getProjection(projectionCode);
-    if (!isProjectionRegistered) {
+    const hasProj4Definition = Boolean(proj4.defs(projectionCode));
+    if (!hasProj4Definition) {
       // Check if the projection exists in proj4list
-      if (!proj4list[projectionCode]) {
+      const proj4Definition = proj4list[projectionCode];
+      if (!proj4Definition) {
         this._log(
           'warning',
           `Projection code '${projectionCode}' not found in proj4list`,
@@ -1796,8 +1825,11 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       }
 
       try {
-        proj4.defs([proj4list[projectionCode]]);
-        register(proj4 as any);
+        if (Array.isArray(proj4Definition)) {
+          proj4.defs([proj4Definition]);
+        } else {
+          proj4.defs(projectionCode, proj4Definition);
+        }
       } catch (error: any) {
         this._log(
           'warning',
@@ -1806,6 +1838,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         return;
       }
     }
+
+    // Always register after ensuring proj4 defs exist so OL transform functions
+    // are available even when the projection object already exists in cache.
+    register(proj4 as any);
   }
 
   /**

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -1203,39 +1203,14 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
             }),
           );
 
-          const sourceProjection = sourceParameters.projection;
-          if (sourceProjection && !proj4.defs(sourceProjection)) {
-            const proj4Definition = proj4list[sourceProjection];
-            if (!proj4Definition) {
-              this._log(
-                'warning',
-                `Projection code '${sourceProjection}' not found in proj4list`,
-              );
-            } else {
-              try {
-                if (Array.isArray(proj4Definition)) {
-                  proj4.defs([proj4Definition]);
-                } else {
-                  proj4.defs(sourceProjection, proj4Definition);
-                }
-                register(proj4 as any);
-              } catch (error: any) {
-                this._log(
-                  'warning',
-                  `Failed to register projection '${sourceProjection}'. Error: ${error.message}`,
-                );
-              }
-            }
-          } else if (sourceProjection) {
-            register(proj4 as any);
-          }
-
           newSource = new GeoTIFFSource({
             interpolate: sourceParameters.interpolate,
             sources,
             normalize: sourceParameters.normalize,
             wrapX: sourceParameters.wrapX,
-            projection: sourceParameters.projection,
+            ...(sourceParameters.projection
+              ? { projection: sourceParameters.projection }
+              : {}),
           });
 
           break;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -1803,15 +1803,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     return newMapLayer;
   }
 
-  addProjection(newMapLayer: Layer) {
-    const sourceProjection = newMapLayer.getSource()?.getProjection();
-    if (!sourceProjection) {
-      this._log('warning', 'Layer source projection is undefined or invalid');
-      return;
-    }
-
-    const projectionCode = sourceProjection.getCode();
-
+  private ensureProjectionRegistered(projectionCode: string): void {
     const hasProj4Definition = Boolean(proj4.defs(projectionCode));
     if (!hasProj4Definition) {
       // Check if the projection exists in proj4list
@@ -1844,6 +1836,41 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     register(proj4 as any);
   }
 
+  private resolveLayerSourceProjection(layer: IJGISLayer): string | undefined {
+    const sourceId = layer.parameters?.source;
+    if (!sourceId) {
+      return;
+    }
+
+    const source = this._model.sharedModel.getLayerSource(sourceId);
+    if (!source) {
+      return;
+    }
+
+    const parameters = source.parameters;
+    return parameters?.projection;
+  }
+
+  addProjection(target: Layer | IJGISLayer): void {
+    if (target instanceof Layer) {
+      const sourceProjection = target.getSource()?.getProjection();
+      if (!sourceProjection) {
+        this._log('warning', 'Layer source projection is undefined or invalid');
+        return;
+      }
+
+      this.ensureProjectionRegistered(sourceProjection.getCode());
+      return;
+    }
+
+    const projectionCode = this.resolveLayerSourceProjection(target);
+    if (!projectionCode) {
+      return;
+    }
+
+    this.ensureProjectionRegistered(projectionCode);
+  }
+
   /**
    * Add a layer to the map.
    *
@@ -1858,6 +1885,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
 
     try {
+      this.addProjection(layer);
       const newMapLayer = await this._buildMapLayer(id, layer);
       if (newMapLayer !== undefined) {
         await this._waitForReady();

--- a/packages/schema/src/schema/project/sources/geoTiffSource.json
+++ b/packages/schema/src/schema/project/sources/geoTiffSource.json
@@ -44,6 +44,11 @@
       "description": "Interpolate between grid cells when overzooming?",
       "default": false
     },
+    "projection": {
+      "type": "string",
+      "description": "Source CRS (e.g. EPSG:3411). Use when the GeoTIFF omits a standard EPSG code in its metadata.",
+      "default": ""
+    },
     "useProxy": {
       "type": "boolean",
       "description": "Route requests through the Jupyter server proxy to avoid CORS issues.",

--- a/packages/schema/src/schema/project/sources/geoTiffSource.json
+++ b/packages/schema/src/schema/project/sources/geoTiffSource.json
@@ -46,7 +46,7 @@
     },
     "projection": {
       "type": "string",
-      "description": "Source CRS (e.g. EPSG:3411). Use when the GeoTIFF omits a standard EPSG code in its metadata.",
+      "description": "Source CRS. Use when the GeoTIFF omits a standard EPSG code in its metadata.",
       "default": ""
     },
     "useProxy": {

--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -446,6 +446,7 @@ class GISDocument(CommWidget):
         name: str | None = None,
         normalize: bool = True,
         wrapX: bool = False,
+        projection: str | None = None,
         attribution: str = "",
         opacity: float = 1.0,
         symbology: SymbologyInput = None,
@@ -458,6 +459,7 @@ class GISDocument(CommWidget):
         :param name: The name that will be used for the object in the document, defaults to "GeoTIFF Layer"
         :param normalize: Select whether to normalize values between 0..1, if false than min/max have no effect, defaults to True
         :param wrapX: Render tiles beyond the tile grid extent, defaults to False
+        :param projection: Source CRS when the GeoTIFF omits a standard EPSG code in its metadata
         :param opacity: The opacity, between 0 and 1, defaults to 1.0
         :param symbology: The symbology configuration to persist with the layer.
         """
@@ -465,14 +467,18 @@ class GISDocument(CommWidget):
         if name is None:
             name = _extract_layer_name(url)
 
+        source_params = {
+            "urls": [{"url": url, "min": min, "max": max}],
+            "normalize": normalize,
+            "wrapX": wrapX,
+        }
+        if projection is not None:
+            source_params["projection"] = projection
+
         source = {
             "type": SourceType.GeoTiffSource,
             "name": f"{name} Source",
-            "parameters": {
-                "urls": [{"url": url, "min": min, "max": max}],
-                "normalize": normalize,
-                "wrapX": wrapX,
-            },
+            "parameters": source_params,
         }
         source_id = self._add_source(OBJECT_FACTORY.create_source(source, self))
 


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix #1532 

<img width="1096" height="944" alt="image" src="https://github.com/user-attachments/assets/7c01eb44-c01f-47f2-a34d-243f4655207b" />

I think this issue was because that file didn't have the projection defined in the metadata so OL couldn't reproject it. So this just adds a projection field to the geotiff schema which probably should've been there from the start.

It also brought up a problem with how we were adding projection, since that happened after we added the source/layer those projections weren't known to OL when creating the layers, so I moved where that happens and made it more robust.
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1576.org.readthedocs.build/en/1576/
💡 JupyterLite preview: https://jupytergis--1576.org.readthedocs.build/en/1576/lite
💡 Specta preview: https://jupytergis--1576.org.readthedocs.build/en/1576/lite/specta

<!-- readthedocs-preview jupytergis end -->