### PR TITLE
Python Expression support for UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^29.4.9",
     "typescript": "^5",
-    "vega2ol": "^1.1.1",
+    "vega2ol": "^1.1.3",
     "webpack": "^5.76.3",
     "zarrita": "^0.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lerna": "^8.1.9",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.0",
+    "py2vega-ts": "^0.1.1",
     "react-draggable": "4.5.0",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.4.9",

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -170,6 +170,7 @@ function defaultScaleForScheme(
         params: {
           expr: '',
           fallback: [0, 0, 0, 0] as RGBA,
+          language: 'vega',
         },
       };
   }

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -4,7 +4,8 @@
  */
 
 import { javascript } from '@codemirror/lang-javascript';
-import { EditorState } from '@codemirror/state';
+import { python } from '@codemirror/lang-python';
+import { Compartment, EditorState } from '@codemirror/state';
 import { EditorView, placeholder } from '@codemirror/view';
 import {
   ClassificationMode,
@@ -389,6 +390,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
   onChange,
 }) => {
   const { params } = scale;
+  const language = params.language ?? 'vega';
 
   const update = useCallback(
     (patch: Partial<IExpressionScale['params']>) =>
@@ -396,29 +398,42 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
     [params, onChange],
   );
 
+  const paramsRef = useRef(params);
   const editorRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
+  const languageComp = useRef(new Compartment()).current;
+  const placeholderComp = useRef(new Compartment()).current;
+
+  const VEGA_PLACEHOLDER = "e.g. datum.value > 10 ? 'red' : 'blue'";
+  const PYTHON_PLACEHOLDER = "e.g. 'red' if datum.value > 10 else 'blue'";
 
   useEffect(() => {
-    if (!editorRef.current) {
-      return;
-    }
+    paramsRef.current = params;
+  }, [params]);
 
-    if (viewRef.current) {
+  useEffect(() => {
+    if (!editorRef.current || viewRef.current) {
       return;
     }
 
     const state = EditorState.create({
       doc: params.expr || '',
       extensions: [
-        javascript(),
+        languageComp.of(language === 'python' ? python() : javascript()),
+        placeholderComp.of(
+          placeholder(
+            language === 'python' ? PYTHON_PLACEHOLDER : VEGA_PLACEHOLDER,
+          ),
+        ),
         jupyterTheme,
         EditorView.lineWrapping,
-        placeholder("e.g. datum.value > 10 ? 'red' : 'blue'"),
         EditorView.updateListener.of(updateView => {
           if (updateView.docChanged) {
             const value = updateView.state.doc.toString();
-            update({ expr: value });
+            onChange({
+              scheme: 'expression',
+              params: { ...paramsRef.current, expr: value },
+            });
           }
         }),
       ],
@@ -440,6 +455,25 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
     if (!view) {
       return;
     }
+    view.dispatch({
+      effects: [
+        languageComp.reconfigure(
+          language === 'python' ? python() : javascript(),
+        ),
+        placeholderComp.reconfigure(
+          placeholder(
+            language === 'python' ? PYTHON_PLACEHOLDER : VEGA_PLACEHOLDER,
+          ),
+        ),
+      ],
+    });
+  }, [language]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) {
+      return;
+    }
 
     const current = view.state.doc.toString();
     if (current !== params.expr) {
@@ -453,27 +487,79 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
     }
   }, [params.expr]);
 
+  const setLanguage = (lang: 'vega' | 'python') => {
+    if (lang !== language) {
+      update({ language: lang });
+    }
+  };
+
   return (
     <div className="jp-gis-color-ramp-container">
       <div className="jp-gis-symbology-row">
-        <label>
-          Vega Expression{' '}
-          <InfoTip text="Use Vega expressions to style features dynamically (e.g. conditional colors based on attributes like datum.population).">
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span
+            role="tablist"
+            aria-label="Expression language"
+            style={{
+              display: 'inline-flex',
+              border: '1px solid var(--jp-border-color1)',
+              borderRadius: 4,
+              overflow: 'hidden',
+            }}
+          >
+            {(['vega', 'python'] as const).map(lang => (
+              <button
+                key={lang}
+                role="tab"
+                aria-selected={language === lang}
+                onClick={() => setLanguage(lang)}
+                style={{
+                  padding: '2px 8px',
+                  border: 'none',
+                  cursor: 'pointer',
+                  background:
+                    language === lang
+                      ? 'var(--jp-layout-color2)'
+                      : 'transparent',
+                  color: 'var(--jp-ui-font-color1)',
+                  fontWeight: language === lang ? 600 : 400,
+                }}
+              >
+                {lang === 'vega' ? 'Vega' : 'Python'}
+              </button>
+            ))}
+          </span>
+          <InfoTip
+            text={
+              language === 'python'
+                ? 'Write a Python expression; it will be compiled to Vega then to OpenLayers style expressions.'
+                : 'Use Vega expressions to style features dynamically (e.g. conditional colors based on attributes like datum.population).'
+            }
+          >
             <ul style={{ paddingLeft: 16, margin: 0 }}>
               <li>
                 Access fields with <code>datum.fieldName</code>
               </li>
-              <li>
-                Use ternary logic: <code>condition ? a : b</code>
-              </li>
+              {language === 'python' ? (
+                <li>
+                  Use Python conditional syntax:{' '}
+                  <code>a if condition else b</code>
+                </li>
+              ) : (
+                <li>
+                  Use ternary logic: <code>condition ? a : b</code>
+                </li>
+              )}
             </ul>
-            <a
-              href="https://vega.github.io/vega/docs/expressions/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Full Vega Expression Docs
-            </a>
+            {language === 'vega' && (
+              <a
+                href="https://vega.github.io/vega/docs/expressions/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Full Vega Expression Docs
+              </a>
+            )}
           </InfoTip>
         </label>
         <div

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -20,7 +20,9 @@ import {
 } from '@jupytergis/schema';
 import { jupyterTheme } from '@jupyterlab/codemirror';
 import { UUID } from '@lumino/coreutils';
+import { py2vega } from 'py2vega-ts';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { vega2ol } from 'vega2ol';
 
 import { ColorRampName } from '@/src/features/layers/symbology/colorRampUtils';
 import { NumericInput } from '@/src/features/layers/symbology/components/NumericInput';
@@ -404,8 +406,25 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
   const languageComp = useRef(new Compartment()).current;
   const placeholderComp = useRef(new Compartment()).current;
 
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const validationTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
   const VEGA_PLACEHOLDER = "e.g. datum.value > 10 ? 'red' : 'blue'";
   const PYTHON_PLACEHOLDER = "e.g. 'red' if datum.value > 10 else 'blue'";
+
+  const validate = useCallback((expr: string, lang: 'vega' | 'python') => {
+    if (!expr.trim()) {
+      setValidationError(null);
+      return;
+    }
+    try {
+      const vegaExpr = lang === 'python' ? py2vega(expr) : expr;
+      vega2ol(vegaExpr as string);
+      setValidationError(null);
+    } catch (err) {
+      setValidationError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
 
   useEffect(() => {
     paramsRef.current = params;
@@ -434,6 +453,11 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
               scheme: 'expression',
               params: { ...paramsRef.current, expr: value },
             });
+
+            clearTimeout(validationTimerRef.current);
+            validationTimerRef.current = setTimeout(() => {
+              validate(value, paramsRef.current.language ?? 'vega');
+            }, 400);
           }
         }),
       ],
@@ -443,6 +467,8 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
       state,
       parent: editorRef.current,
     });
+
+    validate(params.expr || '', language);
 
     return () => {
       viewRef.current?.destroy();
@@ -467,6 +493,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
         ),
       ],
     });
+    validate(params.expr || '', language);
   }, [language]);
 
   useEffect(() => {
@@ -563,15 +590,35 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
           </InfoTip>
         </label>
         <div
-          ref={editorRef}
-          style={{
-            flex: '1 1 auto',
-            height: 80,
-            border: '1px solid var(--jp-border-color2)',
-            borderRadius: 4,
-            overflow: 'auto',
-          }}
-        />
+          style={{ display: 'flex', flexDirection: 'column', flex: '1 1 auto' }}
+        >
+          <div
+            ref={editorRef}
+            style={{
+              flex: '1 1 auto',
+              height: 80,
+              border: `1px solid ${
+                validationError
+                  ? 'var(--jp-error-color1)'
+                  : 'var(--jp-border-color2)'
+              }`,
+              borderRadius: 4,
+              overflow: 'auto',
+            }}
+          />
+          {validationError && (
+            <div
+              role="alert"
+              style={{
+                color: 'var(--jp-error-color1)',
+                fontSize: 'var(--jp-ui-font-size0)',
+                marginTop: 4,
+              }}
+            >
+              {validationError}
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="jp-gis-symbology-row">

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -520,6 +520,17 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
     }
   };
 
+  const DOCS_LINK = (
+    <a
+      href="https://vega.github.io/vega/docs/expressions/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {' '}
+      Full Vega Expression Docs
+    </a>
+  );
+
   const infoTipContent =
     language === 'python'
       ? {
@@ -535,16 +546,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
               are also available
             </>
           ),
-          docsLink: (
-            <a
-              href="https://vega.github.io/vega/docs/expressions/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {' '}
-              Full Vega Expression Docs
-            </a>
-          ),
+          docsLink: DOCS_LINK,
         }
       : {
           text: `Write a Vega expression; ${VEGA_PLACEHOLDER}`,
@@ -554,16 +556,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
             </>
           ),
           extraHint: null,
-          docsLink: (
-            <a
-              href="https://vega.github.io/vega/docs/expressions/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {' '}
-              Full Vega Expression Docs
-            </a>
-          ),
+          docsLink: DOCS_LINK,
         };
 
   return (

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -532,8 +532,8 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
           <InfoTip
             text={
               language === 'python'
-                ? 'Write a Python expression; it will be compiled to Vega then to OpenLayers style expressions.'
-                : 'Use Vega expressions to style features dynamically (e.g. conditional colors based on attributes like datum.population).'
+                ? `Write a Python expression; ${PYTHON_PLACEHOLDER}`
+                : `Write a Vega expression; ${VEGA_PLACEHOLDER}`
             }
           >
             <ul style={{ paddingLeft: 16, margin: 0 }}>

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -520,6 +520,43 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
     }
   };
 
+  const infoTipContent =
+    language === 'python'
+      ? {
+          text: `Write a Python expression; ${PYTHON_PLACEHOLDER}`,
+          syntaxHint: (
+            <>
+              Use Python conditional syntax: <code>a if condition else b</code>
+            </>
+          ),
+          extraHint: (
+            <>
+              Transpiled to Vega expressions, so Vega functions and constants
+              are also available
+            </>
+          ),
+          docsLink: null,
+        }
+      : {
+          text: `Write a Vega expression; ${VEGA_PLACEHOLDER}`,
+          syntaxHint: (
+            <>
+              Use ternary logic: <code>condition ? a : b</code>
+            </>
+          ),
+          extraHint: null,
+          docsLink: (
+            <a
+              href="https://vega.github.io/vega/docs/expressions/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {' '}
+              Full Vega Expression Docs
+            </a>
+          ),
+        };
+
   return (
     <div className="jp-gis-color-ramp-container">
       <div className="jp-gis-symbology-row">
@@ -556,37 +593,16 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
               </button>
             ))}
           </span>
-          <InfoTip
-            text={
-              language === 'python'
-                ? `Write a Python expression; ${PYTHON_PLACEHOLDER}`
-                : `Write a Vega expression; ${VEGA_PLACEHOLDER}`
-            }
-          >
+          <InfoTip text={infoTipContent.text}>
             <ul style={{ paddingLeft: 16, margin: 0 }}>
               <li>
                 Access fields with <code>datum.fieldName</code>
               </li>
-              {language === 'python' ? (
-                <li>
-                  Use Python conditional syntax:{' '}
-                  <code>a if condition else b</code>
-                </li>
-              ) : (
-                <li>
-                  Use ternary logic: <code>condition ? a : b</code>
-                </li>
-              )}
+              <li>{infoTipContent.syntaxHint}</li>
+              {infoTipContent.extraHint && <li>{infoTipContent.extraHint}</li>}
+              <li>Warning: This is a feature preview.</li>
             </ul>
-            {language === 'vega' && (
-              <a
-                href="https://vega.github.io/vega/docs/expressions/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Full Vega Expression Docs
-              </a>
-            )}
+            {infoTipContent.docsLink}
           </InfoTip>
         </label>
         <div

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -535,7 +535,16 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
               are also available
             </>
           ),
-          docsLink: null,
+          docsLink: (
+            <a
+              href="https://vega.github.io/vega/docs/expressions/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {' '}
+              Full Vega Expression Docs
+            </a>
+          ),
         }
       : {
           text: `Write a Vega expression; ${VEGA_PLACEHOLDER}`,

--- a/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
@@ -25,6 +25,7 @@ import {
   UNormChannel,
 } from '@jupytergis/schema';
 import { ExpressionValue } from 'ol/expr/expression';
+import { py2vega } from 'py2vega-ts';
 import { vega2ol } from 'vega2ol';
 
 import {
@@ -387,9 +388,23 @@ function compileMapping(
         ? compileCategorical(field, scale, featureValues)
         : scale.params.fallback;
     case 'expression':
-      return scale.params.expr
-        ? vega2ol(scale.params.expr)
-        : scale.params.fallback;
+      if (!scale.params.expr) {
+        return scale.params.fallback;
+      }
+      try {
+        const vegaExpr =
+          scale.params.language === 'python'
+            ? py2vega(scale.params.expr)
+            : scale.params.expr;
+        const olExpr = vega2ol(vegaExpr as string);
+        return olExpr ?? scale.params.fallback;
+      } catch (err) {
+        console.debug(
+          `grammarToOLStyle: failed to compile ${scale.params.language ?? 'vega'} expression`,
+          err,
+        );
+        return scale.params.fallback;
+      }
     case 'constant_rgba':
     case 'constant_num':
       return scale.params.value as ExpressionValue;

--- a/packages/jest.base.js
+++ b/packages/jest.base.js
@@ -11,5 +11,5 @@ module.exports = {
     '^.+\\.(tsx?|js)$': ['ts-jest', { tsconfig: './tsconfig.test.json' }],
   },
   // Transform ESM-only packages that have no CommonJS build
-  transformIgnorePatterns: ['/node_modules/(?!(vega2ol|vega-.*|d3-.*|@jupyter/ydoc|ol)/)'],
+  transformIgnorePatterns: ['/node_modules/(?!(py2vega-ts|vega2ol|vega-.*|d3-.*|@jupyter/ydoc|ol)/)'],
 };

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -365,6 +365,12 @@
             "expr": { "type": "string" },
             "fallback": {
               "oneOf": [{ "type": "number" }, { "$ref": "#/definitions/RGBA" }]
+            },
+            "language": {
+              "type": "string",
+              "enum": ["vega", "python"],
+              "default": "vega",
+              "description": "Expression language. 'vega' for TS/JS expressions, 'python' for Python expressions compiled via py2vega."
             }
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,6 +1665,7 @@ __metadata:
     lerna: ^8.1.9
     npm-run-all: ^4.1.5
     prettier: ^3.0.0
+    py2vega-ts: ^0.1.1
     react-draggable: 4.5.0
     rimraf: ^3.0.2
     ts-jest: ^29.4.9
@@ -16148,6 +16149,22 @@ __metadata:
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
   checksum: 4f543b97a487857a791b8e4c139aad54937397dc8177f1353f7da88556bfa40f5c32bfce3856843b1c3fc3a00b8472cceb22957c10b21c14e59e36a02ec9353b
+  languageName: node
+  linkType: hard
+
+"py-ast@npm:^1.0.0":
+  version: 1.9.0
+  resolution: "py-ast@npm:1.9.0"
+  checksum: 81408ccf171aca07b95f13bff582211edea7d79acb8639fa686e591563e2c5bd777221377e931dc4bc2d06ea208a212a7abb55567534ecf1de2218eee09dbbfa
+  languageName: node
+  linkType: hard
+
+"py2vega-ts@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "py2vega-ts@npm:0.1.1"
+  dependencies:
+    py-ast: ^1.0.0
+  checksum: 815ede88317316327e77b4896bca560b78ea4d1dc7382f8ceff9cdab5cd50f239fee53bdb95d936456e59ab8daa9c28d9a712b86872655e9e8a7615b3b450500
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,7 +1670,7 @@ __metadata:
     rimraf: ^3.0.2
     ts-jest: ^29.4.9
     typescript: ^5
-    vega2ol: ^1.1.1
+    vega2ol: ^1.1.3
     webpack: ^5.76.3
     zarrita: ^0.7.3
   languageName: unknown
@@ -19059,12 +19059,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega2ol@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "vega2ol@npm:1.1.1"
+"vega2ol@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "vega2ol@npm:1.1.3"
   dependencies:
     vega-expression: ^6.1.0
-  checksum: 83656e196deccac1f20f190e344eadc25362f1407147905e4f1ca377f9471a465355416c6bc5ed5cd620d0bb098613e0ac00b8203f190be9f77fca518f0dcac4
+  checksum: 51a1f579e139f4ba4b7f8dcc7278e62cc7eb673149a5304f9304769fd7f728e0d39d7ff2c87132df8133749bc06825f438a80be757c2616e543ebfa870ead4b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
This PR adds support to write Python expressions into the UI and than it will convert to Vega expressions with the help of Our [`py2vega-ts`](https://github.com/nakul-py/py2vega-ts) after they will covert into OpenLayer's expression with the help of [`vega2ol`](https://github.com/geojupyter/vega2ol)

https://github.com/user-attachments/assets/7febad07-d189-476c-8aeb-50dedb92a61d

__________
### Also working with `in` expression from Python which converts to `indexof` of Vega  later.

https://github.com/user-attachments/assets/67d4f851-5ee2-4477-8a2e-db26cc4f0bb2



- Closes #1555 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1582.org.readthedocs.build/en/1582/
💡 JupyterLite preview: https://jupytergis--1582.org.readthedocs.build/en/1582/lite
💡 Specta preview: https://jupytergis--1582.org.readthedocs.build/en/1582/lite/specta

<!-- readthedocs-preview jupytergis end -->