### PR TITLE
Fix symbology support for ShapeFiles and GeoParquets

### DIFF
--- a/packages/base/src/features/layers/symbology/hooks/useGetProperties.ts
+++ b/packages/base/src/features/layers/symbology/hooks/useGetProperties.ts
@@ -112,7 +112,7 @@ export const useGetProperties = ({
       const sourceType = source?.type;
       let result: Record<string, Set<any>> = {};
 
-      if (sourceType === 'GeoJSONSource' || sourceType === 'ShapefileSource') {
+      if (['GeoJSONSource', 'ShapefileSource', 'GeoParquetSource'].includes(sourceType)) {
         result = await getGeoJsonProperties({ source, model, sourceType });
       } else if (sourceType === 'VectorTileSource') {
         const sourceId = layer?.parameters?.source;

--- a/packages/base/src/features/layers/symbology/hooks/useGetProperties.ts
+++ b/packages/base/src/features/layers/symbology/hooks/useGetProperties.ts
@@ -1,6 +1,10 @@
 // import { GeoJSONFeature } from 'geojson';
 
-import { GeoJSONFeature1, IJupyterGISModel } from '@jupytergis/schema';
+import {
+  GeoJSONFeature1,
+  IJupyterGISModel,
+  SourceType,
+} from '@jupytergis/schema';
 import { useEffect, useState } from 'react';
 
 import { loadFile } from '@/src/tools';
@@ -19,9 +23,11 @@ interface IUseGetPropertiesResult {
 async function getGeoJsonProperties({
   source,
   model,
+  sourceType,
 }: {
   source: any;
   model: IJupyterGISModel;
+  sourceType: SourceType;
 }): Promise<Record<string, Set<any>>> {
   const result: Record<string, Set<any>> = {};
 
@@ -29,7 +35,7 @@ async function getGeoJsonProperties({
     if (source.parameters.path) {
       return await loadFile({
         filepath: source.parameters.path,
-        type: 'GeoJSONSource',
+        type: sourceType,
         model,
       });
     } else if (source.parameters.data) {
@@ -106,8 +112,8 @@ export const useGetProperties = ({
       const sourceType = source?.type;
       let result: Record<string, Set<any>> = {};
 
-      if (sourceType === 'GeoJSONSource') {
-        result = await getGeoJsonProperties({ source, model });
+      if (sourceType === 'GeoJSONSource' || sourceType === 'ShapefileSource') {
+        result = await getGeoJsonProperties({ source, model, sourceType });
       } else if (sourceType === 'VectorTileSource') {
         const sourceId = layer?.parameters?.source;
         result = getVectorTileProperties({ model, sourceId });

--- a/packages/base/src/features/layers/symbology/hooks/useGetProperties.ts
+++ b/packages/base/src/features/layers/symbology/hooks/useGetProperties.ts
@@ -112,7 +112,11 @@ export const useGetProperties = ({
       const sourceType = source?.type;
       let result: Record<string, Set<any>> = {};
 
-      if (['GeoJSONSource', 'ShapefileSource', 'GeoParquetSource'].includes(sourceType)) {
+      if (
+        ['GeoJSONSource', 'ShapefileSource', 'GeoParquetSource'].includes(
+          sourceType,
+        )
+      ) {
         result = await getGeoJsonProperties({ source, model, sourceType });
       } else if (sourceType === 'VectorTileSource') {
         const sourceId = layer?.parameters?.source;


### PR DESCRIPTION
## Description

We were not getting the feature properties correctly, making it impossible to use the symbology panel

<img width="1421" height="1100" alt="Screenshot From 2026-07-06 15-25-06" src="https://github.com/user-attachments/assets/50444be6-631f-4a65-a720-beed04b8548a" />


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1583.org.readthedocs.build/en/1583/
💡 JupyterLite preview: https://jupytergis--1583.org.readthedocs.build/en/1583/lite
💡 Specta preview: https://jupytergis--1583.org.readthedocs.build/en/1583/lite/specta

<!-- readthedocs-preview jupytergis end -->