### PR TITLE
Document installing pre-releases, other install docs improvements

### DIFF
--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -129,4 +129,3 @@ html[data-theme='dark'] {
   border-radius: 4px;
   padding: 10px;
 }
-}

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -120,3 +120,13 @@ html[data-theme='dark'] {
   margin: 1.5rem 0;
   display: block;
 }
+
+/* Make tabbed displays more comprehensible:
+ *   Right now, it's hard to tell when a tab-set ends.
+ */
+.tab-set {
+  border: 1px solid var(--pst-color-border);
+  border-radius: 4px;
+  padding: 10px;
+}
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx_inline_tabs",
     "sphinx_exercise",
     "sphinx_togglebutton",
+    "sphinx_copybutton",
     "myst_parser",
 ]
 

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -17,6 +17,7 @@ dependencies:
   - sphinx-autodoc-typehints
   - sphinx-exercise
   - sphinx-togglebutton
+  - sphinx-copybutton
   - sphinxcontrib-mermaid
   - sphinxcontrib-bibtex
   - myst-parser

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -1,10 +1,12 @@
 # Installation
 
+:::{important}
 It's always a good idea to use virtual environments.
 Installing into a global environment can get you in trouble later!
 
 These instructions presuppose that you know how to create and activate virtual
 environments with your tool of choice.
+:::
 
 ## Installing the latest stable release
 

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -105,7 +105,15 @@ pip/uv) or `jupytergis-tiler` (for conda/mamba/pixi).
 ## Installing a pre-release
 
 To install a pre-release, replace install commands shown above with these examples.
-Using pre-release `0.16.0a4` as an example:
+Changes include:
+
+* Specify a pre-release version exactly; here's we're using pre-release `0.16.0a4` as an
+  example.
+* When installing a Conda package with mamba/conda/pixi, add the pre-release channel as
+  highest priority channel.
+* When installing a PyPI package with pip/uv, add a flag to allow installing
+  pre-releases.
+
 
 ````{tab} Mamba (recommended)
 ```bash

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -117,7 +117,10 @@ Changes include:
 
 ````{tab} Mamba (recommended)
 ```bash
-mamba install -c conda-forge/label/jupytergis_prerelease -c conda-forge jupytergis==0.16.0a4 qgis
+mamba install \
+  --channel conda-forge/label/jupytergis_prerelease \
+  --channel conda-forge \
+  jupytergis==0.16.0a4 qgis
 jupyter lab  # Start JupyterLab!
 ```
 ````
@@ -133,7 +136,12 @@ jupyter lab  # Start JupyterLab!
 Without a permanent install:
 
 ```bash
-pixi exec -c conda-forge/label/jupytergis_prerelease -c conda-forge --spec jupytergis==0.16.0a4 --spec qgis jupyter lab
+pixi exec \
+  --channel conda-forge/label/jupytergis_prerelease \
+  --channel conda-forge \
+  --spec jupytergis==0.16.0a4 \
+  --spec qgis \
+  jupyter lab
 ```
 
 ````

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -6,7 +6,6 @@ Installing into a global environment can get you in trouble later!
 These instructions presuppose that you know how to create and activate virtual
 environments with your tool of choice.
 
-
 ## Installing the latest stable release
 
 ````{tab} Mamba (recommended)
@@ -93,7 +92,6 @@ docker run -p 8888:8888 ghcr.io/geojupyter/jupytergis:latest
 Docker build source: <https://github.com/geojupyter/jupytergis-docker>
 ````
 
-
 ## Installing dynamic tiling functionality
 
 To use dynamic tiling functionality, you'll need our "tiler" optional dependencies.
@@ -101,19 +99,17 @@ To use dynamic tiling functionality, you'll need our "tiler" optional dependenci
 For any of the above commands, replace `jupytergis` with `jupytergis[tiler]` (for
 pip/uv) or `jupytergis-tiler` (for conda/mamba/pixi).
 
-
 ## Installing a pre-release
 
 To install a pre-release, replace install commands shown above with these examples.
 Changes include:
 
-* Specify a pre-release version exactly; here's we're using pre-release `0.16.0a4` as an
+- Specify a pre-release version exactly; here's we're using pre-release `0.16.0a4` as an
   example.
-* When installing a Conda package with mamba/conda/pixi, add the pre-release channel as
+- When installing a Conda package with mamba/conda/pixi, add the pre-release channel as
   highest priority channel.
-* When installing a PyPI package with pip/uv, add a flag to allow installing
+- When installing a PyPI package with pip/uv, add a flag to allow installing
   pre-releases.
-
 
 ````{tab} Mamba (recommended)
 ```bash

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -1,5 +1,14 @@
 # Installation
 
+It's always a good idea to use virtual environments.
+Installing into a global environment can get you in trouble later!
+
+These instructions presuppose that you know how to create and activate virtual
+environments with your tool of choice.
+
+
+## Installing the latest stable release
+
 ````{tab} Mamba (recommended)
 
 :::{tip}

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -32,24 +32,17 @@ You're on your own!
 :::
 
 ```bash
-pip install jupytergis  # or jupytergis[tiler]!
+pip install jupytergis
 ```
 ````
 
-Once JupyterGIS is installed, start JupyterLab:
+````{tab} Pixi
 
-```bash
-jupyter lab
-```
-
-Or with `conda`:
-
-```bash
-conda install -c conda-forge jupytergis qgis
-jupyter lab
-```
-
-## Pixi
+:::{tip}
+Installing with a conda-based tool (`mamba`, `conda`, `micromamba`, or `pixi`) lets you
+install `qgis` alongside JupyterGIS, enabling `.qgz` file support.
+QGIS is a C++ application and cannot be installed via `pip` or `uv`.
+:::
 
 Install into a project:
 
@@ -64,21 +57,15 @@ Or run directly without a permanent install:
 pixi exec --spec jupytergis --spec qgis jupyter lab
 ```
 
-## pip
+````
+
+````{tab} uv
 
 :::{warning}
-`.qgz` file support is not available — QGIS is not distributed on PyPI.
-:::
-
-```bash
-pip install jupytergis
-jupyter lab
-```
-
-## uv
-
-:::{warning}
-`.qgz` file support is not available — QGIS is not distributed on PyPI.
+When installing with `pip`, QGIS compatibility and optional tiler functions won't work out of the box.
+You may especially run in to problems with Python 3.14, for which [many geospatial
+libraries still lack wheels as of May 2026](https://github.com/Toblerity/Fiona/issues/1504).
+You're on your own!
 :::
 
 Install into a project:
@@ -93,11 +80,19 @@ Or run directly without a permanent install:
 ```bash
 uv run --with jupytergis jupyter lab
 ```
+````
 
-## Docker
+````{tab} Docker
 
 ```bash
 docker run -p 8888:8888 ghcr.io/geojupyter/jupytergis:latest
 ```
 
 Docker build source: <https://github.com/geojupyter/jupytergis-docker>
+````
+
+Once JupyterGIS is installed, start JupyterLab:
+
+```bash
+jupyter lab
+```

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -14,8 +14,7 @@ environments with your tool of choice.
 :::{tip}
 Installing with a conda-based tool (`mamba`, `conda`, `micromamba`, or `pixi`) lets you
 install `qgis` alongside JupyterGIS, enabling `.qgz` file support.
-QGIS is a C++ application and only available as a conda-forge package — it cannot be
-installed via `pip` or `uv`.
+QGIS is a C++ application and cannot be installed via `pip` or `uv`.
 :::
 
 ## Mamba / Conda (recommended)

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -96,3 +96,46 @@ Once JupyterGIS is installed, start JupyterLab:
 ```bash
 jupyter lab
 ```
+
+
+## Installing dynamic tiling functionality
+
+To use dynamic tiling functionality, you'll need our "tiler" optional dependencies.
+
+For any of the above commands, replace `jupytergis` with `jupytergis[tiler]` (for
+pip/uv) or `jupytergis-tiler` (for conda/mamba/pixi).
+
+
+## Installing a pre-release
+
+To install a pre-release, replace install commands shown above with these examples.
+Using pre-release `0.16.0a4` as an example:
+
+````{tab} Mamba (recommended)
+```bash
+mamba install -c conda-forge/label/jupytergis_prerelease -c conda-forge jupytergis==0.16.0a4 qgis
+```
+````
+
+````{tab} pip
+```bash
+pip install --pre jupytergis==0.16.0a4
+```
+````
+
+````{tab} Pixi
+Without a permanent install:
+
+```bash
+pixi exec -c conda-forge/label/jupytergis_prerelease -c conda-forge --spec jupytergis==0.16.0a4 --spec qgis jupyter lab
+```
+
+````
+
+````{tab} uv
+Without a permanent install:
+
+```bash
+uv run --prerelease=allow --with jupytergis==0.16.0a4 jupyter lab
+```
+````

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -118,12 +118,14 @@ Changes include:
 ````{tab} Mamba (recommended)
 ```bash
 mamba install -c conda-forge/label/jupytergis_prerelease -c conda-forge jupytergis==0.16.0a4 qgis
+jupyter lab  # Start JupyterLab!
 ```
 ````
 
 ````{tab} pip
 ```bash
 pip install --pre jupytergis==0.16.0a4
+jupyter lab  # Start JupyterLab!
 ```
 ````
 

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -101,6 +101,10 @@ To use dynamic tiling functionality, you'll need our "tiler" optional dependenci
 For any of the above commands, replace `jupytergis` with `jupytergis[tiler]` (for
 pip/uv) or `jupytergis-tiler` (for conda/mamba/pixi).
 
+:::{note}
+This functionality is available as of version `0.16.0`.
+:::
+
 ## Installing a pre-release
 
 To install a pre-release, replace install commands shown above with these examples.

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -17,8 +17,6 @@ install `qgis` alongside JupyterGIS, enabling `.qgz` file support.
 QGIS is a C++ application and cannot be installed via `pip` or `uv`.
 :::
 
-## Mamba / Conda (recommended)
-
 ```bash
 mamba install -c conda-forge jupytergis qgis
 ```

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -19,6 +19,7 @@ QGIS is a C++ application and cannot be installed via `pip` or `uv`.
 
 ```bash
 mamba install -c conda-forge jupytergis qgis
+jupyter lab  # Start JupyterLab!
 ```
 ````
 
@@ -33,6 +34,7 @@ You're on your own!
 
 ```bash
 pip install jupytergis
+jupyter lab  # Start JupyterLab!
 ```
 ````
 
@@ -48,7 +50,7 @@ Install into a project:
 
 ```bash
 pixi add jupytergis qgis
-pixi run jupyter lab
+pixi run jupyter lab  # Start JupyterLab!
 ```
 
 Or run directly without a permanent install:
@@ -72,7 +74,7 @@ Install into a project:
 
 ```bash
 uv add jupytergis
-uv run jupyter lab
+uv run jupyter lab  # Start JupyterLab!
 ```
 
 Or run directly without a permanent install:
@@ -90,12 +92,6 @@ docker run -p 8888:8888 ghcr.io/geojupyter/jupytergis:latest
 
 Docker build source: <https://github.com/geojupyter/jupytergis-docker>
 ````
-
-Once JupyterGIS is installed, start JupyterLab:
-
-```bash
-jupyter lab
-```
 
 
 ## Installing dynamic tiling functionality


### PR DESCRIPTION
## Description

Resolves #1571 

There's also some weird stuff going on with this page (e.g. duplicate instructions and mixing of tabs and headers, leading to a hard-to-navigate page and ToC that doesn't include the recommended install method, see screenshot), and I fixed those issues.

<img width="486" height="482" alt="image" src="https://github.com/user-attachments/assets/b2caabc0-10a2-47d3-a653-5c83bc90878d" />

* Added section: Installing a pre-release
* Added section: Installing dynamic tiling functionality
* Put install commands in tab-sets
* Make tab-sets more visually comprehensible with padding and border.
* Add "copy" button to code cells with [sphinx-copybutton](https://sphinx-copybutton.readthedocs.io/en/latest/)


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1584.org.readthedocs.build/en/1584/
💡 JupyterLite preview: https://jupytergis--1584.org.readthedocs.build/en/1584/lite
💡 Specta preview: https://jupytergis--1584.org.readthedocs.build/en/1584/lite/specta

<!-- readthedocs-preview jupytergis end -->