### PR TITLE
Allow title editing for markdown segments

### DIFF
--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -62,6 +62,7 @@ function SegmentEditor({
   showSegmentAnimation,
   onContentModeChange,
   onContentChange,
+  onLayerNameChange,
   onTransitionChange,
   onRemoveSegment,
 }: {
@@ -75,6 +76,7 @@ function SegmentEditor({
   showSegmentAnimation: boolean;
   onContentModeChange: (mode: StorySegmentDisplayMode) => void;
   onContentChange: (patch: SegmentContentPatch) => void;
+  onLayerNameChange: (name: string) => void;
   onTransitionChange: (patch: SegmentTransitionPatch) => void;
   onRemoveSegment: () => void;
 }): JSX.Element {
@@ -100,7 +102,7 @@ function SegmentEditor({
           <TitleInput
             value={displayTitle}
             onChange={title => {
-              onContentChange({ title });
+              onLayerNameChange(title);
             }}
           />
         </div>
@@ -270,6 +272,7 @@ export function StoryEditorDialogBody({
     updateStory,
     updateSegmentContentMode,
     updateSegmentContent,
+    updateSegmentLayerName,
     updateSegmentTransition,
   } = useStoryEditorSegmentList(model, commands);
 
@@ -312,6 +315,9 @@ export function StoryEditorDialogBody({
               }}
               onContentChange={patch => {
                 updateSegmentContent(selectedSegment.id, patch);
+              }}
+              onLayerNameChange={name => {
+                updateSegmentLayerName(selectedSegment.id, name);
               }}
               onTransitionChange={patch => {
                 updateSegmentTransition(selectedSegment.id, patch);

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -11,6 +11,7 @@ import { SegmentLayerOverrides } from '@/src/features/story/components/SegmentLa
 import { SegmentMarkdownEditor } from '@/src/features/story/components/SegmentMarkdownEditor';
 import { SegmentModePicker } from '@/src/features/story/components/SegmentModePicker';
 import { StoryEditorHeaderBar } from '@/src/features/story/components/StoryEditorHeaderBar';
+import { TitleInput } from '@/src/features/story/components/TitleInput';
 import { StoryEditorSection } from '@/src/features/story/components/StoryEditorSection';
 import { StoryEditorSegmentList } from '@/src/features/story/components/StoryEditorSegmentList';
 import { useStoryEditorSegmentList } from '@/src/features/story/hooks/useStoryEditorSegmentList';
@@ -98,7 +99,12 @@ function SegmentEditor({
           <div className="jgis-story-editor-eyebrow">
             Segment {segment.index + 1}
           </div>
-          <h3 className="jgis-story-editor-segment-title">{displayTitle}</h3>
+          <TitleInput
+            value={displayTitle}
+            onChange={title => {
+              onContentChange({ title });
+            }}
+          />
         </div>
         <Button
           type="button"
@@ -149,15 +155,6 @@ function SegmentEditor({
 
           <StoryEditorSection triggerText="Content" defaultOpen>
             <div className="jgis-story-editor-stack">
-              <label className="jgis-story-editor-field">
-                <span>Title</span>
-                <Input
-                  value={contentTitle}
-                  onChange={event => {
-                    onContentChange({ title: event.target.value });
-                  }}
-                />
-              </label>
               <SegmentImageUrlField
                 value={imageUrl}
                 onChange={nextImageUrl => {

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -11,9 +11,9 @@ import { SegmentLayerOverrides } from '@/src/features/story/components/SegmentLa
 import { SegmentMarkdownEditor } from '@/src/features/story/components/SegmentMarkdownEditor';
 import { SegmentModePicker } from '@/src/features/story/components/SegmentModePicker';
 import { StoryEditorHeaderBar } from '@/src/features/story/components/StoryEditorHeaderBar';
-import { TitleInput } from '@/src/features/story/components/TitleInput';
 import { StoryEditorSection } from '@/src/features/story/components/StoryEditorSection';
 import { StoryEditorSegmentList } from '@/src/features/story/components/StoryEditorSegmentList';
+import { TitleInput } from '@/src/features/story/components/TitleInput';
 import { useStoryEditorSegmentList } from '@/src/features/story/hooks/useStoryEditorSegmentList';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import type {
@@ -35,7 +35,6 @@ import {
   getStorySegmentDisplayTitle,
 } from '@/src/features/story/utils/storySegmentViewItems';
 import { Button } from '@/src/shared/components/Button';
-import { Input } from '@/src/shared/components/Input';
 import {
   NativeSelect,
   NativeSelectOption,
@@ -82,7 +81,6 @@ function SegmentEditor({
   const [layersOpen, setLayersOpen] = useState(true);
   const [animationOpen, setAnimationOpen] = useState(false);
   const displayTitle = getStorySegmentDisplayTitle(segment);
-  const contentTitle = segment.activeSlide?.content?.title ?? '';
   const imageUrl = segment.activeSlide?.content?.image ?? '';
   const markdown = getStoryMarkdownFromSlide(segment.activeSlide);
   const segmentMode = getSegmentDisplayMode(segment.activeSlide);

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -3,9 +3,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IJGISStoryMap, IJupyterGISModel } from '@jupytergis/schema';
 import React, { useState, type RefObject } from 'react';
 
+import { TitleInput } from '@/src/features/story/components/TitleInput';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import { resolveStoryPresentationColorForInput } from '@/src/features/story/utils/spectaPresentation';
-import { TitleInput } from '@/src/features/story/components/TitleInput';
 import {
   formatGradientLabel,
   formatStoryTypeLabel,

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -1,10 +1,11 @@
 import { faGear } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IJGISStoryMap, IJupyterGISModel } from '@jupytergis/schema';
-import React, { useEffect, useState, type RefObject } from 'react';
+import React, { useState, type RefObject } from 'react';
 
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import { resolveStoryPresentationColorForInput } from '@/src/features/story/utils/spectaPresentation';
+import { TitleInput } from '@/src/features/story/components/TitleInput';
 import {
   formatGradientLabel,
   formatStoryTypeLabel,
@@ -32,54 +33,6 @@ export interface IStoryEditorHeaderBarProps {
   segmentCount: number;
   onUpdateStory: (patch: Partial<IJGISStoryMap>) => void;
   portalContainerRef: RefObject<HTMLElement | null>;
-}
-
-function StoryTitleInput({
-  value,
-  onChange,
-  disabled = false,
-}: {
-  value: string;
-  onChange: (title: string) => void;
-  disabled?: boolean;
-}): JSX.Element {
-  const [draft, setDraft] = useState(value);
-
-  useEffect(() => {
-    setDraft(value);
-  }, [value]);
-
-  return (
-    <Input
-      className="jgis-story-editor-toolbar-title"
-      value={disabled ? '' : draft}
-      placeholder={disabled ? 'No story' : 'Untitled story'}
-      disabled={disabled}
-      aria-label="Story title"
-      onChange={event => {
-        setDraft(event.target.value);
-      }}
-      onKeyDown={event => {
-        if (disabled) {
-          return;
-        }
-
-        if (event.key === 'Enter') {
-          event.preventDefault();
-          event.currentTarget.blur();
-        } else if (event.key === 'Escape') {
-          event.preventDefault();
-          setDraft(value);
-          event.currentTarget.blur();
-        }
-      }}
-      onBlur={() => {
-        if (!disabled && draft !== value) {
-          onChange(draft);
-        }
-      }}
-    />
-  );
 }
 
 function StorySettingsPopover({
@@ -186,7 +139,7 @@ export function StoryEditorHeaderBar({
 
   return (
     <div className="jgis-story-editor-context-bar">
-      <StoryTitleInput
+      <TitleInput
         value={story?.title ?? ''}
         disabled={!story}
         onChange={title => {

--- a/packages/base/src/features/story/components/TitleInput.tsx
+++ b/packages/base/src/features/story/components/TitleInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Input } from '@/src/shared/components/Input';
 

--- a/packages/base/src/features/story/components/TitleInput.tsx
+++ b/packages/base/src/features/story/components/TitleInput.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import { Input } from '@/src/shared/components/Input';
+
+export function TitleInput({
+  value,
+  onChange,
+  disabled = false,
+}: {
+  value: string;
+  onChange: (title: string) => void;
+  disabled?: boolean;
+}): JSX.Element {
+  const [draft, setDraft] = useState(value);
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  return (
+    <Input
+      className="jgis-story-editor-toolbar-title"
+      value={disabled ? '' : draft}
+      placeholder="No Story"
+      disabled={disabled}
+      aria-label="Title"
+      onChange={event => {
+        setDraft(event.target.value);
+      }}
+      onKeyDown={event => {
+        if (disabled) {
+          return;
+        }
+
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          event.currentTarget.blur();
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          setDraft(value);
+          event.currentTarget.blur();
+        }
+      }}
+      onBlur={() => {
+        if (!disabled && draft !== value) {
+          onChange(draft);
+        }
+      }}
+    />
+  );
+}

--- a/packages/base/src/features/story/hooks/useStoryEditorSegmentList.ts
+++ b/packages/base/src/features/story/hooks/useStoryEditorSegmentList.ts
@@ -11,6 +11,7 @@ import {
   type SegmentContentPatch,
   updateSegmentContent as applySegmentContent,
   updateSegmentContentMode as applySegmentContentMode,
+  updateSegmentLayerName as applySegmentLayerName,
 } from '@/src/features/story/utils/storySegmentContent';
 import { disposeSegmentMarkdown } from '@/src/features/story/utils/storySegmentMarkdownSharedModel';
 import {
@@ -36,6 +37,7 @@ interface IUseStoryEditorSegmentListResult {
     mode: StorySegmentDisplayMode,
   ) => void;
   updateSegmentContent: (segmentId: string, patch: SegmentContentPatch) => void;
+  updateSegmentLayerName: (segmentId: string, name: string) => void;
   updateSegmentTransition: (
     segmentId: string,
     patch: SegmentTransitionPatch,
@@ -222,6 +224,13 @@ export function useStoryEditorSegmentList(
     [model],
   );
 
+  const updateSegmentLayerName = useCallback(
+    (segmentId: string, name: string) => {
+      applySegmentLayerName(model, segmentId, name);
+    },
+    [model],
+  );
+
   const updateSegmentTransition = useCallback(
     (segmentId: string, patch: SegmentTransitionPatch) => {
       applySegmentTransition(model, segmentId, patch);
@@ -243,6 +252,7 @@ export function useStoryEditorSegmentList(
     updateStory,
     updateSegmentContentMode,
     updateSegmentContent,
+    updateSegmentLayerName,
     updateSegmentTransition,
   };
 }

--- a/packages/base/src/features/story/storyEditorDialog.tsx
+++ b/packages/base/src/features/story/storyEditorDialog.tsx
@@ -44,13 +44,10 @@ export class StoryEditorWidget extends Dialog<boolean> {
     this.addClass('jgis-story-editor-dialog');
   }
 
-  // Prevent Jupyter Dialog from from eating enter key presses
+  // Prevent Jupyter Dialog from from eating key presses
   protected _evtKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Enter') {
-      const active = document.activeElement;
-      if (active?.closest('.cm-editor')) {
-        return;
-      }
+    if (event.key === 'Enter' || event.key === 'Escape') {
+      return;
     }
 
     super._evtKeydown(event);

--- a/packages/base/src/features/story/utils/storySegmentContent.ts
+++ b/packages/base/src/features/story/utils/storySegmentContent.ts
@@ -74,3 +74,20 @@ export function updateSegmentContent(
 
   return true;
 }
+
+export function updateSegmentLayerName(
+  model: IJupyterGISModel,
+  segmentId: string,
+  name: string,
+): boolean {
+  const layer = model.getLayer(segmentId);
+
+  if (!layer || layer.type !== 'StorySegmentLayer') {
+    return false;
+  }
+
+  const nextName = name.trim();
+  model.sharedModel.updateLayer(segmentId, { ...layer, name: nextName });
+
+  return true;
+}

--- a/packages/base/src/features/story/utils/storySegmentViewItems.ts
+++ b/packages/base/src/features/story/utils/storySegmentViewItems.ts
@@ -33,11 +33,6 @@ export function buildStorySegmentViewItems(
 export function getStorySegmentDisplayTitle(
   item: IStorySegmentViewItem,
 ): string {
-  const contentTitle = item.activeSlide?.content?.title;
-  if (typeof contentTitle === 'string' && contentTitle.trim() !== '') {
-    return contentTitle;
-  }
-
   return item.layerName;
 }
 


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix issue where you couldn't actually change the title of markdown segments. Replaces usage of `content:title` field with the segment name and removes `title` field from the content section of the story editor. 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1600.org.readthedocs.build/en/1600/
💡 JupyterLite preview: https://jupytergis--1600.org.readthedocs.build/en/1600/lite
💡 Specta preview: https://jupytergis--1600.org.readthedocs.build/en/1600/lite/specta

<!-- readthedocs-preview jupytergis end -->