### PR TITLE
stop empty `spatial_extent` from blocking graph editing

### DIFF
--- a/packages/base/src/features/layers/openeo/addLayerDialog.tsx
+++ b/packages/base/src/features/layers/openeo/addLayerDialog.tsx
@@ -18,6 +18,7 @@ import {
   IOpenEOTemplate,
   IOpenEOTemplateParams,
   OPENEO_TEMPLATES,
+  normalizeSpatialExtent,
 } from './templates';
 import {
   IValidationError,
@@ -496,24 +497,15 @@ const Form: React.FC<IFormProps> = ({
     setServerMode('select');
   };
 
-  const updateBbox = (key: keyof IBodyState['params']['bbox'], v: string) => {
-    const num = parseFloat(v);
-    guardReseed(() =>
-      update({
-        params: {
-          ...state.params,
-          bbox: { ...state.params.bbox, [key]: isNaN(num) ? 0 : num },
-        },
-        editedGraph: null,
-      }),
-    );
-  };
-
   // Memoize the graph so its identity only changes when the contents
   // actually change. Otherwise every render produces a new object,
   // re-firing validation and reassigning ModelBuilder.value mid-edit.
   const effectiveGraph = React.useMemo(() => {
-    return state.editedGraph ?? template.buildGraph(state.params);
+    const graph = state.editedGraph ?? template.buildGraph(state.params);
+    // An empty `spatial_extent: {}` (e.g. from a graph authored before we
+    // sent a real extent) is invalid per the openEO schema; normalize it to
+    // `null` so validation doesn't block an otherwise-valid graph.
+    return normalizeSpatialExtent(graph);
   }, [state.editedGraph, state.templateId, state.params]);
   const effectiveGraphJson = React.useMemo(
     () => JSON.stringify(effectiveGraph, null, 2),
@@ -1062,7 +1054,7 @@ const Form: React.FC<IFormProps> = ({
             </section>
 
             <section className="jp-openeo-section">
-              <h4>Region &amp; time</h4>
+              <h4>Collection &amp; time</h4>
               <label className="jp-openeo-field">
                 <span>Collection</span>
                 <input
@@ -1079,44 +1071,6 @@ const Form: React.FC<IFormProps> = ({
                   }}
                 />
               </label>
-              <div className="jp-openeo-bbox-grid">
-                <label>
-                  <span>West</span>
-                  <input
-                    type="number"
-                    step="0.001"
-                    value={state.params.bbox.west}
-                    onChange={e => updateBbox('west', e.target.value)}
-                  />
-                </label>
-                <label>
-                  <span>East</span>
-                  <input
-                    type="number"
-                    step="0.001"
-                    value={state.params.bbox.east}
-                    onChange={e => updateBbox('east', e.target.value)}
-                  />
-                </label>
-                <label>
-                  <span>South</span>
-                  <input
-                    type="number"
-                    step="0.001"
-                    value={state.params.bbox.south}
-                    onChange={e => updateBbox('south', e.target.value)}
-                  />
-                </label>
-                <label>
-                  <span>North</span>
-                  <input
-                    type="number"
-                    step="0.001"
-                    value={state.params.bbox.north}
-                    onChange={e => updateBbox('north', e.target.value)}
-                  />
-                </label>
-              </div>
               <label className="jp-openeo-field">
                 <span>Start date</span>
                 <input

--- a/packages/base/src/features/layers/openeo/templates.ts
+++ b/packages/base/src/features/layers/openeo/templates.ts
@@ -15,6 +15,39 @@ export interface IOpenEOTemplate {
 const DEFAULT_BBOX = { west: -74.0, south: 40.7, east: -73.9, north: 40.8 };
 const DEFAULT_TEMPORAL: [string, string] = ['2022-04-15', '2022-12-31'];
 
+/**
+ * openEO's `load_collection` requires `spatial_extent` to be a full bbox
+ * (west/south/east/north) or `null` — an empty `{}` is invalid and gets
+ * rejected by validation. We ignore spatial_extent for the tiled layers we
+ * render anyway, so normalize an empty extent to `null` (which the schema
+ * accepts) rather than blocking the user on an otherwise-valid graph.
+ * Returns the graph unchanged (same reference) when there is nothing to fix.
+ */
+export function normalizeSpatialExtent(
+  graph: Record<string, any>,
+): Record<string, any> {
+  let changed = false;
+  const out: Record<string, any> = {};
+  for (const [nodeId, node] of Object.entries(graph)) {
+    const ext = node?.arguments?.spatial_extent;
+    const isEmptyObject =
+      ext &&
+      typeof ext === 'object' &&
+      !Array.isArray(ext) &&
+      Object.keys(ext).length === 0;
+    if (isEmptyObject) {
+      changed = true;
+      out[nodeId] = {
+        ...node,
+        arguments: { ...node.arguments, spatial_extent: null },
+      };
+    } else {
+      out[nodeId] = node;
+    }
+  }
+  return changed ? out : graph;
+}
+
 function loadCollection(
   params: IOpenEOTemplateParams,
   bands: string[],

--- a/packages/base/style/openeo.css
+++ b/packages/base/style/openeo.css
@@ -713,28 +713,6 @@
   color: var(--jp-ui-font-color1);
 }
 
-.jp-openeo-bbox-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 6px;
-  margin-bottom: 8px;
-}
-
-.jp-openeo-bbox-grid label {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.jp-openeo-bbox-grid span {
-  font-size: var(--jp-ui-font-size0);
-  color: var(--jp-ui-font-color2);
-}
-
-.jp-openeo-bbox-grid input {
-  padding: 3px 6px;
-}
-
 /* Right pane toolbar */
 .jp-openeo-toolbar {
   display: flex;


### PR DESCRIPTION
## Description

Shall close #1599

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1603.org.readthedocs.build/en/1603/
💡 JupyterLite preview: https://jupytergis--1603.org.readthedocs.build/en/1603/lite
💡 Specta preview: https://jupytergis--1603.org.readthedocs.build/en/1603/lite/specta

<!-- readthedocs-preview jupytergis end -->