### PR TITLE
Fix filters ui-test for live-apply "when" clause

### DIFF
--- a/ui-tests/tests/filters.spec.ts
+++ b/ui-tests/tests/filters.spec.ts
@@ -36,25 +36,21 @@ test.describe('#filters', () => {
     // Verify grammar panel is shown
     await expect(dialog.getByText('Layer 1')).toBeVisible();
 
-    // Click the "+" button in the layer-level "when" row to open the add form
+    // Click the "+" button in the layer-level "when" row. This commits a
+    // default predicate live and shows it as an inline, always-editable form.
     const whenRow = dialog.locator('.jp-gis-grammar-when-row').first();
     await whenRow.locator('.jp-gis-grammar-when-add-btn').click();
 
-    // The WhenAddForm should appear with a type selector defaulting to "geometry type"
-    const typeSelect = whenRow.locator('select').first();
-    await expect(typeSelect).toBeVisible();
+    // The inline "when" form should appear with a type selector defaulting to
+    // "geometry type" (predicate is already committed — there is no confirm step).
+    const whenForm = whenRow.locator('.jp-gis-grammar-when-form').first();
+    await expect(whenForm).toBeVisible();
+    const typeSelect = whenForm.locator('select').first();
     await expect(typeSelect).toHaveValue('geometryType');
 
-    // Confirm the predicate (geometry type = Point by default)
-    await whenRow.locator('button[title="Add predicate"]').click();
-
-    // A "when" chip should appear showing the condition
-    const chip = whenRow.locator('.jp-gis-grammar-when-chip').first();
-    await expect(chip).toBeVisible();
-
-    // Remove the chip
-    await chip.locator('button').click();
-    await expect(chip).not.toBeAttached();
+    // Remove the condition
+    await whenForm.locator('button[title="Remove condition"]').click();
+    await expect(whenForm).not.toBeAttached();
 
     await dialog.getByText('Cancel').click();
   });


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1605.org.readthedocs.build/en/1605/
💡 JupyterLite preview: https://jupytergis--1605.org.readthedocs.build/en/1605/lite
💡 Specta preview: https://jupytergis--1605.org.readthedocs.build/en/1605/lite/specta

<!-- readthedocs-preview jupytergis end -->