### PR TITLE
Update jupyter-tiler ndsi example so we lazily visualize the bigger dataset instead

### DIFF
--- a/examples/tiler-ndsi.ipynb
+++ b/examples/tiler-ndsi.ipynb
@@ -49,7 +49,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "!pip install gcsfs dask distributed matplotlib"
@@ -454,40 +456,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "doc = GISDocument(\n",
-    "    longitude=1.7092461496028497,\n",
-    "    latitude=42.530360648396055,\n",
-    "    zoom=11.38992197518327,\n",
-    ")\n",
-    "doc.add_raster_layer(\n",
-    "    name=\"Basemap\",\n",
-    "    url=\"https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}\",\n",
-    ")\n",
-    "doc"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "38",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "await doc.add_data_array_layer(\n",
-    "    name=\"NDSI Layer\",\n",
-    "    data_array=sub_ds.ndsi,\n",
-    "    colormap_name=\"viridis\",\n",
-    "    colormap_range=(vmin, vmax),\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "39",
    "metadata": {},
@@ -774,6 +742,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4f82da07-066d-43f1-a19d-ab9cb91cf2f2",
+   "metadata": {},
+   "source": [
+    "### Now let's visualize it with JupyterGIS and jupyter-tiler!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20199f48-1de7-4845-b60d-c564447124eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc = GISDocument(\n",
+    "    longitude=1.7092461496028497,\n",
+    "    latitude=42.530360648396055,\n",
+    "    zoom=11.38992197518327,\n",
+    ")\n",
+    "doc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2af48a32-cdf7-4aac-abd2-085f2005249b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await doc.add_data_array_layer(\n",
+    "    name=\"NDSI Layer\",\n",
+    "    data_array=complete_ds.ndsi.isel(time=0, drop=True),\n",
+    "    colormap_name=\"viridis\",\n",
+    "    colormap_range=(-1, 1),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "62",
    "metadata": {},
    "source": [
@@ -882,7 +888,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.12.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/examples/tiler-ndsi.ipynb
+++ b/examples/tiler-ndsi.ipynb
@@ -49,9 +49,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!pip install gcsfs dask distributed matplotlib"
@@ -457,7 +455,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "37",
    "metadata": {},
    "source": [
     "### Compute snow percentage over the area\n",
@@ -470,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "39",
    "metadata": {},
    "source": [
     "On this particular patch, you should get over 77% of snow cover."
@@ -487,7 +485,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Compute a time series analysis\n",
@@ -506,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,7 +524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "43",
    "metadata": {},
    "source": [
     "It's really interesting when using Dask to start a real Distributed cluster (even on one machine like we've done above).\n",
@@ -542,7 +540,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "44",
    "metadata": {},
    "source": [
     "### Define some functions to build Datasets\n",
@@ -562,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "46",
    "metadata": {},
    "source": [
     "Try this function on the green band of \"SENTINEL2B_20191224-104910-788_L2A_T31TCH_C_V2-2\", so with a coarsen=2 value, and whatch the HTML repr. What do you notice?"
@@ -591,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "48",
    "metadata": {},
    "source": [
     "Now, we'll define a create_dataset(product) function.\n",
@@ -611,7 +609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +625,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "50",
    "metadata": {},
    "source": [
     "Try it on the above product"
@@ -636,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,7 +643,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "52",
    "metadata": {},
    "source": [
     "### Build our time serie\n",
@@ -662,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +684,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "55",
    "metadata": {},
    "source": [
     "So now, create a list by creating a dataset from all of the products above.\n",
@@ -697,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +715,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "58",
    "metadata": {},
    "source": [
     "### Add NDSI and snow mask\n",
@@ -730,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +740,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f82da07-066d-43f1-a19d-ab9cb91cf2f2",
+   "id": "60",
    "metadata": {},
    "source": [
     "### Now let's visualize it with JupyterGIS and jupyter-tiler!"
@@ -751,7 +749,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20199f48-1de7-4845-b60d-c564447124eb",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -766,7 +764,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2af48a32-cdf7-4aac-abd2-085f2005249b",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -780,7 +778,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "### Compute snow percentage time series over the whole image\n",
@@ -803,7 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -816,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -825,7 +823,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "### And what is the result?\n",
@@ -842,7 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +850,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -861,7 +859,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "source": [
     "# Extends other statistics\n",
@@ -889,13 +887,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.13"
-  },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "state": {},
-    "version_major": 2,
-    "version_minor": 0
-   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

The example was showing a smaller dataset that is already in-memory. I update the example so we visualize the bigger dataset that's lazy

<img width="1543" height="856" alt="Screenshot From 2026-07-08 16-04-54" src="https://github.com/user-attachments/assets/52a44c55-f793-43ad-bc07-80d94c8bb80b" />


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1606.org.readthedocs.build/en/1606/
💡 JupyterLite preview: https://jupytergis--1606.org.readthedocs.build/en/1606/lite
💡 Specta preview: https://jupytergis--1606.org.readthedocs.build/en/1606/lite/specta

<!-- readthedocs-preview jupytergis end -->