### PR TITLE
Add xeus-python dependency in bot run

### DIFF
--- a/.github/workflows/update_galata_references.yaml
+++ b/.github/workflows/update_galata_references.yaml
@@ -38,8 +38,9 @@ jobs:
         with:
           environment-name: gis
           create-args: >-
-            python=3.12
-            jupyterlab
+            python=3.13
+            pip
+            xeus-python>=0.19
 
       - name: Setup pip cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5


### PR DESCRIPTION
## Description

Merging right away, I need it for https://github.com/geojupyter/jupytergis/pull/1528

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1611.org.readthedocs.build/en/1611/
💡 JupyterLite preview: https://jupytergis--1611.org.readthedocs.build/en/1611/lite
💡 Specta preview: https://jupytergis--1611.org.readthedocs.build/en/1611/lite/specta

<!-- readthedocs-preview jupytergis end -->