### PR TITLE
Update releaser

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@b48fcdb87e70c45789abd80d4042b06641e47b46 # v1
 
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: next

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prep Release
         id: prep-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version_spec: ${{ github.event.inputs.version_spec }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Populate Release
         id: populate-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.event.inputs.branch }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Finalize Release
         id: finalize-release
-        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@634ac751f8a58d3d4a19b63f58aad138e6355cc8 # v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@cf9c1ac90471e0978ef4d4f106b5d9b8917cb7af
         with:
           token: ${{ steps.app-token.outputs.token }}
           release_url: ${{ steps.populate-release.outputs.release_url }}


### PR DESCRIPTION
## Description

https://github.com/jupyter-server/jupyter_releaser/releases/tag/v1.11.2

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1613.org.readthedocs.build/en/1613/
💡 JupyterLite preview: https://jupytergis--1613.org.readthedocs.build/en/1613/lite
💡 Specta preview: https://jupytergis--1613.org.readthedocs.build/en/1613/lite/specta

<!-- readthedocs-preview jupytergis end -->