### PR TITLE
Prevent Enter from closing dialogs with editor fields

### DIFF
--- a/packages/base/src/features/layers/openeo/addLayerDialog.tsx
+++ b/packages/base/src/features/layers/openeo/addLayerDialog.tsx
@@ -1,11 +1,7 @@
-import {
-  Dialog,
-  Notification,
-  ReactWidget,
-  showDialog,
-} from '@jupyterlab/apputils';
+import { Dialog, Notification, ReactWidget } from '@jupyterlab/apputils';
 import * as React from 'react';
 
+import { EditorAwareDialog } from '@/src/shared/editorAwareDialog';
 import { fetchBackendCatalog, IBackendCatalog } from '@/src/tools';
 import {
   connect as openEOConnect,
@@ -1403,14 +1399,14 @@ export async function showAddOpenEOLayerDialog(
     },
   );
 
-  const resultPromise = showDialog<IOpenEODialogResult | null>({
+  const resultPromise = new EditorAwareDialog<IOpenEODialogResult | null>({
     title: options.title ?? 'Add OpenEO Layer',
     body,
     buttons: [
       Dialog.cancelButton(),
       Dialog.okButton({ label: options.okLabel ?? 'Add Layer' }),
     ],
-  });
+  }).launch();
   // Apply the initial disabled state once the dialog mounts.
   window.setTimeout(applyOk, 0);
   const result = await resultPromise;

--- a/packages/base/src/features/layers/symbology/symbologyDialog.tsx
+++ b/packages/base/src/features/layers/symbology/symbologyDialog.tsx
@@ -1,10 +1,10 @@
 import { IJupyterGISModel } from '@jupytergis/schema';
-import { Dialog } from '@jupyterlab/apputils';
 import { IStateDB } from '@jupyterlab/statedb';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { Signal } from '@lumino/signaling';
 import React, { useEffect, useState } from 'react';
 
+import { EditorAwareDialog } from '@/src/shared/editorAwareDialog';
 import { SymbologyTab, SymbologyValue } from '@/src/types';
 import Grammar from './Grammar';
 
@@ -117,7 +117,7 @@ export const SymbologyDialog: React.FC<ISymbologyDialogProps> = ({
   return <>{componentToRender}</>;
 };
 
-export class SymbologyWidget extends Dialog<boolean> {
+export class SymbologyWidget extends EditorAwareDialog<boolean> {
   private okSignal: Signal<SymbologyWidget, null>;
 
   constructor(options: ISymbologyWidgetOptions) {

--- a/packages/base/src/shared/editorAwareDialog.ts
+++ b/packages/base/src/shared/editorAwareDialog.ts
@@ -1,0 +1,53 @@
+import { Dialog } from '@jupyterlab/apputils';
+
+// Input types that are not text entry, where Enter may still submit.
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'submit',
+  'reset',
+  'checkbox',
+  'radio',
+  'range',
+  'color',
+  'file',
+  'image',
+]);
+
+/**
+ * Whether the event target is a text field where `Enter` should edit the value
+ * rather than submit the dialog (CodeMirror, textarea, contenteditable, or a
+ * text-entry input).
+ */
+function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (
+    target.tagName === 'TEXTAREA' ||
+    target.isContentEditable ||
+    target.closest('.cm-editor') !== null
+  ) {
+    return true;
+  }
+  return (
+    target instanceof HTMLInputElement && !NON_TEXT_INPUT_TYPES.has(target.type)
+  );
+}
+
+/**
+ * A `Dialog` that does not submit on `Enter` while a text editor is focused, so
+ * expression/JSON editors can accept newlines. See geojupyter/jupytergis#1598.
+ */
+export class EditorAwareDialog<T> extends Dialog<T> {
+  handleEvent(event: Event): void {
+    if (
+      event.type === 'keydown' &&
+      (event as KeyboardEvent).key === 'Enter' &&
+      isTextEntryTarget(event.target)
+    ) {
+      // Let the editor handle Enter instead of resolving the dialog.
+      return;
+    }
+    super.handleEvent(event);
+  }
+}


### PR DESCRIPTION
## Description

Shall close #1598 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1619.org.readthedocs.build/en/1619/
💡 JupyterLite preview: https://jupytergis--1619.org.readthedocs.build/en/1619/lite
💡 Specta preview: https://jupytergis--1619.org.readthedocs.build/en/1619/lite/specta

<!-- readthedocs-preview jupytergis end -->