### PR TITLE
Add a setting to control gap between markdown segments. 

### DIFF
--- a/packages/base/src/features/story/__tests__/getHandoffGapHeight.spec.ts
+++ b/packages/base/src/features/story/__tests__/getHandoffGapHeight.spec.ts
@@ -1,0 +1,32 @@
+import { getHandoffGapHeight } from '../utils/getHandoffGapHeight';
+
+const MAP_HEIGHT = 350;
+
+describe('getHandoffGapHeight', () => {
+  it('returns map height when either segment is a map', () => {
+    expect(getHandoffGapHeight('map', 'map', MAP_HEIGHT, false)).toBe(
+      MAP_HEIGHT,
+    );
+    expect(getHandoffGapHeight('map', 'markdown', MAP_HEIGHT, false)).toBe(
+      MAP_HEIGHT,
+    );
+    expect(getHandoffGapHeight('markdown', 'map', MAP_HEIGHT, false)).toBe(
+      MAP_HEIGHT,
+    );
+    expect(getHandoffGapHeight('map', 'markdown', MAP_HEIGHT, true)).toBe(
+      MAP_HEIGHT,
+    );
+  });
+
+  it('returns zero for markdown-to-markdown when gap is disabled', () => {
+    expect(getHandoffGapHeight('markdown', 'markdown', MAP_HEIGHT, false)).toBe(
+      0,
+    );
+  });
+
+  it('returns map height for markdown-to-markdown when gap is enabled', () => {
+    expect(getHandoffGapHeight('markdown', 'markdown', MAP_HEIGHT, true)).toBe(
+      MAP_HEIGHT,
+    );
+  });
+});

--- a/packages/base/src/features/story/__tests__/listStoryScrollTrack.spec.ts
+++ b/packages/base/src/features/story/__tests__/listStoryScrollTrack.spec.ts
@@ -129,4 +129,51 @@ describe('buildListStoryScrollTrack', () => {
       contentMode: 'markdown',
     });
   });
+
+  it('omits gap between markdown segments when markdownSegmentGap is false', () => {
+    const layout = buildListStoryScrollTrack({
+      items: [
+        storyItem('a', 0, 'markdown', 'one'),
+        storyItem('b', 1, 'markdown', 'two'),
+      ],
+      viewportHeight: 400,
+      heightsById: { a: 120, b: 180 },
+      markdownSegmentGap: false,
+    });
+
+    expect(layout.segments[0]).toMatchObject({
+      start: 0,
+      height: 120,
+      end: 120,
+    });
+    expect(layout.segments[1]).toMatchObject({
+      start: 120,
+      height: 180,
+      end: 300,
+    });
+  });
+
+  it('inserts gap between markdown segments when markdownSegmentGap is true', () => {
+    const layout = buildListStoryScrollTrack({
+      items: [
+        storyItem('a', 0, 'markdown', 'one'),
+        storyItem('b', 1, 'markdown', 'two'),
+      ],
+      viewportHeight: 400,
+      mapViewportHeight: 350,
+      heightsById: { a: 120, b: 180 },
+      markdownSegmentGap: true,
+    });
+
+    expect(layout.segments[0]).toMatchObject({
+      start: 0,
+      height: 120,
+      end: 120 + 350,
+    });
+    expect(layout.segments[1]).toMatchObject({
+      start: 470,
+      height: 180,
+      end: 650,
+    });
+  });
 });

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -16,6 +16,7 @@ import type {
   IStorySegmentViewItem,
 } from '@/src/features/story/types/types';
 import { isIntraSegmentScroll } from '@/src/features/story/utils/computeListStoryScrollState';
+import { getHandoffGapHeight } from '@/src/features/story/utils/getHandoffGapHeight';
 import { getSegmentDisplayMode } from '@/src/features/story/utils/listStoryScrollTrack';
 import { getSpectaPresentationCssVars } from '@/src/features/story/utils/spectaPresentation';
 import {
@@ -156,6 +157,20 @@ export function ListStoryStageOverlay({
   }, [segmentTransition, activeItem]);
 
   const intraSegmentScroll = isIntraSegmentScroll(transition);
+  const markdownSegmentGap = story?.markdownSegmentGap === true;
+
+  const handoffGapHeight = useMemo((): number => {
+    if (!transition || intraSegmentScroll || stageHeight <= 0) {
+      return 0;
+    }
+
+    return getHandoffGapHeight(
+      transition.fromMode,
+      transition.toMode,
+      stageHeight,
+      markdownSegmentGap,
+    );
+  }, [transition, intraSegmentScroll, stageHeight, markdownSegmentGap]);
 
   const { fromIndex, toIndex, fromPaneConfig, toPaneConfig } = useMemo(() => {
     if (!model || !transition) {
@@ -277,7 +292,14 @@ export function ListStoryStageOverlay({
       imageWaitCancelRef.current?.();
       imageWaitCancelRef.current = null;
     };
-  }, [fromIndex, toIndex, fromPaneConfig, toPaneConfig, intraSegmentScroll]);
+  }, [
+    fromIndex,
+    toIndex,
+    fromPaneConfig,
+    toPaneConfig,
+    intraSegmentScroll,
+    handoffGapHeight,
+  ]);
 
   useLayoutEffect(() => {
     measureTransitionRef.current?.();
@@ -324,7 +346,9 @@ export function ListStoryStageOverlay({
         />
         {!intraSegmentScroll ? (
           <>
-            <div className="jgis-story-segment-transition-gap" aria-hidden />
+            {handoffGapHeight > 0 ? (
+              <div className="jgis-story-segment-transition-gap" aria-hidden />
+            ) : null}
             <SegmentOverlayPane
               pane="to"
               segmentIndex={toIndex}

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -127,6 +127,7 @@ function buildOverlayStack({
       transition.fromIndex,
       markdownSegmentGap,
     );
+
     if (lookaheadIndex !== null) {
       const lookaheadItem = items.find(item => item.index === lookaheadIndex);
       panes.push({
@@ -136,6 +137,7 @@ function buildOverlayStack({
         config: buildPaneConfig(lookaheadItem, 'markdown'),
       });
     }
+
     return { panes, includeGap: false };
   }
 
@@ -155,6 +157,7 @@ function buildOverlayStack({
     transition.toIndex,
     markdownSegmentGap,
   );
+
   if (lookaheadIndex !== null) {
     const lookaheadItem = items.find(item => item.index === lookaheadIndex);
     panes.push({
@@ -402,11 +405,9 @@ export function ListStoryStageOverlay({
       const fromReady =
         !fromPaneIsMarkdown ||
         markdownRenderedRef.current.has(fromStackPane.segmentIndex);
+
       if (fromReady && rawTravel > 0) {
-        stableTravelRef.current = Math.max(
-          stableTravelRef.current,
-          rawTravel,
-        );
+        stableTravelRef.current = Math.max(stableTravelRef.current, rawTravel);
       }
       const travel = stableTravelRef.current;
 

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -9,6 +9,7 @@ import React, {
 
 import { ListStoryMapOverlayPanel } from '@/src/features/story/components/ListStoryMapOverlayPanel';
 import { ListStoryOverlayMarkdown } from '@/src/features/story/components/ListStoryOverlayMarkdown';
+import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
 import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSegmentIndex';
 import type {
   IListStorySegmentTransition,
@@ -17,7 +18,10 @@ import type {
 } from '@/src/features/story/types/types';
 import { isIntraSegmentScroll } from '@/src/features/story/utils/computeListStoryScrollState';
 import { getHandoffGapHeight } from '@/src/features/story/utils/getHandoffGapHeight';
-import { getSegmentDisplayMode } from '@/src/features/story/utils/listStoryScrollTrack';
+import {
+  getScrollTrackSegmentHeight,
+  getSegmentDisplayMode,
+} from '@/src/features/story/utils/listStoryScrollTrack';
 import { getSpectaPresentationCssVars } from '@/src/features/story/utils/spectaPresentation';
 import {
   buildStorySegmentViewItems,
@@ -34,10 +38,24 @@ type SegmentOverlayPaneConfig =
   | { type: 'markdown'; markdown: string }
   | { type: 'map'; segmentIndex: number };
 
+type OverlayPaneRole = 'from' | 'to' | 'lookahead';
+
 const EMPTY_MARKDOWN_PANE: SegmentOverlayPaneConfig = {
   type: 'markdown',
   markdown: '',
 };
+
+interface IOverlayStackPane {
+  role: OverlayPaneRole;
+  segmentIndex: number;
+  mode: StorySegmentDisplayMode;
+  config: SegmentOverlayPaneConfig;
+}
+
+interface IOverlayStack {
+  panes: IOverlayStackPane[];
+  includeGap: boolean;
+}
 
 function buildPaneConfig(
   item: IStorySegmentViewItem | undefined,
@@ -55,8 +73,103 @@ function buildPaneConfig(
   };
 }
 
+function getMarkdownLookaheadIndex(
+  items: IStorySegmentViewItem[],
+  afterIndex: number,
+  markdownSegmentGap: boolean,
+): number | null {
+  if (markdownSegmentGap) {
+    return null;
+  }
+
+  const current = items.find(item => item.index === afterIndex);
+  const next = items.find(item => item.index === afterIndex + 1);
+  if (!current || !next) {
+    return null;
+  }
+
+  if (
+    getSegmentDisplayMode(current.activeSlide) === 'markdown' &&
+    getSegmentDisplayMode(next.activeSlide) === 'markdown'
+  ) {
+    return next.index;
+  }
+
+  return null;
+}
+
+function buildOverlayStack({
+  transition,
+  intraSegmentScroll,
+  items,
+  handoffGapHeight,
+  markdownSegmentGap,
+}: {
+  transition: IListStorySegmentTransition;
+  intraSegmentScroll: boolean;
+  items: IStorySegmentViewItem[];
+  handoffGapHeight: number;
+  markdownSegmentGap: boolean;
+}): IOverlayStack {
+  const fromItem = items.find(item => item.index === transition.fromIndex);
+
+  const fromPane: IOverlayStackPane = {
+    role: 'from',
+    segmentIndex: transition.fromIndex,
+    mode: transition.fromMode,
+    config: buildPaneConfig(fromItem, transition.fromMode),
+  };
+
+  if (intraSegmentScroll) {
+    const panes = [fromPane];
+    const lookaheadIndex = getMarkdownLookaheadIndex(
+      items,
+      transition.fromIndex,
+      markdownSegmentGap,
+    );
+    if (lookaheadIndex !== null) {
+      const lookaheadItem = items.find(item => item.index === lookaheadIndex);
+      panes.push({
+        role: 'lookahead',
+        segmentIndex: lookaheadIndex,
+        mode: 'markdown',
+        config: buildPaneConfig(lookaheadItem, 'markdown'),
+      });
+    }
+    return { panes, includeGap: false };
+  }
+
+  const toItem = items.find(item => item.index === transition.toIndex);
+  const panes: IOverlayStackPane[] = [
+    fromPane,
+    {
+      role: 'to',
+      segmentIndex: transition.toIndex,
+      mode: transition.toMode,
+      config: buildPaneConfig(toItem, transition.toMode),
+    },
+  ];
+
+  const lookaheadIndex = getMarkdownLookaheadIndex(
+    items,
+    transition.toIndex,
+    markdownSegmentGap,
+  );
+  if (lookaheadIndex !== null) {
+    const lookaheadItem = items.find(item => item.index === lookaheadIndex);
+    panes.push({
+      role: 'lookahead',
+      segmentIndex: lookaheadIndex,
+      mode: 'markdown',
+      config: buildPaneConfig(lookaheadItem, 'markdown'),
+    });
+  }
+
+  return { panes, includeGap: handoffGapHeight > 0 };
+}
+
 interface ISegmentOverlayPaneProps {
-  pane: 'from' | 'to';
+  pane: OverlayPaneRole;
   segmentIndex: number;
   config: SegmentOverlayPaneConfig;
   storyData: IJGISStoryMap;
@@ -77,6 +190,7 @@ function SegmentOverlayPane({
   return (
     <div
       data-pane={pane}
+      data-segment-index={segmentIndex}
       className={`jgis-story-segment-overlay-pane jgis-story-${
         isMap ? 'map' : 'markdown'
       }-scroll-pane`}
@@ -89,7 +203,7 @@ function SegmentOverlayPane({
         />
       ) : config.markdown ? (
         <ListStoryOverlayMarkdown
-          key={`pane-${pane}-seg-${segmentIndex}`}
+          key={`seg-${segmentIndex}`}
           source={config.markdown}
           onRendered={onMarkdownRendered}
         />
@@ -120,12 +234,16 @@ export function ListStoryStageOverlay({
 }: IListStoryStageOverlayProps): JSX.Element | null {
   const overlayRef = useRef<HTMLDivElement>(null);
   const stackRef = useRef<HTMLDivElement>(null);
-  const fromMarkdownRenderedRef = useRef(false);
+  const markdownRenderedRef = useRef<Set<number>>(new Set());
   const imageWaitCancelRef = useRef<(() => void) | null>(null);
   const measureTransitionRef = useRef<(() => void) | null>(null);
+  const measuredTransitionKeyRef = useRef('');
+  const measureTransitionKeyRef = useRef('');
+  const stableTravelRef = useRef(0);
   const [stageHeight, setStageHeight] = useState(0);
   const [transitionTranslatePx, setTransitionTranslatePx] = useState(0);
   const currentIndex = useCurrentSegmentIndex(model);
+  const { scrollTrackLayout } = useListStoryScrollTrackContext();
 
   const story = model?.getSelectedStory().story ?? null;
   const items = useMemo(
@@ -172,36 +290,36 @@ export function ListStoryStageOverlay({
     );
   }, [transition, intraSegmentScroll, stageHeight, markdownSegmentGap]);
 
-  const { fromIndex, toIndex, fromPaneConfig, toPaneConfig } = useMemo(() => {
-    if (!model || !transition) {
-      return {
-        fromIndex: currentIndex,
-        toIndex: currentIndex,
-        fromPaneConfig: EMPTY_MARKDOWN_PANE,
-        toPaneConfig: EMPTY_MARKDOWN_PANE,
-      };
+  const overlayStack = useMemo((): IOverlayStack => {
+    if (!transition) {
+      return { panes: [], includeGap: false };
     }
 
-    const fromItem = items.find(item => item.index === transition.fromIndex);
-    const toItem = items.find(item => item.index === transition.toIndex);
+    return buildOverlayStack({
+      transition,
+      intraSegmentScroll,
+      items,
+      handoffGapHeight,
+      markdownSegmentGap,
+    });
+  }, [
+    transition,
+    intraSegmentScroll,
+    items,
+    handoffGapHeight,
+    markdownSegmentGap,
+  ]);
 
-    const fromPaneConfig = buildPaneConfig(fromItem, transition.fromMode);
-    const toPaneConfig = intraSegmentScroll
-      ? EMPTY_MARKDOWN_PANE
-      : buildPaneConfig(toItem, transition.toMode);
-
-    const paneState = {
-      fromIndex: transition.fromIndex,
-      toIndex: transition.toIndex,
-      fromPaneConfig,
-      toPaneConfig,
-    };
-
-    return paneState;
-  }, [items, currentIndex, transition, intraSegmentScroll, model]);
+  const fromStackPane = overlayStack.panes.find(pane => pane.role === 'from');
+  const toStackPane = overlayStack.panes.find(pane => pane.role === 'to');
+  const lookaheadStackPane = overlayStack.panes.find(
+    pane => pane.role === 'lookahead',
+  );
 
   const overlayHeight = Math.max(stageHeight, 0);
   const transitionProgress = transition?.progress ?? 0;
+  const fromIndex = fromStackPane?.segmentIndex ?? currentIndex;
+  const toIndex = toStackPane?.segmentIndex ?? fromIndex;
 
   useLayoutEffect(() => {
     const parent = overlayRef.current?.parentElement;
@@ -226,34 +344,51 @@ export function ListStoryStageOverlay({
     };
   }, [model, story]);
 
-  const handleFromMarkdownRendered = useCallback((): void => {
-    fromMarkdownRenderedRef.current = true;
-    measureTransitionRef.current?.();
+  const handleMarkdownRendered = useCallback(
+    (segmentIndex: number): void => {
+      markdownRenderedRef.current.add(segmentIndex);
 
-    const stack = stackRef.current;
-    const fromPane = stack?.querySelector('[data-pane="from"]');
-    if (!(fromPane instanceof HTMLElement)) {
-      return;
-    }
+      if (segmentIndex !== fromIndex) {
+        return;
+      }
 
-    imageWaitCancelRef.current?.();
-    imageWaitCancelRef.current = whenImagesSettled(fromPane, () => {
-      imageWaitCancelRef.current = null;
       measureTransitionRef.current?.();
-    });
-  }, []);
+
+      const stack = stackRef.current;
+      const fromPane = stack?.querySelector('[data-pane="from"]');
+      if (!(fromPane instanceof HTMLElement)) {
+        return;
+      }
+
+      imageWaitCancelRef.current?.();
+      imageWaitCancelRef.current = whenImagesSettled(fromPane, () => {
+        imageWaitCancelRef.current = null;
+        measureTransitionRef.current?.();
+      });
+    },
+    [fromIndex],
+  );
 
   useLayoutEffect(() => {
     const stack = stackRef.current;
-    if (!stack) {
+    if (!stack || !transition || !fromStackPane) {
       return;
     }
 
     const fromPaneIsMarkdown =
-      fromPaneConfig.type === 'markdown' && Boolean(fromPaneConfig.markdown);
-    fromMarkdownRenderedRef.current = !fromPaneIsMarkdown;
-    imageWaitCancelRef.current?.();
-    imageWaitCancelRef.current = null;
+      fromStackPane.config.type === 'markdown' &&
+      Boolean(fromStackPane.config.markdown);
+
+    const transitionKey = intraSegmentScroll
+      ? `intra:${fromIndex}`
+      : `handoff:${fromIndex}:${toIndex}:${transition.fromMode}:${transition.toMode}`;
+
+    if (measureTransitionKeyRef.current !== transitionKey) {
+      measureTransitionKeyRef.current = transitionKey;
+      measuredTransitionKeyRef.current = '';
+      stableTravelRef.current = 0;
+      setTransitionTranslatePx(0);
+    }
 
     const measure = (): void => {
       const fromPane = stack.querySelector('[data-pane="from"]');
@@ -262,13 +397,24 @@ export function ListStoryStageOverlay({
         return;
       }
 
-      const gap = stack.querySelector('.jgis-story-segment-transition-gap');
-      const gapHeight =
-        gap instanceof HTMLElement && !intraSegmentScroll
-          ? gap.offsetHeight
-          : 0;
+      const gapHeight = overlayStack.includeGap ? handoffGapHeight : 0;
+      const rawTravel = fromPane.offsetHeight + gapHeight;
+      const fromReady =
+        !fromPaneIsMarkdown ||
+        markdownRenderedRef.current.has(fromStackPane.segmentIndex);
+      if (fromReady && rawTravel > 0) {
+        stableTravelRef.current = Math.max(
+          stableTravelRef.current,
+          rawTravel,
+        );
+      }
+      const travel = stableTravelRef.current;
 
-      const travel = fromPane.offsetHeight + gapHeight;
+      if (!fromReady) {
+        return;
+      }
+
+      measuredTransitionKeyRef.current = transitionKey;
       setTransitionTranslatePx(prev => (prev === travel ? prev : travel));
     };
 
@@ -281,7 +427,10 @@ export function ListStoryStageOverlay({
     }
 
     const ro = new ResizeObserver(() => {
-      if (!fromPaneIsMarkdown || fromMarkdownRenderedRef.current) {
+      if (
+        !fromPaneIsMarkdown ||
+        markdownRenderedRef.current.has(fromStackPane.segmentIndex)
+      ) {
         measure();
       }
     });
@@ -293,11 +442,14 @@ export function ListStoryStageOverlay({
       imageWaitCancelRef.current = null;
     };
   }, [
+    transition,
+    fromStackPane,
+    toStackPane,
+    lookaheadStackPane,
+    overlayStack.includeGap,
+    intraSegmentScroll,
     fromIndex,
     toIndex,
-    fromPaneConfig,
-    toPaneConfig,
-    intraSegmentScroll,
     handoffGapHeight,
   ]);
 
@@ -306,8 +458,30 @@ export function ListStoryStageOverlay({
   }, [stageHeight]);
 
   const overlaySized = stageHeight > 0;
+  const currentTransitionKey = intraSegmentScroll
+    ? `intra:${fromIndex}`
+    : `handoff:${fromIndex}:${toIndex}:${transition?.fromMode ?? ''}:${transition?.toMode ?? ''}`;
+  const scrollFromHeight = getScrollTrackSegmentHeight(
+    scrollTrackLayout,
+    fromIndex,
+  );
+  const isMdToMdNoGap =
+    !intraSegmentScroll &&
+    handoffGapHeight === 0 &&
+    transition?.fromMode === 'markdown' &&
+    transition?.toMode === 'markdown';
+  const translateIsCurrent =
+    measuredTransitionKeyRef.current === currentTransitionKey &&
+    transitionTranslatePx > 0;
+  const effectiveTranslatePx = translateIsCurrent
+    ? transitionTranslatePx
+    : isMdToMdNoGap && scrollFromHeight
+      ? scrollFromHeight
+      : handoffGapHeight > 0
+        ? stageHeight
+        : 0;
 
-  if (!model || !story || !activeItem || !transition) {
+  if (!model || !story || !activeItem || !transition || !fromStackPane) {
     return null;
   }
 
@@ -325,7 +499,7 @@ export function ListStoryStageOverlay({
             ? {
                 height: overlayHeight,
                 '--jgis-handoff-gap-height': `${stageHeight}px`,
-                '--jgis-transition-translate': `${transitionTranslatePx || stageHeight}px`,
+                '--jgis-transition-translate': `${effectiveTranslatePx}px`,
               }
             : {}),
         } as React.CSSProperties
@@ -334,29 +508,57 @@ export function ListStoryStageOverlay({
       <div ref={stackRef} className="jgis-story-segment-transition-stack">
         <SegmentOverlayPane
           pane="from"
-          segmentIndex={fromIndex}
-          config={fromPaneConfig}
+          segmentIndex={fromStackPane.segmentIndex}
+          config={fromStackPane.config}
           storyData={story}
           items={items}
           onMarkdownRendered={
-            fromPaneConfig.type === 'markdown' && fromPaneConfig.markdown
-              ? handleFromMarkdownRendered
+            fromStackPane.config.type === 'markdown' &&
+            fromStackPane.config.markdown
+              ? () => {
+                  handleMarkdownRendered(fromStackPane.segmentIndex);
+                }
               : undefined
           }
         />
-        {!intraSegmentScroll ? (
+        {toStackPane ? (
           <>
-            {handoffGapHeight > 0 ? (
+            {overlayStack.includeGap ? (
               <div className="jgis-story-segment-transition-gap" aria-hidden />
             ) : null}
             <SegmentOverlayPane
               pane="to"
-              segmentIndex={toIndex}
-              config={toPaneConfig}
+              segmentIndex={toStackPane.segmentIndex}
+              config={toStackPane.config}
               storyData={story}
               items={items}
+              onMarkdownRendered={
+                toStackPane.config.type === 'markdown' &&
+                toStackPane.config.markdown
+                  ? () => {
+                      handleMarkdownRendered(toStackPane.segmentIndex);
+                    }
+                  : undefined
+              }
             />
           </>
+        ) : null}
+        {lookaheadStackPane ? (
+          <SegmentOverlayPane
+            pane="lookahead"
+            segmentIndex={lookaheadStackPane.segmentIndex}
+            config={lookaheadStackPane.config}
+            storyData={story}
+            items={items}
+            onMarkdownRendered={
+              lookaheadStackPane.config.type === 'markdown' &&
+              lookaheadStackPane.config.markdown
+                ? () => {
+                    handleMarkdownRendered(lookaheadStackPane.segmentIndex);
+                  }
+                : undefined
+            }
+          />
         ) : null}
       </div>
     </div>

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -95,6 +95,17 @@ function StorySettingsPopover({
                 }}
               />
             </label>
+            {story.storyType === STORY_TYPE.verticalScroll ? (
+              <label className="jgis-story-editor-toggle-row">
+                <span>Gap between markdown segments</span>
+                <Switch
+                  checked={story.markdownSegmentGap === true}
+                  onCheckedChange={checked => {
+                    onUpdateStory({ markdownSegmentGap: checked });
+                  }}
+                />
+              </label>
+            ) : null}
             <label className="jgis-story-editor-field">
               <span>Background color</span>
               <Input

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -8,6 +8,7 @@ import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import { resolveStoryPresentationColorForInput } from '@/src/features/story/utils/spectaPresentation';
 import {
   formatGradientLabel,
+  formatMarkdownSegmentGapLabel,
   formatStoryTypeLabel,
 } from '@/src/features/story/utils/storyEditorLabels';
 import Badge from '@/src/shared/components/Badge';
@@ -167,6 +168,11 @@ export function StoryEditorHeaderBar({
         {story ? (
           <span className="jgis-story-editor-context-meta">
             {formatGradientLabel(story.showGradient)}
+          </span>
+        ) : null}
+        {story?.storyType === STORY_TYPE.verticalScroll ? (
+          <span className="jgis-story-editor-context-meta">
+            {formatMarkdownSegmentGapLabel(story.markdownSegmentGap)}
           </span>
         ) : null}
         {story && canPreview ? (

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -86,6 +86,8 @@ export function ListStoryScrollTrackProvider({
   const mapViewportHeightOption =
     mapViewportHeight > 0 ? mapViewportHeight : undefined;
 
+  const markdownSegmentGap = storyData?.markdownSegmentGap === true;
+
   const buildScrollTrackLayout = useCallback(
     (
       nextHeightsById: Readonly<Record<string, number>>,
@@ -95,8 +97,9 @@ export function ListStoryScrollTrackProvider({
         viewportHeight,
         mapViewportHeight: mapViewportHeightOption,
         heightsById: nextHeightsById,
+        markdownSegmentGap,
       }),
-    [items, viewportHeight, mapViewportHeightOption],
+    [items, viewportHeight, mapViewportHeightOption, markdownSegmentGap],
   );
 
   const syncScrollerMetrics = useCallback((scroller: HTMLDivElement): void => {
@@ -207,6 +210,7 @@ export function ListStoryScrollTrackProvider({
                 viewportHeight,
                 mapViewportHeight: mapViewportHeight || undefined,
                 heightsById: prev,
+                markdownSegmentGap,
               })
             : null;
 
@@ -230,7 +234,7 @@ export function ListStoryScrollTrackProvider({
         return next;
       });
     },
-    [enabled, items, mapViewportHeight, viewportHeight],
+    [enabled, items, mapViewportHeight, viewportHeight, markdownSegmentGap],
   );
 
   const { segmentBeingMeasured, reportHeight, completeMeasure } =

--- a/packages/base/src/features/story/utils/getHandoffGapHeight.ts
+++ b/packages/base/src/features/story/utils/getHandoffGapHeight.ts
@@ -2,8 +2,8 @@ import type { StorySegmentDisplayMode } from '@/src/features/story/types/types';
 
 /**
  * Height of the handoff gap between two list-story segments.
- * Map-adjacent transitions always use the full stage height; markdown-only
- * transitions use it only when markdownSegmentGap is enabled.
+ * Map-adjacent transitions always use the full stage height.
+ * markdown-only transitions use it only when markdownSegmentGap is enabled.
  */
 export function getHandoffGapHeight(
   fromMode: StorySegmentDisplayMode,

--- a/packages/base/src/features/story/utils/getHandoffGapHeight.ts
+++ b/packages/base/src/features/story/utils/getHandoffGapHeight.ts
@@ -1,0 +1,19 @@
+import type { StorySegmentDisplayMode } from '@/src/features/story/types/types';
+
+/**
+ * Height of the handoff gap between two list-story segments.
+ * Map-adjacent transitions always use the full stage height; markdown-only
+ * transitions use it only when markdownSegmentGap is enabled.
+ */
+export function getHandoffGapHeight(
+  fromMode: StorySegmentDisplayMode,
+  toMode: StorySegmentDisplayMode,
+  mapHeight: number,
+  markdownSegmentGap: boolean,
+): number {
+  if (fromMode === 'map' || toMode === 'map') {
+    return mapHeight;
+  }
+
+  return markdownSegmentGap ? mapHeight : 0;
+}

--- a/packages/base/src/features/story/utils/listStoryScrollTrack.ts
+++ b/packages/base/src/features/story/utils/listStoryScrollTrack.ts
@@ -6,7 +6,6 @@ import type {
   StorySegmentDisplayMode,
   IStorySegmentViewItem,
 } from '@/src/features/story/types/types';
-
 import { getHandoffGapHeight } from './getHandoffGapHeight';
 
 const MARKDOWN_LINE_HEIGHT_PX = 28;

--- a/packages/base/src/features/story/utils/listStoryScrollTrack.ts
+++ b/packages/base/src/features/story/utils/listStoryScrollTrack.ts
@@ -7,6 +7,8 @@ import type {
   IStorySegmentViewItem,
 } from '@/src/features/story/types/types';
 
+import { getHandoffGapHeight } from './getHandoffGapHeight';
+
 const MARKDOWN_LINE_HEIGHT_PX = 28;
 const MARKDOWN_CONTENT_PADDING_PX = 32;
 const MIN_MARKDOWN_VIEWPORT_RATIO = 0.5;
@@ -18,6 +20,8 @@ interface IBuildListStoryScrollTrackInput {
   /** Map stage height (`.jGIS-Mainview-Container`); defaults to viewportHeight. */
   mapViewportHeight?: number;
   heightsById?: Readonly<Record<string, number>>;
+  /** Gap between consecutive markdown segments; map-adjacent gaps are always kept. */
+  markdownSegmentGap?: boolean;
 }
 
 export function estimateMarkdownHeight(
@@ -77,6 +81,7 @@ export function buildListStoryScrollTrack({
   viewportHeight,
   mapViewportHeight,
   heightsById = {},
+  markdownSegmentGap = false,
 }: IBuildListStoryScrollTrackInput): IListStoryScrollTrackLayout | null {
   if (!items.length || viewportHeight <= 0) {
     return null;
@@ -87,19 +92,29 @@ export function buildListStoryScrollTrack({
     segmentHeightForItem(item, viewportHeight, mapHeight, heightsById),
   );
 
-  const handoffGap = mapHeight;
+  const modes: StorySegmentDisplayMode[] = items.map(item =>
+    getSegmentDisplayMode(item.activeSlide),
+  );
 
   let offset = 0;
   const segments: IListStoryScrollTrackSegment[] = items.map((item, i) => {
     const start = offset;
     const height = heights[i].height;
-    const gapAfter = i < items.length - 1 ? handoffGap : 0;
+    const gapAfter =
+      i < items.length - 1
+        ? getHandoffGapHeight(
+            modes[i],
+            modes[i + 1],
+            mapHeight,
+            markdownSegmentGap,
+          )
+        : 0;
     const end = start + height + gapAfter;
     offset = end;
     return {
       id: item.id,
       index: item.index,
-      contentMode: getSegmentDisplayMode(item.activeSlide),
+      contentMode: modes[i],
       height,
       measured: heights[i].measured,
       start,

--- a/packages/base/src/features/story/utils/listStoryScrollTrack.ts
+++ b/packages/base/src/features/story/utils/listStoryScrollTrack.ts
@@ -1,5 +1,3 @@
-import type { IStorySegmentLayer } from '@jupytergis/schema';
-
 import type {
   IListStoryScrollTrackLayout,
   IListStoryScrollTrackSegment,
@@ -128,7 +126,7 @@ export function buildListStoryScrollTrack({
 }
 
 export function getSegmentDisplayMode(
-  activeSlide: IStorySegmentLayer['parameters'] | undefined,
+  activeSlide: IStorySegmentViewItem['activeSlide'],
 ): StorySegmentDisplayMode {
   if (activeSlide?.content?.contentMode === 'markdown') {
     return 'markdown';

--- a/packages/base/src/features/story/utils/storyEditorLabels.ts
+++ b/packages/base/src/features/story/utils/storyEditorLabels.ts
@@ -9,3 +9,9 @@ export function formatStoryTypeLabel(storyType: string | undefined): string {
 export function formatGradientLabel(showGradient: boolean | undefined): string {
   return showGradient !== false ? 'Gradient on' : 'Solid background';
 }
+
+export function formatMarkdownSegmentGapLabel(
+  markdownSegmentGap: boolean | undefined,
+): string {
+  return markdownSegmentGap === true ? 'Markdown gap on' : 'Markdown gap off';
+}

--- a/packages/schema/src/schema/project/jgis.json
+++ b/packages/schema/src/schema/project/jgis.json
@@ -175,6 +175,12 @@
           "description": "Toggle the gradient background in presentation mode.",
           "default": true
         },
+        "markdownSegmentGap": {
+          "type": "boolean",
+          "title": "Gap between markdown segments",
+          "description": "Inserts a full-stage gap between consecutive markdown segments in vertical scroll stories.",
+          "default": false
+        },
         "presentationBgColor": {
           "type": "string",
           "title": "Presentation Background Color",


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Close #1608 

Adds a setting to control if there is a gap between markdown segments in vertical scroll mode. 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1621.org.readthedocs.build/en/1621/
💡 JupyterLite preview: https://jupytergis--1621.org.readthedocs.build/en/1621/lite
💡 Specta preview: https://jupytergis--1621.org.readthedocs.build/en/1621/lite/specta

<!-- readthedocs-preview jupytergis end -->