### PR TITLE
Fixup ambiguously named generated types

### DIFF
--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -317,6 +317,16 @@
         }
       }
     },
+    "IConstantNumScaleParams": {
+      "type": "object",
+      "title": "IConstantNumParams",
+      "description": "Constant numeric payload.",
+      "required": ["value"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "type": "number" }
+      }
+    },
     "IConstantNumScale": {
       "type": "object",
       "title": "IConstantNumScale",
@@ -325,16 +335,7 @@
       "additionalProperties": false,
       "properties": {
         "scheme": { "const": "constant_num" },
-        "params": {
-          "type": "object",
-          "title": "IConstantNumParams",
-          "description": "Constant numeric payload.",
-          "required": ["value"],
-          "additionalProperties": false,
-          "properties": {
-            "value": { "type": "number" }
-          }
-        }
+        "params": { "$ref": "#/definitions/IConstantNumScaleParams" }
       }
     },
     "IIdentityScale": {

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -251,6 +251,42 @@
         }
       }
     },
+    "IScalarScaleParams": {
+      "type": "object",
+      "title": "IScalarScaleParams",
+      "description": "Parameters controlling scalar interpolation and fallback behavior.",
+      "required": ["domain", "range", "mode", "nStops", "fallback"],
+      "additionalProperties": false,
+      "properties": {
+        "domain": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "range": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "fallback": { "type": "number" },
+        "scalarStops": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "IScalarStop",
+            "description": "Explicit input stop to output value mapping.",
+            "required": ["stop", "output"],
+            "additionalProperties": false,
+            "properties": {
+              "stop": { "type": "number" },
+              "output": { "type": "number" }
+            }
+          }
+        }
+      }
+    },
     "IScalarScale": {
       "type": "object",
       "title": "IScalarScale",
@@ -259,42 +295,7 @@
       "additionalProperties": false,
       "properties": {
         "scheme": { "const": "scalar" },
-        "params": {
-          "type": "object",
-          "title": "IScalarScaleParams",
-          "description": "Parameters controlling scalar interpolation and fallback behavior.",
-          "required": ["domain", "range", "mode", "nStops", "fallback"],
-          "additionalProperties": false,
-          "properties": {
-            "domain": {
-              "type": "array",
-              "items": { "type": "number" },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "range": {
-              "type": "array",
-              "items": { "type": "number" },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "fallback": { "type": "number" },
-            "scalarStops": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "title": "IScalarStop",
-                "description": "Explicit input stop to output value mapping.",
-                "required": ["stop", "output"],
-                "additionalProperties": false,
-                "properties": {
-                  "stop": { "type": "number" },
-                  "output": { "type": "number" }
-                }
-              }
-            }
-          }
-        }
+        "params": { "$ref": "#/definitions/IScalarScaleParams" }
       }
     },
     "IConstantRGBAScaleParams": {

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -297,6 +297,16 @@
         }
       }
     },
+    "IConstantRGBAScaleParams": {
+      "type": "object",
+      "title": "IConstantRGBAParams",
+      "description": "Constant RGBA payload.",
+      "required": ["value"],
+      "additionalProperties": false,
+      "properties": {
+        "value": { "$ref": "#/definitions/RGBA" }
+      }
+    },
     "IConstantRGBAScale": {
       "type": "object",
       "title": "IConstantRGBAScale",
@@ -305,16 +315,7 @@
       "additionalProperties": false,
       "properties": {
         "scheme": { "const": "constant_rgba" },
-        "params": {
-          "type": "object",
-          "title": "IConstantRGBAParams",
-          "description": "Constant RGBA payload.",
-          "required": ["value"],
-          "additionalProperties": false,
-          "properties": {
-            "value": { "$ref": "#/definitions/RGBA" }
-          }
-        }
+        "params": { "$ref": "#/definitions/IConstantRGBAScaleParams" }
       }
     },
     "IConstantNumScaleParams": {

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -347,6 +347,25 @@
         "scheme": { "const": "identity" }
       }
     },
+    "IExpressionScaleParams": {
+      "type": "object",
+      "title": "IExpressionScaleParams",
+      "description": "Expression source and fallback output value.",
+      "required": ["expr", "fallback"],
+      "additionalProperties": false,
+      "properties": {
+        "expr": { "type": "string" },
+        "fallback": {
+          "oneOf": [{ "type": "number" }, { "$ref": "#/definitions/RGBA" }]
+        },
+        "language": {
+          "type": "string",
+          "enum": ["vega", "python"],
+          "default": "vega",
+          "description": "Expression language. 'vega' for TS/JS expressions, 'python' for Python expressions compiled via py2vega."
+        }
+      }
+    },
     "IExpressionScale": {
       "type": "object",
       "title": "IExpressionScale",
@@ -355,25 +374,7 @@
       "additionalProperties": false,
       "properties": {
         "scheme": { "const": "expression" },
-        "params": {
-          "type": "object",
-          "title": "IExpressionScaleParams",
-          "description": "Expression source and fallback output value.",
-          "required": ["expr", "fallback"],
-          "additionalProperties": false,
-          "properties": {
-            "expr": { "type": "string" },
-            "fallback": {
-              "oneOf": [{ "type": "number" }, { "$ref": "#/definitions/RGBA" }]
-            },
-            "language": {
-              "type": "string",
-              "enum": ["vega", "python"],
-              "default": "vega",
-              "description": "Expression language. 'vega' for TS/JS expressions, 'python' for Python expressions compiled via py2vega."
-            }
-          }
-        }
+        "params": { "$ref": "#/definitions/IExpressionScaleParams" }
       }
     },
     "IScale": {

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -212,6 +212,19 @@
         }
       }
     },
+    "ICategoricalColorStop": {
+      "type": "object",
+      "title": "ICategoricalColorStop",
+      "description": "Discrete value-to-color mapping entry.",
+      "required": ["stop", "color"],
+      "additionalProperties": false,
+      "properties": {
+        "stop": {
+          "oneOf": [{ "type": "string" }, { "type": "number" }]
+        },
+        "color": { "$ref": "#/definitions/RGBA" }
+      }
+    },
     "ICategoricalScaleParams": {
       "type": "object",
       "title": "ICategoricalScaleParams",
@@ -225,19 +238,7 @@
         "fallback": { "$ref": "#/definitions/RGBA" },
         "colorStops": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "title": "ICategoricalColorStop",
-            "description": "Discrete value-to-color mapping entry.",
-            "required": ["stop", "color"],
-            "additionalProperties": false,
-            "properties": {
-              "stop": {
-                "oneOf": [{ "type": "string" }, { "type": "number" }]
-              },
-              "color": { "$ref": "#/definitions/RGBA" }
-            }
-          }
+          "items": { "$ref": "#/definitions/ICategoricalColorStop" }
         }
       }
     },

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -212,6 +212,35 @@
         }
       }
     },
+    "ICategoricalScaleParams": {
+      "type": "object",
+      "title": "ICategoricalScaleParams",
+      "description": "Parameters controlling category-to-color mapping.",
+      "required": ["colorRamp", "fallback"],
+      "additionalProperties": false,
+      "properties": {
+        "colorRamp": { "type": "string" },
+        "nShades": { "type": "number" },
+        "reverse": { "type": "boolean" },
+        "fallback": { "$ref": "#/definitions/RGBA" },
+        "colorStops": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "ICategoricalColorStop",
+            "description": "Discrete value-to-color mapping entry.",
+            "required": ["stop", "color"],
+            "additionalProperties": false,
+            "properties": {
+              "stop": {
+                "oneOf": [{ "type": "string" }, { "type": "number" }]
+              },
+              "color": { "$ref": "#/definitions/RGBA" }
+            }
+          }
+        }
+      }
+    },
     "ICategoricalScale": {
       "type": "object",
       "title": "ICategoricalScale",
@@ -220,35 +249,7 @@
       "additionalProperties": false,
       "properties": {
         "scheme": { "const": "categorical" },
-        "params": {
-          "type": "object",
-          "title": "ICategoricalScaleParams",
-          "description": "Parameters controlling category-to-color mapping.",
-          "required": ["colorRamp", "fallback"],
-          "additionalProperties": false,
-          "properties": {
-            "colorRamp": { "type": "string" },
-            "nShades": { "type": "number" },
-            "reverse": { "type": "boolean" },
-            "fallback": { "$ref": "#/definitions/RGBA" },
-            "colorStops": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "title": "ICategoricalColorStop",
-                "description": "Discrete value-to-color mapping entry.",
-                "required": ["stop", "color"],
-                "additionalProperties": false,
-                "properties": {
-                  "stop": {
-                    "oneOf": [{ "type": "string" }, { "type": "number" }]
-                  },
-                  "color": { "$ref": "#/definitions/RGBA" }
-                }
-              }
-            }
-          }
-        }
+        "params": { "$ref": "#/definitions/ICategoricalScaleParams" }
       }
     },
     "IScalarScaleParams": {

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -168,6 +168,40 @@
         { "$ref": "#/definitions/IClusterTransform" }
       ]
     },
+    "IColorRampScaleParams": {
+      "type": "object",
+      "title": "IColorRampScaleParams",
+      "description": "Parameters controlling color-ramp classification and fallback behavior.",
+      "required": ["name", "nShades", "mode", "reverse", "fallback"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "domain": {
+          "type": "array",
+          "items": { "type": "number" },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "nShades": { "type": "number" },
+        "mode": { "$ref": "#/definitions/ClassificationMode" },
+        "reverse": { "type": "boolean" },
+        "fallback": { "$ref": "#/definitions/RGBA" },
+        "colorStops": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "IColorStop",
+            "description": "Explicit stop-to-color mapping entry.",
+            "required": ["stop", "color"],
+            "additionalProperties": false,
+            "properties": {
+              "stop": { "type": "number" },
+              "color": { "$ref": "#/definitions/RGBA" }
+            }
+          }
+        }
+      }
+    },
     "IColorRampScale": {
       "type": "object",
       "title": "IColorRampScale",
@@ -176,40 +210,7 @@
       "additionalProperties": false,
       "properties": {
         "scheme": { "const": "colorRamp" },
-        "params": {
-          "type": "object",
-          "title": "IColorRampScaleParams",
-          "description": "Parameters controlling color-ramp classification and fallback behavior.",
-          "required": ["name", "nShades", "mode", "reverse", "fallback"],
-          "additionalProperties": false,
-          "properties": {
-            "name": { "type": "string" },
-            "domain": {
-              "type": "array",
-              "items": { "type": "number" },
-              "minItems": 2,
-              "maxItems": 2
-            },
-            "nShades": { "type": "number" },
-            "mode": { "$ref": "#/definitions/ClassificationMode" },
-            "reverse": { "type": "boolean" },
-            "fallback": { "$ref": "#/definitions/RGBA" },
-            "colorStops": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "title": "IColorStop",
-                "description": "Explicit stop-to-color mapping entry.",
-                "required": ["stop", "color"],
-                "additionalProperties": false,
-                "properties": {
-                  "stop": { "type": "number" },
-                  "color": { "$ref": "#/definitions/RGBA" }
-                }
-              }
-            }
-          }
-        }
+        "params": { "$ref": "#/definitions/IColorRampScaleParams" }
       }
     },
     "ICategoricalColorStop": {

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -168,6 +168,17 @@
         { "$ref": "#/definitions/IClusterTransform" }
       ]
     },
+    "IColorStop": {
+      "type": "object",
+      "title": "IColorStop",
+      "description": "Explicit stop-to-color mapping entry.",
+      "required": ["stop", "color"],
+      "additionalProperties": false,
+      "properties": {
+        "stop": { "type": "number" },
+        "color": { "$ref": "#/definitions/RGBA" }
+      }
+    },
     "IColorRampScaleParams": {
       "type": "object",
       "title": "IColorRampScaleParams",
@@ -188,17 +199,7 @@
         "fallback": { "$ref": "#/definitions/RGBA" },
         "colorStops": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "title": "IColorStop",
-            "description": "Explicit stop-to-color mapping entry.",
-            "required": ["stop", "color"],
-            "additionalProperties": false,
-            "properties": {
-              "stop": { "type": "number" },
-              "color": { "$ref": "#/definitions/RGBA" }
-            }
-          }
+          "items": { "$ref": "#/definitions/IColorStop" }
         }
       }
     },

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -830,7 +830,10 @@ def expression(
         fallback_value = coerce_rgba(fallback)
 
     return schema_symbology.IExpressionScale(
-        params=schema_symbology.Params5(expr=expr, fallback=fallback_value),
+        params=schema_symbology.IExpressionScaleParams(
+            expr=expr,
+            fallback=fallback_value,
+        ),
     )
 
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -783,7 +783,7 @@ def _constant_color_scale(
     value: RGBA | Sequence[float] | str,
 ) -> schema_symbology.IConstantRGBAScale:
     return schema_symbology.IConstantRGBAScale(
-        params=schema_symbology.Params3(
+        params=schema_symbology.IConstantRGBAScaleParams(
             value=schema_symbology.RGBA(root=coerce_rgba(value)),
         ),
     )

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -845,7 +845,7 @@ def _colormap_scale(
     mode="equal interval",
     reverse: bool = False,
     fallback: RGBA | Sequence[float] | str = (0.0, 0.0, 0.0, 1.0),
-    color_stops: Sequence[schema_symbology.ColorStop] | None = None,
+    color_stops: Sequence[schema_symbology.IColorStop] | None = None,
 ) -> schema_symbology.IColorRampScale:
     params = schema_symbology.IColorRampScaleParams(
         name=name,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -847,7 +847,7 @@ def _colormap_scale(
     fallback: RGBA | Sequence[float] | str = (0.0, 0.0, 0.0, 1.0),
     color_stops: Sequence[schema_symbology.ColorStop] | None = None,
 ) -> schema_symbology.IColorRampScale:
-    params = schema_symbology.Params(
+    params = schema_symbology.IColorRampScaleParams(
         name=name,
         domain=list(domain) if domain is not None else None,
         nShades=n_shades,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -791,7 +791,7 @@ def _constant_color_scale(
 
 def _constant_num_scale(value: float) -> schema_symbology.IConstantNumScale:
     return schema_symbology.IConstantNumScale(
-        params=schema_symbology.Params4(value=value),
+        params=schema_symbology.IConstantNumScaleParams(value=value),
     )
 
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -885,7 +885,7 @@ def _scalar_scale(
     fallback: float,
     scalar_stops: Sequence[ScalarStop] | None = None,
 ) -> schema_symbology.IScalarScale:
-    params = schema_symbology.Params2(
+    params = schema_symbology.IScalarScaleParams(
         domain=list(domain),
         range=list(output_range),
         fallback=fallback,

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -869,7 +869,7 @@ def _categorical_scale(
     fallback: RGBA | Sequence[float] | str = (0.0, 0.0, 0.0, 1.0),
 ) -> schema_symbology.ICategoricalScale:
     return schema_symbology.ICategoricalScale(
-        params=schema_symbology.Params1(
+        params=schema_symbology.ICategoricalScaleParams(
             colorRamp=name,
             nShades=n_shades,
             reverse=reverse,


### PR DESCRIPTION
## Description

We have some symbology types that are being generated with sequential numeric names like `Params1`, `Params2`, ... `Params5`. This PR gives them real names!

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself
