### PR TITLE
Expression Functions and Constants Auto Completion in CodeMirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^29.4.9",
     "typescript": "^5",
-    "vega2ol": "^1.1.5",
+    "vega2ol": "^1.2.0",
     "webpack": "^5.76.3",
     "zarrita": "^0.7.3"
   }

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -1083,7 +1083,11 @@ const MappingRow: React.FC<IMappingRowProps> = ({
             </p>
           )}
           {row.scale.scheme === 'expression' && (
-            <ExpressionEditor scale={row.scale} onChange={handleScaleChange} />
+            <ExpressionEditor
+              scale={row.scale}
+              onChange={handleScaleChange}
+              fields={availableFields.map(f => f.value)}
+            />
           )}
         </div>
       )}

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -2,11 +2,19 @@
  * Inline scale editor for one IMapping.
  * Renders a different UI for each scale scheme.
  */
-
+import {
+  autocompletion,
+  acceptCompletion,
+  completionKeymap,
+  Completion,
+  CompletionContext,
+  CompletionResult,
+} from '@codemirror/autocomplete';
+import { indentWithTab } from '@codemirror/commands';
 import { javascript } from '@codemirror/lang-javascript';
 import { python } from '@codemirror/lang-python';
-import { Compartment, EditorState } from '@codemirror/state';
-import { EditorView, placeholder } from '@codemirror/view';
+import { Compartment, EditorState, Prec } from '@codemirror/state';
+import { EditorView, placeholder, keymap } from '@codemirror/view';
 import {
   ClassificationMode,
   ICategoricalScale,
@@ -22,7 +30,7 @@ import { jupyterTheme } from '@jupyterlab/codemirror';
 import { UUID } from '@lumino/coreutils';
 import { py2vega } from 'py2vega-ts';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { vega2ol } from 'vega2ol';
+import { vega2ol, FUNCTION_MAPPING, CONSTANTS_MAPPING } from 'vega2ol';
 
 import { ColorRampName } from '@/src/features/layers/symbology/colorRampUtils';
 import { NumericInput } from '@/src/features/layers/symbology/components/NumericInput';
@@ -384,11 +392,55 @@ export const CategoricalEditor: React.FC<ICategoricalEditorProps> = ({
 
 interface IExpressionEditorProps {
   scale: IExpressionScale;
+  fields: string[];
   onChange: (scale: IScale) => void;
 }
 
+function vegaExprCompletion(fieldsRef: React.MutableRefObject<string[]>) {
+  // 'indexof' is excluded: it's handled as a special-case pattern
+  const functionNames = Object.keys(FUNCTION_MAPPING).filter(
+    name => name !== 'indexof',
+  );
+
+  const constantNames = Object.keys(CONSTANTS_MAPPING);
+
+  return (context: CompletionContext): CompletionResult | null => {
+    const datumMatch = context.matchBefore(/datum\.\w*/);
+    if (datumMatch) {
+      return {
+        from: datumMatch.from + 6,
+        options: fieldsRef.current.map(
+          (f): Completion => ({ label: f, type: 'property' }),
+        ),
+        validFor: /^\w*$/,
+      };
+    }
+
+    const word = context.matchBefore(/\w+/);
+    if (!word || (word.from === word.to && !context.explicit)) {
+      return null;
+    }
+
+    const options: Completion[] = [
+      {
+        label: 'datum',
+        type: 'variable',
+        detail: 'current data object',
+      },
+      ...functionNames.map(
+        (name): Completion => ({ label: name, type: 'function' }),
+      ),
+      ...constantNames.map(
+        (name): Completion => ({ label: name, type: 'constant' }),
+      ),
+    ];
+
+    return { from: word.from, options, validFor: /^\w*$/ };
+  };
+}
 export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
   scale,
+  fields,
   onChange,
 }) => {
   const { params } = scale;
@@ -401,6 +453,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
   );
 
   const paramsRef = useRef(params);
+  const fielsdRef = useRef(fields);
   const editorRef = useRef<HTMLDivElement | null>(null);
   const viewRef = useRef<EditorView | null>(null);
   const languageComp = useRef(new Compartment()).current;
@@ -428,7 +481,8 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
 
   useEffect(() => {
     paramsRef.current = params;
-  }, [params]);
+    fielsdRef.current = fields;
+  }, [params, fields]);
 
   useEffect(() => {
     if (!editorRef.current || viewRef.current) {
@@ -446,6 +500,14 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
         ),
         jupyterTheme,
         EditorView.lineWrapping,
+        autocompletion({
+          override: [vegaExprCompletion(fielsdRef)],
+          activateOnTyping: true,
+        }),
+        Prec.highest(
+          keymap.of([{ key: 'Tab', run: acceptCompletion }, indentWithTab]),
+        ),
+        keymap.of(completionKeymap),
         EditorView.updateListener.of(updateView => {
           if (updateView.docChanged) {
             const value = updateView.state.doc.toString();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,7 +1670,7 @@ __metadata:
     rimraf: ^3.0.2
     ts-jest: ^29.4.9
     typescript: ^5
-    vega2ol: ^1.1.5
+    vega2ol: ^1.2.0
     webpack: ^5.76.3
     zarrita: ^0.7.3
   languageName: unknown
@@ -19059,12 +19059,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vega2ol@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "vega2ol@npm:1.1.5"
+"vega2ol@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "vega2ol@npm:1.2.0"
   dependencies:
     vega-expression: ^6.1.0
-  checksum: bcc6ece2e0a02202d2cb6cd4fbddd02f7303177ad03f4abd38049a67daeb635ece48f5f3d4d557f377c4075a4ce3b5b5d52b32899289589a447329d4c3c0416f
+  checksum: 1444c972fd8c3824ae66a21f855258fa057edfca9c021694a65b525a611fdef73946e76beeba73151ad61ff364355d2c1c30a744412d3991390a69d9c8d9f332
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR adds support for auto completions of supported [`vega2ol`](https://github.com/geojupyter/vega2ol) expressions's Variable, Functions and Constants with the help of Tab key in CodeMirror.
As well as we can also access all the available fields from the data or in the map.




https://github.com/user-attachments/assets/9bc6bec1-eee6-4d12-96a9-fdc03239de3e




## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1623.org.readthedocs.build/en/1623/
💡 JupyterLite preview: https://jupytergis--1623.org.readthedocs.build/en/1623/lite
💡 Specta preview: https://jupytergis--1623.org.readthedocs.build/en/1623/lite/specta

<!-- readthedocs-preview jupytergis end -->