### PR TITLE
Support Jupyter notebook style attachments for story segments

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -49,6 +49,7 @@
     "@jupytergis/schema": "^0.16.0-beta.4",
     "@jupyterlab/application": "^4.6",
     "@jupyterlab/apputils": "^4.6",
+    "@jupyterlab/attachments": "^4.6",
     "@jupyterlab/codeeditor": "^4.6",
     "@jupyterlab/codemirror": "^4.6",
     "@jupyterlab/completer": "^4.6",

--- a/packages/base/src/features/story/__tests__/storySegmentAttachments.spec.ts
+++ b/packages/base/src/features/story/__tests__/storySegmentAttachments.spec.ts
@@ -46,9 +46,9 @@ describe('storySegmentAttachments', () => {
   });
 
   it('formats attachment markdown links', () => {
-    expect(
-      formatSegmentAttachmentMarkdown('plot.png', 'uuid.png'),
-    ).toBe('![plot.png](attachment:uuid.png)');
+    expect(formatSegmentAttachmentMarkdown('plot.png', 'uuid.png')).toBe(
+      '![plot.png](attachment:uuid.png)',
+    );
   });
 
   it('generates attachment uris with preserved extensions', () => {

--- a/packages/base/src/features/story/__tests__/storySegmentAttachments.spec.ts
+++ b/packages/base/src/features/story/__tests__/storySegmentAttachments.spec.ts
@@ -1,0 +1,89 @@
+import {
+  formatSegmentAttachmentMarkdown,
+  generateSegmentAttachmentUri,
+  getSegmentAttachments,
+  setSegmentAttachment,
+} from '@/src/features/story/utils/storySegmentAttachments';
+import { updateSegmentContent } from '@/src/features/story/utils/storySegmentContent';
+
+describe('storySegmentAttachments', () => {
+  it('reads and writes attachments on segment content', () => {
+    const updateObjectParameters = jest.fn();
+    const model = {
+      getLayer: jest.fn(() => ({
+        type: 'StorySegmentLayer',
+        parameters: {
+          content: {
+            contentMode: 'markdown',
+            markdown: '# Hello',
+            attachments: {
+              'plot.png': { 'image/png': 'abc123' },
+            },
+          },
+        },
+      })),
+      sharedModel: { updateObjectParameters },
+    };
+
+    expect(getSegmentAttachments(model as never, 'segment-1')).toEqual({
+      'plot.png': { 'image/png': 'abc123' },
+    });
+
+    setSegmentAttachment(model as never, 'segment-1', 'new.png', {
+      'image/png': 'def456',
+    });
+
+    expect(updateObjectParameters).toHaveBeenCalledWith('segment-1', {
+      content: {
+        contentMode: 'markdown',
+        markdown: '# Hello',
+        attachments: {
+          'plot.png': { 'image/png': 'abc123' },
+          'new.png': { 'image/png': 'def456' },
+        },
+      },
+    });
+  });
+
+  it('formats attachment markdown links', () => {
+    expect(
+      formatSegmentAttachmentMarkdown('plot.png', 'uuid.png'),
+    ).toBe('![plot.png](attachment:uuid.png)');
+  });
+
+  it('generates attachment uris with preserved extensions', () => {
+    const uri = generateSegmentAttachmentUri('plot.png');
+    expect(uri.endsWith('.png')).toBe(true);
+    expect(uri.length).toBeGreaterThan('.png'.length);
+  });
+});
+
+describe('updateSegmentContent attachments patch', () => {
+  it('merges attachments into segment content', () => {
+    const updateObjectParameters = jest.fn();
+    const model = {
+      getLayer: jest.fn(() => ({
+        type: 'StorySegmentLayer',
+        parameters: {
+          content: {
+            contentMode: 'markdown',
+            markdown: 'Old body',
+          },
+        },
+      })),
+      sharedModel: { updateObjectParameters },
+    };
+
+    updateSegmentContent(model as never, 'segment-1', {
+      attachments: { 'a.png': { 'image/png': 'x' } },
+    });
+
+    expect(updateObjectParameters).toHaveBeenCalledWith('segment-1', {
+      content: {
+        contentMode: 'markdown',
+        markdown: 'Old body',
+        attachments: { 'a.png': { 'image/png': 'x' } },
+      },
+    });
+  });
+});

--- a/packages/base/src/features/story/components/ListStoryMarkdownMeasurePane.tsx
+++ b/packages/base/src/features/story/components/ListStoryMarkdownMeasurePane.tsx
@@ -1,9 +1,11 @@
+import type { IJupyterGISModel } from '@jupytergis/schema';
 import React, { useCallback, useLayoutEffect, useRef } from 'react';
 
 import { ListStoryOverlayMarkdown } from '@/src/features/story/components/ListStoryOverlayMarkdown';
 import { whenImagesSettled } from '@/src/features/story/utils/whenImagesSettled';
 
 interface IListStoryMarkdownMeasurePaneProps {
+  model: IJupyterGISModel;
   segmentId: string;
   markdown: string;
   onHeight: (segmentId: string, height: number) => void;
@@ -14,6 +16,7 @@ interface IListStoryMarkdownMeasurePaneProps {
  * Single off-screen pane matching overlay markdown layout for height measurement.
  */
 export function ListStoryMarkdownMeasurePane({
+  model,
   segmentId,
   markdown,
   onHeight,
@@ -102,6 +105,8 @@ export function ListStoryMarkdownMeasurePane({
       <div ref={contentRef}>
         {markdown ? (
           <ListStoryOverlayMarkdown
+            model={model}
+            segmentId={segmentId}
             source={markdown}
             onRendered={handleRendered}
           />

--- a/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
+++ b/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
@@ -1,16 +1,28 @@
+import type { IJupyterGISModel } from '@jupytergis/schema';
 import React from 'react';
 
 import { RenderedStoryMarkdown } from '@/src/features/story/components/RenderedStoryMarkdown';
 
 interface IListStoryOverlayMarkdownProps {
+  model: IJupyterGISModel;
+  segmentId: string;
   source: string;
   onRendered?: () => void;
 }
 
 /** Markdown body for a list-story stage overlay segment. */
 export function ListStoryOverlayMarkdown({
+  model,
+  segmentId,
   source,
   onRendered,
 }: IListStoryOverlayMarkdownProps): JSX.Element | null {
-  return <RenderedStoryMarkdown source={source} onRendered={onRendered} />;
+  return (
+    <RenderedStoryMarkdown
+      model={model}
+      segmentId={segmentId}
+      source={source}
+      onRendered={onRendered}
+    />
+  );
 }

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -35,7 +35,7 @@ interface IListStoryStageOverlayProps {
 }
 
 type SegmentOverlayPaneConfig =
-  | { type: 'markdown'; markdown: string }
+  | { type: 'markdown'; markdown: string; segmentId: string }
   | { type: 'map'; segmentIndex: number };
 
 type OverlayPaneRole = 'from' | 'to' | 'lookahead';
@@ -43,6 +43,7 @@ type OverlayPaneRole = 'from' | 'to' | 'lookahead';
 const EMPTY_MARKDOWN_PANE: SegmentOverlayPaneConfig = {
   type: 'markdown',
   markdown: '',
+  segmentId: '',
 };
 
 interface IOverlayStackPane {
@@ -70,6 +71,7 @@ function buildPaneConfig(
   return {
     type: 'markdown',
     markdown: getStoryMarkdownFromSlide(item.activeSlide),
+    segmentId: item.id,
   };
 }
 
@@ -175,6 +177,7 @@ interface ISegmentOverlayPaneProps {
   pane: OverlayPaneRole;
   segmentIndex: number;
   config: SegmentOverlayPaneConfig;
+  model: IJupyterGISModel;
   storyData: IJGISStoryMap;
   items: IStorySegmentViewItem[];
   onMarkdownRendered?: () => void;
@@ -184,6 +187,7 @@ function SegmentOverlayPane({
   pane,
   segmentIndex,
   config,
+  model,
   storyData,
   items,
   onMarkdownRendered,
@@ -206,7 +210,9 @@ function SegmentOverlayPane({
         />
       ) : config.markdown ? (
         <ListStoryOverlayMarkdown
-          key={`seg-${segmentIndex}`}
+          key={`pane-${pane}-seg-${segmentIndex}`}
+          model={model}
+          segmentId={config.segmentId}
           source={config.markdown}
           onRendered={onMarkdownRendered}
         />
@@ -509,8 +515,8 @@ export function ListStoryStageOverlay({
       <div ref={stackRef} className="jgis-story-segment-transition-stack">
         <SegmentOverlayPane
           pane="from"
-          segmentIndex={fromStackPane.segmentIndex}
-          config={fromStackPane.config}
+          segmentIndex={fromIndex}
+          config={fromPaneConfig}
           storyData={story}
           items={items}
           onMarkdownRendered={
@@ -529,8 +535,8 @@ export function ListStoryStageOverlay({
             ) : null}
             <SegmentOverlayPane
               pane="to"
-              segmentIndex={toStackPane.segmentIndex}
-              config={toStackPane.config}
+              segmentIndex={toIndex}
+              config={toPaneConfig}
               storyData={story}
               items={items}
               onMarkdownRendered={

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -514,9 +514,10 @@ export function ListStoryStageOverlay({
     >
       <div ref={stackRef} className="jgis-story-segment-transition-stack">
         <SegmentOverlayPane
+          model={model}
           pane="from"
-          segmentIndex={fromIndex}
-          config={fromPaneConfig}
+          segmentIndex={fromStackPane.segmentIndex}
+          config={fromStackPane.config}
           storyData={story}
           items={items}
           onMarkdownRendered={
@@ -534,9 +535,10 @@ export function ListStoryStageOverlay({
               <div className="jgis-story-segment-transition-gap" aria-hidden />
             ) : null}
             <SegmentOverlayPane
+              model={model}
               pane="to"
-              segmentIndex={toIndex}
-              config={toPaneConfig}
+              segmentIndex={toStackPane.segmentIndex}
+              config={toStackPane.config}
               storyData={story}
               items={items}
               onMarkdownRendered={
@@ -552,6 +554,7 @@ export function ListStoryStageOverlay({
         ) : null}
         {lookaheadStackPane ? (
           <SegmentOverlayPane
+            model={model}
             pane="lookahead"
             segmentIndex={lookaheadStackPane.segmentIndex}
             config={lookaheadStackPane.config}

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -1,3 +1,4 @@
+import type { IJupyterGISModel } from '@jupytergis/schema';
 import { MimeModel } from '@jupyterlab/rendermime';
 import { Widget } from '@lumino/widgets';
 import React, { useLayoutEffect, useRef } from 'react';
@@ -7,6 +8,8 @@ import { useStoryRenderMime } from '@/src/features/story/components/StoryRenderM
 const MARKDOWN_MIME = 'text/markdown';
 
 export interface IRenderedStoryMarkdownProps {
+  model: IJupyterGISModel;
+  segmentId: string;
   source: string;
   /** Fires after rendermime has painted. */
   onRendered?: () => void;
@@ -29,10 +32,12 @@ function disposeRenderer(renderer: Widget): void {
 
 /** Jupyter rendermime markdown output (shared by overlay and story editor). */
 export function RenderedStoryMarkdown({
+  model,
+  segmentId,
   source,
   onRendered,
 }: IRenderedStoryMarkdownProps): JSX.Element | null {
-  const rendermime = useStoryRenderMime();
+  const rendermime = useStoryRenderMime(model, segmentId);
   const hostRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
@@ -43,7 +48,7 @@ export function RenderedStoryMarkdown({
 
     const registry = rendermime.clone();
     const renderer = registry.createRenderer(MARKDOWN_MIME);
-    const model = new MimeModel({
+    const mimeModel = new MimeModel({
       data: { [MARKDOWN_MIME]: source },
       trusted: false,
     });
@@ -63,7 +68,7 @@ export function RenderedStoryMarkdown({
       }
 
       try {
-        await renderer.renderModel(model);
+        await renderer.renderModel(mimeModel);
       } catch (error) {
         console.error('Failed to render story markdown', error);
         disposeRenderer(renderer);

--- a/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
+++ b/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { RenderedStoryMarkdown } from '@/src/features/story/components/RenderedStoryMarkdown';
 import { getStorySegmentMarkdownSharedModel } from '@/src/features/story/utils/storySegmentMarkdownSharedModel';
+import { handleStorySegmentMarkdownPaste } from '@/src/features/story/utils/storySegmentMarkdownPaste';
 import {
   Tabs,
   TabsContent,
@@ -70,6 +71,18 @@ export function SegmentMarkdownEditor({
     }) as CodeMirrorEditor;
     editorRef.current = editor;
 
+    const onPaste = (event: ClipboardEvent): void => {
+      handleStorySegmentMarkdownPaste(event, {
+        model,
+        segmentId,
+        insertMarkdown: markdown => {
+          editor.replaceSelection(markdown);
+        },
+      });
+    };
+
+    host.addEventListener('paste', onPaste);
+
     const refreshPreview = (): void => {
       setPreviewMarkdown(sharedModel.getSource());
     };
@@ -78,6 +91,7 @@ export function SegmentMarkdownEditor({
     refreshPreview();
 
     return () => {
+      host.removeEventListener('paste', onPaste);
       sharedModel.changed.disconnect(refreshPreview);
       editor.dispose();
       editorRef.current = null;
@@ -127,7 +141,11 @@ export function SegmentMarkdownEditor({
       >
         <div className="jgis-story-editor-markdown jgis-story-editor-markdown-preview jgis-story-viewer-content">
           {previewMarkdown.trim() ? (
-            <RenderedStoryMarkdown source={previewMarkdown} />
+            <RenderedStoryMarkdown
+              model={model}
+              segmentId={segmentId}
+              source={previewMarkdown}
+            />
           ) : (
             <p className="jgis-story-editor-help">Nothing to preview yet.</p>
           )}

--- a/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
+++ b/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
@@ -4,8 +4,8 @@ import type { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { RenderedStoryMarkdown } from '@/src/features/story/components/RenderedStoryMarkdown';
-import { getStorySegmentMarkdownSharedModel } from '@/src/features/story/utils/storySegmentMarkdownSharedModel';
 import { handleStorySegmentMarkdownPaste } from '@/src/features/story/utils/storySegmentMarkdownPaste';
+import { getStorySegmentMarkdownSharedModel } from '@/src/features/story/utils/storySegmentMarkdownSharedModel';
 import {
   Tabs,
   TabsContent,

--- a/packages/base/src/features/story/components/StoryRenderMime.tsx
+++ b/packages/base/src/features/story/components/StoryRenderMime.tsx
@@ -57,9 +57,9 @@ export function useStoryRenderMime(
   model: IJupyterGISModel,
   segmentId: string,
 ): IRenderMimeRegistry {
-  const base = useContext(StoryRenderMimeContext);
+  const context = useContext(StoryRenderMimeContext);
 
-  if (!base) {
+  if (!context) {
     throw new Error(
       'useStoryRenderMime must be used within StoryRenderMimeProvider.',
     );
@@ -74,11 +74,11 @@ export function useStoryRenderMime(
       values: getSegmentAttachments(model, segmentId),
     });
 
-    return base.clone({
+    return context.clone({
       resolver: new AttachmentsResolver({
-        parent: base.resolver ?? undefined,
+        parent: context.resolver ?? undefined,
         model: attachmentsModel,
       }),
     });
-  }, [base, model, segmentId, attachmentsKey]);
+  }, [context, model, segmentId, attachmentsKey]);
 }

--- a/packages/base/src/features/story/components/StoryRenderMime.tsx
+++ b/packages/base/src/features/story/components/StoryRenderMime.tsx
@@ -1,9 +1,12 @@
 import type { IJupyterGISModel } from '@jupytergis/schema';
+import { AttachmentsModel, AttachmentsResolver } from '@jupyterlab/attachments';
 import {
   RenderMimeRegistry,
   type IRenderMimeRegistry,
 } from '@jupyterlab/rendermime';
 import React, { createContext, useContext, useMemo } from 'react';
+
+import { getSegmentAttachments } from '@/src/features/story/utils/storySegmentAttachments';
 
 const StoryRenderMimeContext = createContext<IRenderMimeRegistry | null>(null);
 
@@ -50,14 +53,32 @@ export function StoryRenderMimeProvider({
   );
 }
 
-export function useStoryRenderMime(): IRenderMimeRegistry {
-  const rendermime = useContext(StoryRenderMimeContext);
+export function useStoryRenderMime(
+  model: IJupyterGISModel,
+  segmentId: string,
+): IRenderMimeRegistry {
+  const base = useContext(StoryRenderMimeContext);
 
-  if (!rendermime) {
+  if (!base) {
     throw new Error(
       'useStoryRenderMime must be used within StoryRenderMimeProvider.',
     );
   }
 
-  return rendermime;
+  const attachmentsKey = JSON.stringify(
+    getSegmentAttachments(model, segmentId),
+  );
+
+  return useMemo(() => {
+    const attachmentsModel = new AttachmentsModel({
+      values: getSegmentAttachments(model, segmentId),
+    });
+
+    return base.clone({
+      resolver: new AttachmentsResolver({
+        parent: base.resolver ?? undefined,
+        model: attachmentsModel,
+      }),
+    });
+  }, [base, model, segmentId, attachmentsKey]);
 }

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -297,6 +297,7 @@ export function ListStoryScrollTrackProvider({
         <div className="jgis-story-markdown-measure-host" aria-hidden>
           <ListStoryMarkdownMeasurePane
             key={segmentBeingMeasured.id}
+            model={model}
             segmentId={segmentBeingMeasured.id}
             markdown={segmentBeingMeasured.markdown}
             onHeight={reportHeight}

--- a/packages/base/src/features/story/utils/storySegmentAttachments.ts
+++ b/packages/base/src/features/story/utils/storySegmentAttachments.ts
@@ -1,0 +1,52 @@
+import type { IJupyterGISModel, IStorySegmentLayer } from '@jupytergis/schema';
+import type * as nbformat from '@jupyterlab/nbformat';
+import { UUID } from '@lumino/coreutils';
+
+import { updateSegmentContent } from './storySegmentContent';
+
+type SegmentAttachments = NonNullable<
+  NonNullable<IStorySegmentLayer['content']>['attachments']
+>;
+
+export function getSegmentAttachments(
+  model: IJupyterGISModel,
+  segmentId: string,
+): SegmentAttachments {
+  const layer = model.getLayer(segmentId);
+
+  if (!layer || layer.type !== 'StorySegmentLayer') {
+    return {};
+  }
+
+  const parameters = layer.parameters as IStorySegmentLayer;
+  return parameters.content?.attachments ?? {};
+}
+
+export function setSegmentAttachment(
+  model: IJupyterGISModel,
+  segmentId: string,
+  key: string,
+  attachment: nbformat.IMimeBundle,
+): void {
+  const attachments: SegmentAttachments = {
+    ...getSegmentAttachments(model, segmentId),
+    [key]: attachment as SegmentAttachments[string],
+  };
+
+  updateSegmentContent(model, segmentId, { attachments });
+}
+
+export function generateSegmentAttachmentUri(name = ''): string {
+  const lastIndex = name.lastIndexOf('.');
+
+  return lastIndex !== -1
+    ? UUID.uuid4().concat(name.substring(lastIndex))
+    : UUID.uuid4();
+}
+
+export function formatSegmentAttachmentMarkdown(
+  label: string,
+  uri: string,
+): string {
+  return `![${label}](attachment:${uri})`;
+}

--- a/packages/base/src/features/story/utils/storySegmentContent.ts
+++ b/packages/base/src/features/story/utils/storySegmentContent.ts
@@ -5,7 +5,7 @@ import type { StorySegmentDisplayMode } from '@/src/features/story/types/types';
 type SegmentContent = NonNullable<IStorySegmentLayer['content']>;
 
 export type SegmentContentPatch = Partial<
-  Pick<SegmentContent, 'title' | 'markdown' | 'image'>
+  Pick<SegmentContent, 'title' | 'markdown' | 'image' | 'attachments'>
 >;
 
 const EMPTY_SEGMENT_CONTENT: SegmentContent = { contentMode: 'map' };
@@ -20,6 +20,7 @@ export function normalizeSegmentContentForMode(
     return {
       contentMode: 'markdown',
       markdown: value.markdown ?? '',
+      attachments: value.attachments,
     };
   }
 
@@ -28,6 +29,7 @@ export function normalizeSegmentContentForMode(
     title: value.title ?? '',
     image: value.image ?? '',
     markdown: value.markdown ?? '',
+    attachments: value.attachments,
   };
 }
 

--- a/packages/base/src/features/story/utils/storySegmentMarkdownPaste.ts
+++ b/packages/base/src/features/story/utils/storySegmentMarkdownPaste.ts
@@ -1,0 +1,94 @@
+import type { IJupyterGISModel } from '@jupytergis/schema';
+import { URLExt } from '@jupyterlab/coreutils';
+import type * as nbformat from '@jupyterlab/nbformat';
+import { imageRendererFactory } from '@jupyterlab/rendermime';
+
+import {
+  formatSegmentAttachmentMarkdown,
+  generateSegmentAttachmentUri,
+  setSegmentAttachment,
+} from '@/src/features/story/utils/storySegmentAttachments';
+
+interface IStorySegmentMarkdownPasteOptions {
+  model: IJupyterGISModel;
+  segmentId: string;
+  insertMarkdown: (markdown: string) => void;
+}
+
+/**
+ * Paste image clipboard items as segment attachments (notebook-style).
+ * Returns true when an image paste was handled.
+ */
+export function handleStorySegmentMarkdownPaste(
+  event: ClipboardEvent,
+  options: IStorySegmentMarkdownPasteOptions,
+): boolean {
+  const { clipboardData } = event;
+  if (!clipboardData) {
+    return false;
+  }
+
+  let handledImage = false;
+
+  for (let i = 0; i < clipboardData.items.length; i++) {
+    const item = clipboardData.items[i];
+    if (item.kind !== 'file') {
+      continue;
+    }
+
+    const blob = item.getAsFile();
+    if (!blob || imageRendererFactory.mimeTypes.indexOf(blob.type) === -1) {
+      continue;
+    }
+
+    handledImage = true;
+    void attachImageBlob(blob, options);
+  }
+
+  if (handledImage) {
+    event.preventDefault();
+    return true;
+  }
+
+  return false;
+}
+
+async function attachImageBlob(
+  blob: File,
+  options: IStorySegmentMarkdownPasteOptions,
+): Promise<void> {
+  const dataUrl = await readAsDataURL(blob);
+  const { href, protocol } = URLExt.parse(dataUrl);
+
+  if (protocol !== 'data:') {
+    return;
+  }
+
+  const dataURIRegex = /([\w+/]+)?(?:;(charset=[\w-]*|base64))?,(.*)/;
+  const matches = dataURIRegex.exec(href);
+
+  if (!matches || matches.length !== 4) {
+    return;
+  }
+
+  const mimeType = matches[1];
+  const encodedData = matches[3];
+  const bundle: nbformat.IMimeBundle = { [mimeType]: encodedData };
+  const uri = generateSegmentAttachmentUri(blob.name);
+
+  setSegmentAttachment(options.model, options.segmentId, uri, bundle);
+  options.insertMarkdown(formatSegmentAttachmentMarkdown(blob.name, uri));
+}
+
+function readAsDataURL(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      resolve(reader.result as string);
+    };
+    reader.onerror = () => {
+      reject(reader.error);
+    };
+    reader.readAsDataURL(blob);
+  });
+}

--- a/packages/schema/src/schema/project/layers/storySegmentLayer.json
+++ b/packages/schema/src/schema/project/layers/storySegmentLayer.json
@@ -40,6 +40,17 @@
           "type": "string",
           "description": "Markdown string representing the content of the story stop",
           "default": ""
+        },
+        "attachments": {
+          "type": "object",
+          "description": "Embedded markdown attachments keyed by filename (nbformat attachments)",
+          "default": {},
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
         }
       },
       "required": ["contentMode"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,6 +1464,7 @@ __metadata:
     "@jupytergis/schema": ^0.16.0-beta.4
     "@jupyterlab/application": ^4.6
     "@jupyterlab/apputils": ^4.6
+    "@jupyterlab/attachments": ^4.6
     "@jupyterlab/codeeditor": ^4.6
     "@jupyterlab/codemirror": ^4.6
     "@jupyterlab/completer": ^4.6
@@ -1754,6 +1755,20 @@ __metadata:
     react: ^18.2.0
     sanitize-html: ~2.12.1
   checksum: 317ef843a5118f96b723e7ebc40be637c3dc6b78f2b148d80e5b4b248be9bc81a65452b75026e82abd97598a7a72b93ad5a66fe294c7cad3eb63cea2b3b94831
+  languageName: node
+  linkType: hard
+
+"@jupyterlab/attachments@npm:^4.6":
+  version: 4.6.1
+  resolution: "@jupyterlab/attachments@npm:4.6.1"
+  dependencies:
+    "@jupyterlab/nbformat": ^4.6.1
+    "@jupyterlab/observables": ^5.6.1
+    "@jupyterlab/rendermime": ^4.6.1
+    "@jupyterlab/rendermime-interfaces": ^3.14.1
+    "@lumino/disposable": ^2.1.5
+    "@lumino/signaling": ^2.1.5
+  checksum: 100c5c4974e08f4d45422795f4266f97af81acfb478d1bcfc734b3f4d945912c50474035c4e546934858499d98c559a393b06a6a17dba56d3885c224caf6ee8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Close #1592 
Support Jupyter notebook style attachments

https://github.com/user-attachments/assets/a0301375-06d6-4b93-8588-8b44c2410854

(It's not clear, but I'm pasting an image from the clipboard)

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1625.org.readthedocs.build/en/1625/
💡 JupyterLite preview: https://jupytergis--1625.org.readthedocs.build/en/1625/lite
💡 Specta preview: https://jupytergis--1625.org.readthedocs.build/en/1625/lite/specta

<!-- readthedocs-preview jupytergis end -->