### PR TITLE
Add shared ErrorBanner component for inline UI errors

### DIFF
--- a/packages/base/src/features/layers/openeo/jsonEditor.tsx
+++ b/packages/base/src/features/layers/openeo/jsonEditor.tsx
@@ -5,6 +5,8 @@ import { EditorState } from '@codemirror/state';
 import { EditorView, keymap, lineNumbers } from '@codemirror/view';
 import * as React from 'react';
 
+import { ErrorBanner } from '@/src/shared/components/ErrorBanner';
+
 export interface IJsonEditorProps {
   /** Stable serialized initial value. Changes reset the editor. */
   value: string;
@@ -79,7 +81,11 @@ export const JsonEditor: React.FC<IJsonEditorProps> = ({
     <div className="jp-openeo-json-editor">
       <div ref={hostRef} className="jp-openeo-json-editor-host" />
       {parseError && (
-        <div className="jp-openeo-json-editor-error">{parseError}</div>
+        <ErrorBanner
+          variant="error"
+          message={parseError}
+          className="jp-openeo-json-editor-error"
+        />
       )}
     </div>
   );

--- a/packages/base/src/shared/components/ErrorBanner.tsx
+++ b/packages/base/src/shared/components/ErrorBanner.tsx
@@ -1,0 +1,78 @@
+import { AlertTriangle, Info, XCircle, X } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from './utils';
+
+export type ErrorBannerVariant = 'info' | 'warning' | 'error';
+
+interface IErrorBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * The message to display in the banner.
+   */
+  message: React.ReactNode;
+  /**
+   * The severity of the message. Controls the icon and colour.
+   *
+   * @default 'error'
+   */
+  variant?: ErrorBannerVariant;
+  /**
+   * Called when the user dismisses the banner. When omitted the banner is not
+   * dismissable and no close button is rendered.
+   */
+  onDismiss?: () => void;
+}
+
+const variantIcon: Record<ErrorBannerVariant, React.ReactNode> = {
+  info: <Info data-size="md" />,
+  warning: <AlertTriangle data-size="md" />,
+  error: <XCircle data-size="md" />,
+};
+
+const variantLabel: Record<ErrorBannerVariant, string> = {
+  info: 'Information',
+  warning: 'Warning',
+  error: 'Error',
+};
+
+/**
+ * A dismissable inline banner for surfacing scoped messages (info / warning /
+ * error) inside a dialog body, side panel or any other React tree.
+ *
+ * For app-global messages that are not tied to a specific open surface, use
+ * `Notification` from `@jupyterlab/apputils` instead.
+ */
+export function ErrorBanner({
+  message,
+  variant = 'error',
+  onDismiss,
+  className,
+  ...props
+}: IErrorBannerProps) {
+  return (
+    <div
+      role={variant === 'error' ? 'alert' : 'status'}
+      data-variant={variant}
+      className={cn('jgis-error-banner', className)}
+      {...props}
+    >
+      <span className="jgis-error-banner-icon" aria-hidden="true">
+        {variantIcon[variant]}
+      </span>
+      <span className="jgis-sr-only">{variantLabel[variant]}:</span>
+      <span className="jgis-error-banner-message">{message}</span>
+      {onDismiss && (
+        <button
+          type="button"
+          className="jgis-error-banner-dismiss"
+          aria-label="Dismiss"
+          onClick={onDismiss}
+        >
+          <X data-size="sm" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default ErrorBanner;

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -36,6 +36,7 @@
 @import url('./shared/popover.css');
 @import url('./shared/hoverCard.css');
 @import url('./shared/infoTip.css');
+@import url('./shared/errorBanner.css');
 @import url('./shared/command.css');
 @import url('./shared/combobox.css');
 @import url('./shared/input.css');

--- a/packages/base/style/shared/errorBanner.css
+++ b/packages/base/style/shared/errorBanner.css
@@ -1,0 +1,78 @@
+.jgis-error-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: var(--jp-ui-font-color1);
+}
+
+.jgis-error-banner-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.jgis-error-banner-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.jgis-error-banner-message {
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.jgis-error-banner-dismiss {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.jgis-error-banner-dismiss:hover,
+.jgis-error-banner-dismiss:focus-visible {
+  opacity: 1;
+}
+
+.jgis-error-banner-dismiss svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.jgis-error-banner[data-variant='info'] {
+  border-color: color-mix(in srgb, var(--jp-info-color1) 40%, transparent);
+  background-color: color-mix(in srgb, var(--jp-info-color1) 12%, transparent);
+}
+
+.jgis-error-banner[data-variant='info'] .jgis-error-banner-icon {
+  color: var(--jp-info-color1);
+}
+
+.jgis-error-banner[data-variant='warning'] {
+  border-color: color-mix(in srgb, var(--jp-warn-color1) 40%, transparent);
+  background-color: color-mix(in srgb, var(--jp-warn-color1) 12%, transparent);
+}
+
+.jgis-error-banner[data-variant='warning'] .jgis-error-banner-icon {
+  color: var(--jp-warn-color1);
+}
+
+.jgis-error-banner[data-variant='error'] {
+  border-color: color-mix(in srgb, var(--jp-error-color1) 40%, transparent);
+  background-color: color-mix(in srgb, var(--jp-error-color1) 12%, transparent);
+}
+
+.jgis-error-banner[data-variant='error'] .jgis-error-banner-icon {
+  color: var(--jp-error-color1);
+}


### PR DESCRIPTION
## Description

Part 1

Towards #1609

<img width="2476" height="1350" alt="30731" src="https://github.com/user-attachments/assets/669a5363-84b2-4439-b987-3cf36926a5b9" />


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1628.org.readthedocs.build/en/1628/
💡 JupyterLite preview: https://jupytergis--1628.org.readthedocs.build/en/1628/lite
💡 Specta preview: https://jupytergis--1628.org.readthedocs.build/en/1628/lite/specta

<!-- readthedocs-preview jupytergis end -->