### PR TITLE
docs: add dev-environment context to contributor guide (closes #580)

### DIFF
--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -6,7 +6,7 @@
 You only need to set up a development environment if you plan to **change
 JupyterGIS itself** — fixing a bug, adding a feature, or editing these docs
 locally. If you just want to _use_ JupyterGIS, you can skip everything below
-and install the released package by following the {doc}`../getting_started/index`.
+and install the released package by following the {doc}`user install instructions </user_guide/install>`.
 :::
 
 ## Development install

--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -5,7 +5,7 @@
 
 You only need to set up a development environment if you plan to **change
 JupyterGIS itself** — fixing a bug, adding a feature, or editing these docs
-locally. If you just want to *use* JupyterGIS, you can skip everything below
+locally. If you just want to _use_ JupyterGIS, you can skip everything below
 and install the released package by following the {doc}`../getting_started/index`.
 :::
 

--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -1,7 +1,7 @@
 # Development setup
 
-:::{hint} Do I need a development environment?
-:class: dropdown
+:::{admonition} Do I need a development environment?
+:class: hint, dropdown
 
 You only need to set up a development environment if you plan to **change
 JupyterGIS itself** — fixing a bug, adding a feature, or editing these docs
@@ -31,8 +31,8 @@ cd jupytergis
 
 ### Create a virtual environment
 
-:::{hint} What is a virtual environment, and why use one?
-:class: dropdown
+:::{admonition} What is a virtual environment, and why use one?
+:class: hint, dropdown
 
 A virtual environment is an isolated space for this project's dependencies, so
 the versions JupyterGIS needs (Python, Node.js, QGIS) don't clash with other

--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -36,7 +36,7 @@ cd jupytergis
 
 A virtual environment is an isolated space for this project's dependencies, so
 the versions JupyterGIS needs (Python, Node.js, QGIS) don't clash with other
-projects on your machine — and vice versa. The Micromamba option below sets one
+projects on your machine — and vice versa. The instructions below set one
 up for you.
 :::
 

--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -1,5 +1,14 @@
 # Development setup
 
+:::{hint} Do I need a development environment?
+:class: dropdown
+
+You only need to set up a development environment if you plan to **change
+JupyterGIS itself** — fixing a bug, adding a feature, or editing these docs
+locally. If you just want to *use* JupyterGIS, you can skip everything below
+and install the released package by following the {doc}`../getting_started/index`.
+:::
+
 ## Development install
 
 :::{note}
@@ -21,6 +30,15 @@ cd jupytergis
 ```
 
 ### Create a virtual environment
+
+:::{hint} What is a virtual environment, and why use one?
+:class: dropdown
+
+A virtual environment is an isolated space for this project's dependencies, so
+the versions JupyterGIS needs (Python, Node.js, QGIS) don't clash with other
+projects on your machine — and vice versa. The Micromamba option below sets one
+up for you.
+:::
 
 ````{tab} Micromamba (Recommended)
 ```{note}


### PR DESCRIPTION
## Summary

Closes #580.

Adds two collapsible [MyST dropdown](https://myst-parser.readthedocs.io/en/latest/syntax/admonitions.html) hint admonitions to `docs/contributor_guide/development_setup.md`, giving newcomers context without bloating the page (as suggested in the issue):

- **"Do I need a development environment?"** at the top — clarifies that these steps are only for people modifying JupyterGIS, and points users who just want to *use* it to the Getting Started guide.
- **"What is a virtual environment, and why use one?"** under that section — brief explanation for first-timers.

Both use the `:::{hint} … :class: dropdown` pattern the issue author suggested, so they're collapsed by default.

## Notes
- Docs-only change; the `{doc}` cross-reference targets the existing `getting_started/index` page.
- Transparency: this contribution was AI-assisted (drafted with Claude, reviewed against the actual doc contents). Happy to adjust wording or scope to fit your conventions.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1630.org.readthedocs.build/en/1630/
💡 JupyterLite preview: https://jupytergis--1630.org.readthedocs.build/en/1630/lite
💡 Specta preview: https://jupytergis--1630.org.readthedocs.build/en/1630/lite/specta

<!-- readthedocs-preview jupytergis end -->