### PR TITLE
Use IUrlResolverFactory to support local images in lite

### DIFF
--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -12,7 +12,10 @@ import {
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import type { IEditorServices } from '@jupyterlab/codeeditor';
 import { ICompletionProviderManager } from '@jupyterlab/completer';
-import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import type {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator } from '@jupyterlab/translation';
 import { CommandRegistry } from '@lumino/commands';
@@ -112,7 +115,8 @@ export function addCommands(
   state: IStateDB,
   editorServices: IEditorServices,
   rendermime: IRenderMimeRegistry,
-  completionProviderManager: ICompletionProviderManager | undefined,
+  urlResolverFactory?: IUrlResolverFactory,
+  completionProviderManager?: ICompletionProviderManager,
 ): void {
   const trans = translator.load('jupyterlab');
   const { commands } = app;
@@ -1947,6 +1951,7 @@ export function addCommands(
           tracker,
           editorServices,
           rendermime,
+          urlResolverFactory,
         );
         return;
       }
@@ -2088,6 +2093,7 @@ namespace Private {
     tracker: JupyterGISTracker,
     editorServices: IEditorServices,
     rendermime: IRenderMimeRegistry,
+    urlResolverFactory?: IUrlResolverFactory,
   ): Promise<void> {
     await StoryEditorSession.getInstance().openEditor(
       model,
@@ -2097,6 +2103,7 @@ namespace Private {
       tracker,
       editorServices,
       rendermime,
+      urlResolverFactory,
     );
   }
 

--- a/packages/base/src/features/story/components/StoryRenderMime.tsx
+++ b/packages/base/src/features/story/components/StoryRenderMime.tsx
@@ -3,6 +3,7 @@ import { AttachmentsModel, AttachmentsResolver } from '@jupyterlab/attachments';
 import {
   RenderMimeRegistry,
   type IRenderMimeRegistry,
+  type IUrlResolverFactory,
 } from '@jupyterlab/rendermime';
 import React, { createContext, useContext, useMemo } from 'react';
 
@@ -10,9 +11,22 @@ import { getSegmentAttachments } from '@/src/features/story/utils/storySegmentAt
 
 const StoryRenderMimeContext = createContext<IRenderMimeRegistry | null>(null);
 
+function getUrlResolverFactory(
+  urlResolverFactory?: IUrlResolverFactory,
+): IUrlResolverFactory {
+  return (
+    urlResolverFactory ?? {
+      createResolver: (
+        options: RenderMimeRegistry.IUrlResolverOptions,
+      ) => new RenderMimeRegistry.UrlResolver(options),
+    }
+  );
+}
+
 function createStoryRenderMimeRegistry(
   rendermime: IRenderMimeRegistry,
   model: IJupyterGISModel,
+  urlResolverFactory?: IUrlResolverFactory,
 ): IRenderMimeRegistry {
   const { filePath, contentsManager } = model;
 
@@ -22,7 +36,7 @@ function createStoryRenderMimeRegistry(
     );
   }
 
-  const resolver = new RenderMimeRegistry.UrlResolver({
+  const resolver = getUrlResolverFactory(urlResolverFactory).createResolver({
     path: filePath,
     contents: contentsManager,
   });
@@ -33,17 +47,20 @@ function createStoryRenderMimeRegistry(
 interface IStoryRenderMimeProviderProps {
   rendermime: IRenderMimeRegistry;
   model: IJupyterGISModel;
+  urlResolverFactory?: IUrlResolverFactory;
   children: React.ReactNode;
 }
 
 export function StoryRenderMimeProvider({
   rendermime,
   model,
+  urlResolverFactory,
   children,
 }: IStoryRenderMimeProviderProps): JSX.Element {
   const scopedRendermime = useMemo(
-    () => createStoryRenderMimeRegistry(rendermime, model),
-    [rendermime, model, model.filePath, model.contentsManager],
+    () =>
+      createStoryRenderMimeRegistry(rendermime, model, urlResolverFactory),
+    [rendermime, model, model.filePath, model.contentsManager, urlResolverFactory],
   );
 
   return (

--- a/packages/base/src/features/story/components/StoryRenderMime.tsx
+++ b/packages/base/src/features/story/components/StoryRenderMime.tsx
@@ -16,9 +16,8 @@ function getUrlResolverFactory(
 ): IUrlResolverFactory {
   return (
     urlResolverFactory ?? {
-      createResolver: (
-        options: RenderMimeRegistry.IUrlResolverOptions,
-      ) => new RenderMimeRegistry.UrlResolver(options),
+      createResolver: (options: RenderMimeRegistry.IUrlResolverOptions) =>
+        new RenderMimeRegistry.UrlResolver(options),
     }
   );
 }
@@ -58,9 +57,14 @@ export function StoryRenderMimeProvider({
   children,
 }: IStoryRenderMimeProviderProps): JSX.Element {
   const scopedRendermime = useMemo(
-    () =>
-      createStoryRenderMimeRegistry(rendermime, model, urlResolverFactory),
-    [rendermime, model, model.filePath, model.contentsManager, urlResolverFactory],
+    () => createStoryRenderMimeRegistry(rendermime, model, urlResolverFactory),
+    [
+      rendermime,
+      model,
+      model.filePath,
+      model.contentsManager,
+      urlResolverFactory,
+    ],
   );
 
   return (

--- a/packages/base/src/features/story/storyEditorDialog.tsx
+++ b/packages/base/src/features/story/storyEditorDialog.tsx
@@ -1,7 +1,10 @@
 import { IJGISFormSchemaRegistry, IJupyterGISModel } from '@jupytergis/schema';
 import { Dialog } from '@jupyterlab/apputils';
 import type { IEditorServices } from '@jupyterlab/codeeditor';
-import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import type {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { IStateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 import React from 'react';
@@ -17,6 +20,7 @@ export interface IStoryEditorWidgetOptions {
   formSchemaRegistry: IJGISFormSchemaRegistry;
   editorServices: IEditorServices;
   rendermime: IRenderMimeRegistry;
+  urlResolverFactory?: IUrlResolverFactory;
 }
 
 export class StoryEditorWidget extends Dialog<boolean> {
@@ -27,6 +31,7 @@ export class StoryEditorWidget extends Dialog<boolean> {
       <StoryRenderMimeProvider
         rendermime={options.rendermime}
         model={options.model}
+        urlResolverFactory={options.urlResolverFactory}
       >
         <StoryEditorDialogBody
           model={options.model}

--- a/packages/base/src/features/story/storyEditorSession.ts
+++ b/packages/base/src/features/story/storyEditorSession.ts
@@ -3,7 +3,10 @@ import type {
   IJupyterGISModel,
 } from '@jupytergis/schema';
 import type { IEditorServices } from '@jupyterlab/codeeditor';
-import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import type {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { IStateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 
@@ -44,6 +47,7 @@ interface ISharedEditorContext {
   tracker: JupyterGISTracker;
   editorServices: IEditorServices;
   rendermime: IRenderMimeRegistry;
+  urlResolverFactory?: IUrlResolverFactory;
 }
 
 export const StoryEditorMode = {
@@ -88,6 +92,7 @@ export class StoryEditorSession implements IStoryMapBarHost {
     tracker: JupyterGISTracker,
     editorServices: IEditorServices,
     rendermime: IRenderMimeRegistry,
+    urlResolverFactory?: IUrlResolverFactory,
   ): void {
     this._context = {
       commands,
@@ -96,6 +101,7 @@ export class StoryEditorSession implements IStoryMapBarHost {
       tracker,
       editorServices,
       rendermime,
+      urlResolverFactory,
     };
 
     this.releaseOtherDialogs(model);
@@ -112,6 +118,7 @@ export class StoryEditorSession implements IStoryMapBarHost {
     tracker: JupyterGISTracker,
     editorServices: IEditorServices,
     rendermime: IRenderMimeRegistry,
+    urlResolverFactory?: IUrlResolverFactory,
   ): Promise<void> {
     this._context = {
       commands,
@@ -120,6 +127,7 @@ export class StoryEditorSession implements IStoryMapBarHost {
       tracker,
       editorServices,
       rendermime,
+      urlResolverFactory,
     };
     this.bindTracker();
 
@@ -455,6 +463,7 @@ export class StoryEditorSession implements IStoryMapBarHost {
       formSchemaRegistry: this._context.formSchemaRegistry,
       editorServices: this._context.editorServices,
       rendermime: this._context.rendermime,
+      urlResolverFactory: this._context.urlResolverFactory,
     });
     editorState.dialog = dialog;
 

--- a/packages/base/src/mainview/mainviewwidget.tsx
+++ b/packages/base/src/mainview/mainviewwidget.tsx
@@ -1,7 +1,10 @@
 import { IAnnotationModel, IJGISFormSchemaRegistry } from '@jupytergis/schema';
 import { ReactWidget } from '@jupyterlab/apputils';
 import type { ILoggerRegistry } from '@jupyterlab/logconsole';
-import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import type {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { IStateDB } from '@jupyterlab/statedb';
 import * as React from 'react';
 
@@ -12,6 +15,7 @@ import { MainViewModel } from '@/src/mainview/mainviewmodel';
 export interface IOptions {
   mainViewModel: MainViewModel;
   rendermime: IRenderMimeRegistry;
+  urlResolverFactory?: IUrlResolverFactory;
   state?: IStateDB;
   formSchemaRegistry?: IJGISFormSchemaRegistry;
   annotationModel?: IAnnotationModel;
@@ -28,6 +32,7 @@ export class JupyterGISMainViewPanel extends ReactWidget {
     this._state = options.state;
     this._options = options;
     this._rendermime = options.rendermime;
+    this._urlResolverFactory = options.urlResolverFactory;
 
     this.addClass('jp-jupytergis-panel');
   }
@@ -37,6 +42,7 @@ export class JupyterGISMainViewPanel extends ReactWidget {
       <StoryRenderMimeProvider
         rendermime={this._rendermime}
         model={this._options.mainViewModel.jGISModel}
+        urlResolverFactory={this._urlResolverFactory}
       >
         <MainViewWithObserver
           state={this._state}
@@ -52,4 +58,5 @@ export class JupyterGISMainViewPanel extends ReactWidget {
   private _state?: IStateDB;
   private _options: IOptions;
   private _rendermime: IRenderMimeRegistry;
+  private _urlResolverFactory?: IUrlResolverFactory;
 }

--- a/packages/base/src/workspace/widget.ts
+++ b/packages/base/src/workspace/widget.ts
@@ -10,7 +10,10 @@ import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import type { ILoggerRegistry } from '@jupyterlab/logconsole';
 import { IObservableMap, ObservableMap } from '@jupyterlab/observables';
-import type { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import type {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { IStateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 import { JSONValue } from '@lumino/coreutils';
@@ -102,6 +105,7 @@ export class JupyterGISPanel extends SplitPanel {
   constructor({
     model,
     rendermime,
+    urlResolverFactory,
     consoleTracker,
     state,
     commandRegistry,
@@ -114,6 +118,7 @@ export class JupyterGISPanel extends SplitPanel {
 
     this._state = state;
     this._rendermime = rendermime;
+    this._urlResolverFactory = urlResolverFactory;
     this._consoleOption = { commandRegistry, rendermime, ...consoleOption };
     this._consoleTracker = consoleTracker;
 
@@ -158,6 +163,7 @@ export class JupyterGISPanel extends SplitPanel {
       annotationModel: annotationModel,
       loggerRegistry: loggerRegistry,
       rendermime: this._rendermime,
+      urlResolverFactory: this._urlResolverFactory,
     });
     this.addWidget(this._jupyterGISMainViewPanel);
     SplitPanel.setStretch(this._jupyterGISMainViewPanel, 1);
@@ -286,6 +292,7 @@ export class JupyterGISPanel extends SplitPanel {
   private _view: ObservableMap<JSONValue>;
   private _jupyterGISMainViewPanel: JupyterGISMainViewPanel;
   private _rendermime: IRenderMimeRegistry;
+  private _urlResolverFactory?: IUrlResolverFactory;
   private _consoleView?: ConsoleView;
   private _consoleOpened = false;
   private _consoleOption: Partial<ConsoleView.IOptions>;
@@ -297,6 +304,7 @@ export namespace JupyterGISPanel {
     model: IJupyterGISModel;
     commandRegistry: CommandRegistry;
     rendermime: IRenderMimeRegistry;
+    urlResolverFactory?: IUrlResolverFactory;
     state?: IStateDB;
     consoleTracker?: IConsoleTracker;
     formSchemaRegistry?: IJGISFormSchemaRegistry;

--- a/python/jupytergis_core/src/factory.ts
+++ b/python/jupytergis_core/src/factory.ts
@@ -14,7 +14,10 @@ import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
 import type { ILoggerRegistry } from '@jupyterlab/logconsole';
-import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
+import {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { Contents, ServiceManager } from '@jupyterlab/services';
 import { IStateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';

--- a/python/jupytergis_core/src/factory.ts
+++ b/python/jupytergis_core/src/factory.ts
@@ -14,7 +14,7 @@ import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
 import type { ILoggerRegistry } from '@jupyterlab/logconsole';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
 import { Contents, ServiceManager } from '@jupyterlab/services';
 import { IStateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
@@ -27,6 +27,7 @@ interface IOptions extends DocumentRegistry.IWidgetFactoryOptions {
   contentFactory?: ConsolePanel.IContentFactory;
   mimeTypeService?: IEditorMimeTypeService;
   rendermime: IRenderMimeRegistry;
+  urlResolverFactory?: IUrlResolverFactory;
   consoleTracker?: IConsoleTracker;
   backendCheck?: () => boolean;
   drive?: Contents.IDrive | null;
@@ -79,6 +80,7 @@ export class JupyterGISDocumentWidgetFactory extends ABCWidgetFactory<
       contentFactory: this.options.contentFactory,
       mimeTypeService: this.options.mimeTypeService,
       rendermime: this.options.rendermime,
+      urlResolverFactory: this.options.urlResolverFactory,
       consoleTracker: this.options.consoleTracker,
       commandRegistry: this.options.commands,
       state: this.options.state,

--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -38,7 +38,10 @@ import { MimeDocumentFactory } from '@jupyterlab/docregistry';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import { ILoggerRegistry } from '@jupyterlab/logconsole';
-import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
+import {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { SharedDocumentFactory } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';

--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -38,7 +38,7 @@ import { MimeDocumentFactory } from '@jupyterlab/docregistry';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import { ILoggerRegistry } from '@jupyterlab/logconsole';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
 import { SharedDocumentFactory } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';
@@ -70,6 +70,7 @@ const activate = async (
   palette: ICommandPalette | null,
   collaborativeContentProvider: ICollaborativeContentProvider | null,
   loggerRegistry: ILoggerRegistry | null,
+  urlResolverFactory: IUrlResolverFactory | null,
 ): Promise<void> => {
   formSchemaRegistry && state;
   if (PageConfig.getOption('jgis_expose_maps')) {
@@ -171,6 +172,7 @@ const activate = async (
     manager: app.serviceManager,
     contentFactory,
     rendermime,
+    urlResolverFactory: urlResolverFactory ?? undefined,
     mimeTypeService: editorServices.mimeTypeService,
     formSchemaRegistry: formSchemaRegistry,
     consoleTracker,
@@ -398,6 +400,7 @@ const jGISPlugin: JupyterFrontEndPlugin<void> = {
     ICommandPalette,
     ICollaborativeContentProvider,
     ILoggerRegistry,
+    IUrlResolverFactory,
   ],
   autoStart: true,
   activate,

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -22,7 +22,7 @@ import { WidgetTracker } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { ICompletionProviderManager } from '@jupyterlab/completer';
 import { IMainMenu } from '@jupyterlab/mainmenu';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { Menu } from '@lumino/widgets';
@@ -40,7 +40,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     IEditorServices,
     IRenderMimeRegistry,
   ],
-  optional: [IMainMenu, ITranslator, ICompletionProviderManager],
+  optional: [IMainMenu, ITranslator, ICompletionProviderManager, IUrlResolverFactory],
   activate: (
     app: JupyterFrontEnd,
     tracker: WidgetTracker<IJupyterGISWidget>,
@@ -52,6 +52,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     mainMenu?: IMainMenu,
     translator?: ITranslator,
     completionProviderManager?: ICompletionProviderManager,
+    urlResolverFactory?: IUrlResolverFactory,
   ): void => {
     console.debug('jupytergis:lab:main-menu is activated!');
     translator = translator ?? nullTranslator;
@@ -95,6 +96,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       state,
       editorServices,
       rendermime,
+      urlResolverFactory,
       completionProviderManager,
     );
 

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -22,7 +22,10 @@ import { WidgetTracker } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { ICompletionProviderManager } from '@jupyterlab/completer';
 import { IMainMenu } from '@jupyterlab/mainmenu';
-import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
+import {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { Menu } from '@lumino/widgets';
@@ -40,7 +43,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
     IEditorServices,
     IRenderMimeRegistry,
   ],
-  optional: [IMainMenu, ITranslator, ICompletionProviderManager, IUrlResolverFactory],
+  optional: [
+    IMainMenu,
+    ITranslator,
+    ICompletionProviderManager,
+    IUrlResolverFactory,
+  ],
   activate: (
     app: JupyterFrontEnd,
     tracker: WidgetTracker<IJupyterGISWidget>,

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -24,7 +24,7 @@ import { showErrorMessage } from '@jupyterlab/apputils';
 import { ConsolePanel } from '@jupyterlab/console';
 import { PathExt } from '@jupyterlab/coreutils';
 import { NotebookPanel } from '@jupyterlab/notebook';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
 import { Contents, IDefaultDrive } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';
@@ -102,6 +102,7 @@ export class YJupyterGISLuminoWidget extends Panel {
       state,
       annotationModel,
       rendermime,
+      urlResolverFactory,
     } = options;
     const content = new JupyterGISPanel({
       model,
@@ -110,6 +111,7 @@ export class YJupyterGISLuminoWidget extends Panel {
       state,
       annotationModel,
       rendermime,
+      urlResolverFactory,
     });
     let toolbar: Toolbar | undefined = undefined;
     if (model.filePath) {
@@ -135,6 +137,7 @@ interface IOptions {
   commands: CommandRegistry;
   model: JupyterGISModel;
   rendermime: IRenderMimeRegistry;
+  urlResolverFactory?: IUrlResolverFactory;
   externalCommands?: IJGISExternalCommandRegistry;
   tracker?: JupyterGISTracker;
   formSchemaRegistry: IJGISFormSchemaRegistry;
@@ -154,6 +157,7 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
     IStateDB,
     IAnnotationToken,
     ISettingRegistry,
+    IUrlResolverFactory,
   ],
   activate: (
     app: JupyterFrontEnd,
@@ -166,6 +170,7 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
     state?: IStateDB,
     annotationModel?: IAnnotationModel,
     settingRegistry?: ISettingRegistry,
+    urlResolverFactory?: IUrlResolverFactory,
   ): void => {
     if (!yWidgetManager) {
       console.error('Missing IJupyterYWidgetManager token!');
@@ -259,6 +264,7 @@ export const notebookRendererPlugin: JupyterFrontEndPlugin<void> = {
           model: yModel.jupyterGISModel,
           externalCommands: externalCommandRegistry,
           rendermime,
+          urlResolverFactory,
           tracker: jgisTracker,
           annotationModel,
           state,

--- a/python/jupytergis_lab/src/notebookrenderer.ts
+++ b/python/jupytergis_lab/src/notebookrenderer.ts
@@ -24,7 +24,10 @@ import { showErrorMessage } from '@jupyterlab/apputils';
 import { ConsolePanel } from '@jupyterlab/console';
 import { PathExt } from '@jupyterlab/coreutils';
 import { NotebookPanel } from '@jupyterlab/notebook';
-import { IRenderMimeRegistry, IUrlResolverFactory } from '@jupyterlab/rendermime';
+import {
+  IRenderMimeRegistry,
+  IUrlResolverFactory,
+} from '@jupyterlab/rendermime';
 import { Contents, IDefaultDrive } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStateDB } from '@jupyterlab/statedb';


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Use `IUrlResolverFactory` to support local images in markdown segments when using Jupyter Lite / Notebook.link

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1635.org.readthedocs.build/en/1635/
💡 JupyterLite preview: https://jupytergis--1635.org.readthedocs.build/en/1635/lite
💡 Specta preview: https://jupytergis--1635.org.readthedocs.build/en/1635/lite/specta

<!-- readthedocs-preview jupytergis end -->