### PR TITLE
Reduce radius of circle highlight style

### DIFF
--- a/packages/base/src/features/identify/utils/highlightStyle.ts
+++ b/packages/base/src/features/identify/utils/highlightStyle.ts
@@ -16,7 +16,7 @@ export function buildHighlightStyle(original: Style, geomType?: string): Style {
     if (image instanceof CircleStyle) {
       return new Style({
         image: new Circle({
-          radius: image.getRadius() + 4,
+          radius: image.getRadius(),
           fill: new Fill({ color: 'transparent' }),
           stroke: new Stroke({ color: '#ff0', width: 3 }),
         }),


### PR DESCRIPTION
## Description

This PR removes the additional radius from the Circle Style to fix the highlighted feature outline shifts.

Now it looks more suitable than before.

#### Chrome 
<img width="116" height="115" alt="image" src="https://github.com/user-attachments/assets/ffbe65f5-8ca1-4673-b82e-a7c5f78f58f6" />

#### Brave
<img width="116" height="115" alt="image" src="https://github.com/user-attachments/assets/08dce45b-d0e5-444e-bc06-2f75c758a4d8" />

#### Firefox
<img width="116" height="115" alt="image" src="https://github.com/user-attachments/assets/848e5c94-a0a7-45a3-b035-3d6249689f00" />

#### Mobile screen

<img width="211" height="199" alt="image" src="https://github.com/user-attachments/assets/32e7ebce-fccc-4ba1-baa4-ff1a3a12b0a0" />


- Closes #1441 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1641.org.readthedocs.build/en/1641/
💡 JupyterLite preview: https://jupytergis--1641.org.readthedocs.build/en/1641/lite
💡 Specta preview: https://jupytergis--1641.org.readthedocs.build/en/1641/lite/specta

<!-- readthedocs-preview jupytergis end -->