### PR TITLE
Add field-level ErrorTip and extract shared HoverTip primitive

### DIFF
--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -45,6 +45,7 @@ import {
   IComputedStop,
 } from '@/src/features/layers/symbology/styleBuilder';
 import { IStopRow } from '@/src/features/layers/symbology/symbologyDialog';
+import { ErrorTip } from '@/src/shared/components/ErrorTip';
 import { InfoTip } from '@/src/shared/components/InfoTip';
 
 function stopsToRows(
@@ -670,7 +671,12 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
           </InfoTip>
         </label>
         <div
-          style={{ display: 'flex', flexDirection: 'column', flex: '1 1 auto' }}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            flex: '1 1 auto',
+          }}
         >
           <div
             ref={editorRef}
@@ -686,18 +692,7 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
               overflow: 'auto',
             }}
           />
-          {validationError && (
-            <div
-              role="alert"
-              style={{
-                color: 'var(--jp-error-color1)',
-                fontSize: 'var(--jp-ui-font-size0)',
-                marginTop: 4,
-              }}
-            >
-              {validationError}
-            </div>
-          )}
+          {validationError && <ErrorTip text={validationError} />}
         </div>
       </div>
 

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -692,7 +692,17 @@ export const ExpressionEditor: React.FC<IExpressionEditorProps> = ({
               overflow: 'auto',
             }}
           />
-          {validationError && <ErrorTip text={validationError} />}
+          {validationError && (
+            <ErrorTip text={validationError}>
+              <a
+                href="https://vega.github.io/vega/docs/expressions/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Expression syntax reference
+              </a>
+            </ErrorTip>
+          )}
         </div>
       </div>
 

--- a/packages/base/src/shared/components/ErrorTip.tsx
+++ b/packages/base/src/shared/components/ErrorTip.tsx
@@ -1,0 +1,36 @@
+import { XCircle } from 'lucide-react';
+import React from 'react';
+
+import { HoverTip, IHoverTipProps } from './HoverTip';
+import { cn } from './utils';
+
+interface IErrorTipProps extends Omit<IHoverTipProps, 'icon' | 'triggerLabel'> {
+  /**
+   * Accessible label for the trigger.
+   *
+   * @default 'Validation error'
+   */
+  triggerLabel?: string;
+}
+
+/**
+ * A compact field-level error indicator: a `❌` icon that reveals the error
+ * `text` on hover. Use next to a self-validating form field.
+ *
+ * For dialog- or panel-scoped messages use `ErrorBanner`; for app-global
+ * messages use `Notification` from `@jupyterlab/apputils`.
+ */
+export function ErrorTip({
+  triggerLabel = 'Validation error',
+  className,
+  ...props
+}: IErrorTipProps) {
+  return (
+    <HoverTip
+      icon={<XCircle data-size="md" className="jgis-error-tip-icon" />}
+      triggerLabel={triggerLabel}
+      className={cn('jgis-error-tip-content', className)}
+      {...props}
+    />
+  );
+}

--- a/packages/base/src/shared/components/HoverTip.tsx
+++ b/packages/base/src/shared/components/HoverTip.tsx
@@ -1,0 +1,80 @@
+import { ChevronRightIcon } from 'lucide-react';
+import React, { ReactNode } from 'react';
+
+import { Button } from './Button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from './Collapsible';
+import { HoverCardTrigger, HoverCardContent, HoverCard } from './HoverCard';
+import { cn } from './utils';
+
+export interface IHoverTipProps extends Omit<
+  React.ComponentProps<typeof HoverCardContent>,
+  'children'
+> {
+  /**
+   * Icon rendered as the hover trigger.
+   */
+  icon: ReactNode;
+  /**
+   * Accessible label for the trigger.
+   */
+  triggerLabel: string;
+  text: string;
+  openDelay?: number;
+  closeDelay?: number;
+  children?: ReactNode;
+}
+
+/**
+ * Shared hover-tip primitive: an icon trigger that reveals `text` (and optional
+ * collapsible `children`) on hover. Not used directly — see `InfoTip` and
+ * `ErrorTip` for the concrete variants.
+ */
+export function HoverTip({
+  icon,
+  triggerLabel,
+  children,
+  text,
+  openDelay = 100,
+  closeDelay = 100,
+  className,
+  portalContainerRef,
+  ...contentProps
+}: IHoverTipProps) {
+  return (
+    <HoverCard openDelay={openDelay} closeDelay={closeDelay}>
+      <HoverCardTrigger aria-label={triggerLabel}>{icon}</HoverCardTrigger>
+      <HoverCardContent
+        portalContainerRef={portalContainerRef}
+        className={cn('jgis-info-tip-content', className)}
+        {...contentProps}
+      >
+        {text}
+        {children && (
+          <Collapsible asChild>
+            <div className="jgis-info-tip-collapsible">
+              <CollapsibleTrigger asChild>
+                <div className="jgis-info-tip-collapsible-trigger">
+                  <Button
+                    size="icon-sm"
+                    variant="icon"
+                    className="jgis-rotate-90 jgis-bg-transparent"
+                  >
+                    <ChevronRightIcon data-icon="inline-start" />
+                  </Button>
+                  <span className="jgis-info-tip-more-info">More Info</span>
+                </div>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="jgis-info-tip-collapsible-content">
+                {children}
+              </CollapsibleContent>
+            </div>
+          </Collapsible>
+        )}
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/packages/base/src/shared/components/InfoTip.tsx
+++ b/packages/base/src/shared/components/InfoTip.tsx
@@ -1,67 +1,16 @@
-import { ChevronRightIcon, Info } from 'lucide-react';
-import React, { ReactNode } from 'react';
+import { Info } from 'lucide-react';
+import React from 'react';
 
-import { Button } from './Button';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from './Collapsible';
-import { HoverCardTrigger, HoverCardContent, HoverCard } from './HoverCard';
-import { cn } from './utils';
+import { HoverTip, IHoverTipProps } from './HoverTip';
 
-interface IInfoTipProps extends Omit<
-  React.ComponentProps<typeof HoverCardContent>,
-  'children'
-> {
-  text: string;
-  openDelay?: number;
-  closeDelay?: number;
-  children?: ReactNode;
-}
+type IInfoTipProps = Omit<IHoverTipProps, 'icon' | 'triggerLabel'>;
 
-export function InfoTip({
-  children,
-  text,
-  openDelay = 100,
-  closeDelay = 100,
-  className,
-  portalContainerRef,
-  ...contentProps
-}: IInfoTipProps) {
+export function InfoTip(props: IInfoTipProps) {
   return (
-    <HoverCard openDelay={openDelay} closeDelay={closeDelay}>
-      <HoverCardTrigger aria-label="More information">
-        <Info data-size="md" />
-      </HoverCardTrigger>
-      <HoverCardContent
-        portalContainerRef={portalContainerRef}
-        className={cn('jgis-info-tip-content', className)}
-        {...contentProps}
-      >
-        {text}
-        {children && (
-          <Collapsible asChild>
-            <div className="jgis-info-tip-collapsible">
-              <CollapsibleTrigger asChild>
-                <div className="jgis-info-tip-collapsible-trigger">
-                  <Button
-                    size="icon-sm"
-                    variant="icon"
-                    className="jgis-rotate-90 jgis-bg-transparent"
-                  >
-                    <ChevronRightIcon data-icon="inline-start" />
-                  </Button>
-                  <span className="jgis-info-tip-more-info">More Info</span>
-                </div>
-              </CollapsibleTrigger>
-              <CollapsibleContent className="jgis-info-tip-collapsible-content">
-                {children}
-              </CollapsibleContent>
-            </div>
-          </Collapsible>
-        )}
-      </HoverCardContent>
-    </HoverCard>
+    <HoverTip
+      icon={<Info data-size="md" />}
+      triggerLabel="More information"
+      {...props}
+    />
   );
 }

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -37,6 +37,7 @@
 @import url('./shared/hoverCard.css');
 @import url('./shared/infoTip.css');
 @import url('./shared/errorBanner.css');
+@import url('./shared/errorTip.css');
 @import url('./shared/command.css');
 @import url('./shared/combobox.css');
 @import url('./shared/input.css');

--- a/packages/base/style/shared/errorTip.css
+++ b/packages/base/style/shared/errorTip.css
@@ -3,6 +3,5 @@
 }
 
 .jgis-error-tip-content {
-  color: var(--jp-error-color1);
   max-width: 20rem;
 }

--- a/packages/base/style/shared/errorTip.css
+++ b/packages/base/style/shared/errorTip.css
@@ -1,0 +1,8 @@
+.jgis-error-tip-icon {
+  color: var(--jp-error-color1);
+}
+
+.jgis-error-tip-content {
+  color: var(--jp-error-color1);
+  max-width: 20rem;
+}

--- a/ui-tests/tests/error-tip.spec.ts
+++ b/ui-tests/tests/error-tip.spec.ts
@@ -1,0 +1,66 @@
+import { expect, galata, test } from '@jupyterlab/galata';
+import path from 'path';
+
+const FILENAME = 'graduated-lines-test.jGIS';
+
+test.describe('#errorTip', () => {
+  test.beforeAll(async ({ request }) => {
+    const content = galata.newContentsHelper(request);
+    await content.deleteDirectory('/testDir');
+    await content.uploadDirectory(
+      path.resolve(__dirname, './gis-files'),
+      '/testDir',
+    );
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.open(`testDir/${FILENAME}`);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.activity.closeAll();
+  });
+
+  test('invalid expression shows a field-level ErrorTip', async ({ page }) => {
+    const main = page.locator('.jGIS-Mainview');
+    await expect(main).toBeVisible();
+
+    // Open the symbology dialog for the vector layer.
+    await page
+      .getByText('Roads (Graduated)', { exact: true })
+      .click({ button: 'right' });
+    await page.getByText('Edit Symbology').click();
+
+    const dialog = page.locator('.jp-Dialog-content');
+    await expect(dialog).toBeAttached();
+
+    // Switch the mapping's scale scheme to "expression".
+    await dialog
+      .locator('.jp-gis-grammar-scale-section select')
+      .first()
+      .selectOption('expression');
+
+    // Expand the inline scale editor.
+    await dialog.locator('.jp-gis-grammar-preview-btn').first().click();
+
+    // The ErrorTip is not shown while the expression is empty.
+    await expect(dialog.getByLabel('Validation error')).toHaveCount(0);
+
+    // Type an invalid expression into the CodeMirror editor.
+    const editor = dialog.locator('.cm-content').first();
+    await editor.click();
+    await page.keyboard.type('1 +');
+
+    // Validation is debounced; the ErrorTip appears once it fails.
+    const errorTip = dialog.getByLabel('Validation error');
+    await expect(errorTip).toBeVisible();
+
+    // Hovering the tip reveals the validation message.
+    await errorTip.hover();
+    await expect(
+      page.locator('[data-slot="hover-card-content"]'),
+    ).toBeVisible();
+
+    await dialog.getByText('Cancel').click();
+  });
+});

--- a/ui-tests/tests/error-tip.spec.ts
+++ b/ui-tests/tests/error-tip.spec.ts
@@ -57,9 +57,18 @@ test.describe('#errorTip', () => {
 
     // Hovering the tip reveals the validation message.
     await errorTip.hover();
-    await expect(
-      page.locator('[data-slot="hover-card-content"]'),
-    ).toBeVisible();
+    const hoverCard = page.locator('[data-slot="hover-card-content"]');
+    await expect(hoverCard).toBeVisible();
+
+    // Expand "More Info" and verify the docs link.
+    await hoverCard.getByText('More Info').click();
+    const docsLink = hoverCard.getByRole('link', {
+      name: 'Expression syntax reference',
+    });
+    await expect(docsLink).toHaveAttribute(
+      'href',
+      'https://vega.github.io/vega/docs/expressions/',
+    );
 
     await dialog.getByText('Cancel').click();
   });


### PR DESCRIPTION
## Description

Towards #1609 

<img width="2398" height="690" alt="26248" src="https://github.com/user-attachments/assets/6a820d37-be6e-4aa2-94ae-3abcfd0ef04c" />



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1671.org.readthedocs.build/en/1671/
💡 JupyterLite preview: https://jupytergis--1671.org.readthedocs.build/en/1671/lite
💡 Specta preview: https://jupytergis--1671.org.readthedocs.build/en/1671/lite/specta

<!-- readthedocs-preview jupytergis end -->