### PR TITLE
Suppress warnings to fix RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,11 @@ extensions = [
     "myst_parser",
 ]
 
+suppress_warnings = [
+    "sphinx_autodoc_typehints.guarded_import",
+    "sphinx_autodoc_typehints.forward_reference",
+]
+
 myst_enable_extensions = [
     "colon_fence",
 ]


### PR DESCRIPTION
## Description

RTD Failure before https://app.readthedocs.org/projects/jupytergis/builds/33702441/

RTD build successfully But we got two warnings during the build and warnings are considered as errors so the RTD failed. So this PR suppress the warnings to get pass the test. 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1674.org.readthedocs.build/en/1674/
💡 JupyterLite preview: https://jupytergis--1674.org.readthedocs.build/en/1674/lite
💡 Specta preview: https://jupytergis--1674.org.readthedocs.build/en/1674/lite/specta

<!-- readthedocs-preview jupytergis end -->