### PR TITLE
Add explicit `sniffio` dependency to `tiler` optional group to restore functionality

### DIFF
--- a/python/jupytergis_lab/pyproject.toml
+++ b/python/jupytergis_lab/pyproject.toml
@@ -41,6 +41,7 @@ requires-python = ">=3.12"
 [project.optional-dependencies]
 tiler = [
   "jupyter-tiler>=0.8.1",
+  "sniffio",
 ]
 
 [tool.hatch.version]


### PR DESCRIPTION
## Description

Shall close #1676 

`jupytergis_lab[tiler]` gained an explicit `sniffio` dependency. This is not a new feature requirement - it restores a transitive dependency that `anyio` silently dropped, which broke the tiler's ASGI server (`anycorn`) at import time.

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1677.org.readthedocs.build/en/1677/
💡 JupyterLite preview: https://jupytergis--1677.org.readthedocs.build/en/1677/lite
💡 Specta preview: https://jupytergis--1677.org.readthedocs.build/en/1677/lite/specta

<!-- readthedocs-preview jupytergis end -->