### PR TITLE
Fix markdown scrolling

### DIFF
--- a/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
+++ b/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
@@ -22,12 +22,12 @@ function listStoryOverlayMarkdownPropsAreEqual(
 }
 
 /** Markdown body for a list-story stage overlay segment. */
-export const ListStoryOverlayMarkdown = memo(function ListStoryOverlayMarkdown({
+export const ListStoryOverlayMarkdown = memo(({
   model,
   segmentId,
   source,
   onRendered,
-}: IListStoryOverlayMarkdownProps): JSX.Element | null {
+}: IListStoryOverlayMarkdownProps): JSX.Element | null => {
   return (
     <RenderedStoryMarkdown
       model={model}

--- a/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
+++ b/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
@@ -22,18 +22,21 @@ function listStoryOverlayMarkdownPropsAreEqual(
 }
 
 /** Markdown body for a list-story stage overlay segment. */
-export const ListStoryOverlayMarkdown = memo(({
-  model,
-  segmentId,
-  source,
-  onRendered,
-}: IListStoryOverlayMarkdownProps): JSX.Element | null => {
-  return (
-    <RenderedStoryMarkdown
-      model={model}
-      segmentId={segmentId}
-      source={source}
-      onRendered={onRendered}
-    />
-  );
-}, listStoryOverlayMarkdownPropsAreEqual);
+export const ListStoryOverlayMarkdown = memo(
+  ({
+    model,
+    segmentId,
+    source,
+    onRendered,
+  }: IListStoryOverlayMarkdownProps): JSX.Element | null => {
+    return (
+      <RenderedStoryMarkdown
+        model={model}
+        segmentId={segmentId}
+        source={source}
+        onRendered={onRendered}
+      />
+    );
+  },
+  listStoryOverlayMarkdownPropsAreEqual,
+);

--- a/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
+++ b/packages/base/src/features/story/components/ListStoryOverlayMarkdown.tsx
@@ -1,5 +1,5 @@
 import type { IJupyterGISModel } from '@jupytergis/schema';
-import React from 'react';
+import React, { memo } from 'react';
 
 import { RenderedStoryMarkdown } from '@/src/features/story/components/RenderedStoryMarkdown';
 
@@ -10,8 +10,19 @@ interface IListStoryOverlayMarkdownProps {
   onRendered?: () => void;
 }
 
+function listStoryOverlayMarkdownPropsAreEqual(
+  prev: IListStoryOverlayMarkdownProps,
+  next: IListStoryOverlayMarkdownProps,
+): boolean {
+  return (
+    prev.model === next.model &&
+    prev.segmentId === next.segmentId &&
+    prev.source === next.source
+  );
+}
+
 /** Markdown body for a list-story stage overlay segment. */
-export function ListStoryOverlayMarkdown({
+export const ListStoryOverlayMarkdown = memo(function ListStoryOverlayMarkdown({
   model,
   segmentId,
   source,
@@ -25,4 +36,4 @@ export function ListStoryOverlayMarkdown({
       onRendered={onRendered}
     />
   );
-}
+}, listStoryOverlayMarkdownPropsAreEqual);

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -180,8 +180,8 @@ interface ISegmentOverlayPaneProps {
   model: IJupyterGISModel;
   storyData: IJGISStoryMap;
   items: IStorySegmentViewItem[];
-  onMarkdownRendered?: (segmentIndex: number) => void;
-  onPaneUnmount?: (segmentIndex: number) => void;
+  onMarkdownRendered: (segmentIndex: number) => void;
+  onPaneUnmount: (segmentIndex: number) => void;
 }
 
 function segmentConfigsEqual(
@@ -191,14 +191,15 @@ function segmentConfigsEqual(
   if (prev.type !== next.type) {
     return false;
   }
+
   if (prev.type === 'map' && next.type === 'map') {
     return prev.segmentIndex === next.segmentIndex;
   }
+
   if (prev.type === 'markdown' && next.type === 'markdown') {
-    return (
-      prev.segmentId === next.segmentId && prev.markdown === next.markdown
-    );
+    return prev.segmentId === next.segmentId && prev.markdown === next.markdown;
   }
+
   return false;
 }
 
@@ -216,7 +217,7 @@ function segmentOverlayPanePropsAreEqual(
   );
 }
 
-const SegmentOverlayPane = React.memo(function SegmentOverlayPane({
+const SegmentOverlayPane = React.memo(({
   pane,
   segmentIndex,
   config,
@@ -225,12 +226,12 @@ const SegmentOverlayPane = React.memo(function SegmentOverlayPane({
   items,
   onMarkdownRendered,
   onPaneUnmount,
-}: ISegmentOverlayPaneProps): React.ReactElement {
+}: ISegmentOverlayPaneProps): React.ReactElement => {
   const isMap = config.type === 'map';
 
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     return () => {
-      onPaneUnmount?.(segmentIndex);
+      onPaneUnmount(segmentIndex);
     };
   }, [segmentIndex, onPaneUnmount]);
 
@@ -254,13 +255,7 @@ const SegmentOverlayPane = React.memo(function SegmentOverlayPane({
           model={model}
           segmentId={config.segmentId}
           source={config.markdown}
-          onRendered={
-            onMarkdownRendered
-              ? () => {
-                  onMarkdownRendered(segmentIndex);
-                }
-              : undefined
-          }
+          onRendered={() => onMarkdownRendered(segmentIndex)}
         />
       ) : null}
     </div>
@@ -411,29 +406,29 @@ export function ListStoryStageOverlay({
       const paneEl = stack?.querySelector(
         `[data-segment-index="${segmentIndex}"]`,
       );
+
       if (paneEl instanceof HTMLElement) {
         const stackPane = overlayStack.panes.find(
           p => p.segmentIndex === segmentIndex,
         );
-        if (
-          stackPane?.config.type === 'markdown' &&
-          stackPane.config.segmentId
-        ) {
-          reportSegmentHeight(stackPane.config.segmentId, paneEl.offsetHeight);
-        }
+
+        const segmentId =
+          stackPane?.config.type === 'markdown'
+            ? stackPane.config.segmentId
+            : undefined;
+
+        const reportPaneHeight = (): void => {
+          if (segmentId) {
+            reportSegmentHeight(segmentId, paneEl.offsetHeight);
+          }
+        };
+
+        reportPaneHeight();
 
         imageWaitCancelRef.current?.();
         imageWaitCancelRef.current = whenImagesSettled(paneEl, () => {
           imageWaitCancelRef.current = null;
-          if (
-            stackPane?.config.type === 'markdown' &&
-            stackPane.config.segmentId
-          ) {
-            reportSegmentHeight(
-              stackPane.config.segmentId,
-              paneEl.offsetHeight,
-            );
-          }
+          reportPaneHeight();
           measureTransitionRef.current?.();
         });
       }
@@ -591,6 +586,7 @@ export function ListStoryStageOverlay({
   const currentTransitionKey = intraSegmentScroll
     ? `intra:${fromIndex}`
     : `handoff:${fromIndex}:${toIndex}:${transition?.fromMode ?? ''}:${transition?.toMode ?? ''}`;
+
   const scrollFromHeight = getScrollTrackSegmentHeight(
     scrollTrackLayout,
     fromIndex,
@@ -598,16 +594,25 @@ export function ListStoryStageOverlay({
   const fromTrackSegment = scrollTrackLayout?.segments.find(
     segment => segment.index === fromIndex,
   );
+
   const isMdToMdNoGap =
     !intraSegmentScroll &&
     handoffGapHeight === 0 &&
     transition?.fromMode === 'markdown' &&
     transition?.toMode === 'markdown';
+
   const translateIsCurrent =
     measuredTransitionKeyRef.current === currentTransitionKey &&
     transitionTranslatePx > 0;
-  // Md->md no-gap progress uses scroll-track height, prefer that once measured.
-  // Fall back to live DOM travel until the track catches up.
+
+  // Pixel travel for progress 0->1 (`--jgis-transition-translate`).
+  //
+  // Md->md with no gap: scroll progress is computed from the virtual track, so
+  // prefer the track's from-segment height once measured. Until then, use the
+  // live DOM measure if ready, else use the track estimate.
+  //
+  // All other transitions: use the live DOM measure when it matches this
+  // transition, gap handoffs fall back to stageHeight, otherwise 0.
   const effectiveTranslatePx = isMdToMdNoGap
     ? fromTrackSegment?.measured && scrollFromHeight
       ? scrollFromHeight

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -181,6 +181,7 @@ interface ISegmentOverlayPaneProps {
   storyData: IJGISStoryMap;
   items: IStorySegmentViewItem[];
   onMarkdownRendered?: (segmentIndex: number) => void;
+  onPaneUnmount?: (segmentIndex: number) => void;
 }
 
 function segmentConfigsEqual(
@@ -223,8 +224,15 @@ const SegmentOverlayPane = React.memo(function SegmentOverlayPane({
   storyData,
   items,
   onMarkdownRendered,
+  onPaneUnmount,
 }: ISegmentOverlayPaneProps): React.ReactElement {
   const isMap = config.type === 'map';
+
+  React.useLayoutEffect(() => {
+    return () => {
+      onPaneUnmount?.(segmentIndex);
+    };
+  }, [segmentIndex, onPaneUnmount]);
 
   return (
     <div
@@ -287,6 +295,9 @@ export function ListStoryStageOverlay({
   const measuredTransitionKeyRef = useRef('');
   const measureTransitionKeyRef = useRef('');
   const stableTravelRef = useRef(0);
+  const clearMarkdownRendered = useCallback((segmentIndex: number): void => {
+    markdownRenderedRef.current.delete(segmentIndex);
+  }, []);
   const [stageHeight, setStageHeight] = useState(0);
   const [transitionTranslatePx, setTransitionTranslatePx] = useState(0);
   const currentIndex = useCurrentSegmentIndex(model);
@@ -656,6 +667,7 @@ export function ListStoryStageOverlay({
               storyData={story}
               items={items}
               onMarkdownRendered={handleMarkdownRendered}
+              onPaneUnmount={clearMarkdownRendered}
             />,
           );
           return nodes;

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -217,50 +217,53 @@ function segmentOverlayPanePropsAreEqual(
   );
 }
 
-const SegmentOverlayPane = React.memo(({
-  pane,
-  segmentIndex,
-  config,
-  model,
-  storyData,
-  items,
-  onMarkdownRendered,
-  onPaneUnmount,
-}: ISegmentOverlayPaneProps): React.ReactElement => {
-  const isMap = config.type === 'map';
+const SegmentOverlayPane = React.memo(
+  ({
+    pane,
+    segmentIndex,
+    config,
+    model,
+    storyData,
+    items,
+    onMarkdownRendered,
+    onPaneUnmount,
+  }: ISegmentOverlayPaneProps): React.ReactElement => {
+    const isMap = config.type === 'map';
 
-  useLayoutEffect(() => {
-    return () => {
-      onPaneUnmount(segmentIndex);
-    };
-  }, [segmentIndex, onPaneUnmount]);
+    useLayoutEffect(() => {
+      return () => {
+        onPaneUnmount(segmentIndex);
+      };
+    }, [segmentIndex, onPaneUnmount]);
 
-  return (
-    <div
-      data-pane={pane}
-      data-segment-index={segmentIndex}
-      className={`jgis-story-segment-overlay-pane jgis-story-${
-        isMap ? 'map' : 'markdown'
-      }-scroll-pane`}
-    >
-      {isMap ? (
-        <ListStoryMapOverlayPanel
-          model={model}
-          storyData={storyData}
-          segmentIndex={config.segmentIndex}
-          items={items}
-        />
-      ) : config.markdown ? (
-        <ListStoryOverlayMarkdown
-          model={model}
-          segmentId={config.segmentId}
-          source={config.markdown}
-          onRendered={() => onMarkdownRendered(segmentIndex)}
-        />
-      ) : null}
-    </div>
-  );
-}, segmentOverlayPanePropsAreEqual);
+    return (
+      <div
+        data-pane={pane}
+        data-segment-index={segmentIndex}
+        className={`jgis-story-segment-overlay-pane jgis-story-${
+          isMap ? 'map' : 'markdown'
+        }-scroll-pane`}
+      >
+        {isMap ? (
+          <ListStoryMapOverlayPanel
+            model={model}
+            storyData={storyData}
+            segmentIndex={config.segmentIndex}
+            items={items}
+          />
+        ) : config.markdown ? (
+          <ListStoryOverlayMarkdown
+            model={model}
+            segmentId={config.segmentId}
+            source={config.markdown}
+            onRendered={() => onMarkdownRendered(segmentIndex)}
+          />
+        ) : null}
+      </div>
+    );
+  },
+  segmentOverlayPanePropsAreEqual,
+);
 
 function buildFallbackTransition(
   activeItem: IStorySegmentViewItem,

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -211,7 +211,6 @@ function SegmentOverlayPane({
         />
       ) : config.markdown ? (
         <ListStoryOverlayMarkdown
-          key={`pane-${pane}-seg-${segmentIndex}`}
           model={model}
           segmentId={config.segmentId}
           source={config.markdown}
@@ -253,7 +252,8 @@ export function ListStoryStageOverlay({
   const [stageHeight, setStageHeight] = useState(0);
   const [transitionTranslatePx, setTransitionTranslatePx] = useState(0);
   const currentIndex = useCurrentSegmentIndex(model);
-  const { scrollTrackLayout } = useListStoryScrollTrackContext();
+  const { scrollTrackLayout, reportSegmentHeight } =
+    useListStoryScrollTrackContext();
 
   const story = model?.getSelectedStory().story ?? null;
   const items = useMemo(
@@ -358,26 +358,99 @@ export function ListStoryStageOverlay({
     (segmentIndex: number): void => {
       markdownRenderedRef.current.add(segmentIndex);
 
-      if (segmentIndex !== fromIndex) {
-        return;
-      }
-
-      measureTransitionRef.current?.();
-
       const stack = stackRef.current;
-      const fromPane = stack?.querySelector('[data-pane="from"]');
-      if (!(fromPane instanceof HTMLElement)) {
-        return;
+      const paneEl = stack?.querySelector(
+        `[data-segment-index="${segmentIndex}"]`,
+      );
+      if (paneEl instanceof HTMLElement) {
+        const stackPane = overlayStack.panes.find(
+          p => p.segmentIndex === segmentIndex,
+        );
+        if (
+          stackPane?.config.type === 'markdown' &&
+          stackPane.config.segmentId
+        ) {
+          reportSegmentHeight(stackPane.config.segmentId, paneEl.offsetHeight);
+        }
+
+        imageWaitCancelRef.current?.();
+        imageWaitCancelRef.current = whenImagesSettled(paneEl, () => {
+          imageWaitCancelRef.current = null;
+          if (
+            stackPane?.config.type === 'markdown' &&
+            stackPane.config.segmentId
+          ) {
+            reportSegmentHeight(
+              stackPane.config.segmentId,
+              paneEl.offsetHeight,
+            );
+          }
+          measureTransitionRef.current?.();
+        });
       }
 
-      imageWaitCancelRef.current?.();
-      imageWaitCancelRef.current = whenImagesSettled(fromPane, () => {
-        imageWaitCancelRef.current = null;
+      if (segmentIndex === fromIndex) {
         measureTransitionRef.current?.();
-      });
+      }
     },
-    [fromIndex],
+    [fromIndex, overlayStack.panes, reportSegmentHeight],
   );
+
+  useLayoutEffect(() => {
+    const stack = stackRef.current;
+    if (!stack) {
+      return;
+    }
+
+    const reportVisibleMarkdownHeights = (): void => {
+      for (const stackPane of overlayStack.panes) {
+        if (
+          stackPane.config.type !== 'markdown' ||
+          !stackPane.config.segmentId
+        ) {
+          continue;
+        }
+
+        if (!markdownRenderedRef.current.has(stackPane.segmentIndex)) {
+          continue;
+        }
+
+        const paneEl = stack.querySelector(
+          `[data-segment-index="${stackPane.segmentIndex}"]`,
+        );
+
+        if (!(paneEl instanceof HTMLElement) || paneEl.offsetHeight <= 0) {
+          continue;
+        }
+
+        reportSegmentHeight(stackPane.config.segmentId, paneEl.offsetHeight);
+      }
+    };
+
+    reportVisibleMarkdownHeights();
+
+    const ro = new ResizeObserver(() => {
+      reportVisibleMarkdownHeights();
+    });
+
+    for (const stackPane of overlayStack.panes) {
+      if (stackPane.config.type !== 'markdown') {
+        continue;
+      }
+
+      const paneEl = stack.querySelector(
+        `[data-segment-index="${stackPane.segmentIndex}"]`,
+      );
+
+      if (paneEl instanceof HTMLElement) {
+        ro.observe(paneEl);
+      }
+    }
+
+    return () => {
+      ro.disconnect();
+    };
+  }, [overlayStack.panes, reportSegmentHeight]);
 
   useLayoutEffect(() => {
     const stack = stackRef.current;
@@ -473,6 +546,9 @@ export function ListStoryStageOverlay({
     scrollTrackLayout,
     fromIndex,
   );
+  const fromTrackSegment = scrollTrackLayout?.segments.find(
+    segment => segment.index === fromIndex,
+  );
   const isMdToMdNoGap =
     !intraSegmentScroll &&
     handoffGapHeight === 0 &&
@@ -481,10 +557,16 @@ export function ListStoryStageOverlay({
   const translateIsCurrent =
     measuredTransitionKeyRef.current === currentTransitionKey &&
     transitionTranslatePx > 0;
-  const effectiveTranslatePx = translateIsCurrent
-    ? transitionTranslatePx
-    : isMdToMdNoGap && scrollFromHeight
+  // Md->md no-gap progress uses scroll-track height, prefer that once measured.
+  // Fall back to live DOM travel until the track catches up.
+  const effectiveTranslatePx = isMdToMdNoGap
+    ? fromTrackSegment?.measured && scrollFromHeight
       ? scrollFromHeight
+      : translateIsCurrent
+        ? transitionTranslatePx
+        : (scrollFromHeight ?? 0)
+    : translateIsCurrent
+      ? transitionTranslatePx
       : handoffGapHeight > 0
         ? stageHeight
         : 0;
@@ -514,63 +596,39 @@ export function ListStoryStageOverlay({
       }
     >
       <div ref={stackRef} className="jgis-story-segment-transition-stack">
-        <SegmentOverlayPane
-          model={model}
-          pane="from"
-          segmentIndex={fromStackPane.segmentIndex}
-          config={fromStackPane.config}
-          storyData={story}
-          items={items}
-          onMarkdownRendered={
-            fromStackPane.config.type === 'markdown' &&
-            fromStackPane.config.markdown
-              ? () => {
-                  handleMarkdownRendered(fromStackPane.segmentIndex);
-                }
-              : undefined
+        {overlayStack.panes.flatMap((stackPane, paneOrder) => {
+          const nodes: React.ReactNode[] = [];
+
+          if (paneOrder === 1 && overlayStack.includeGap) {
+            nodes.push(
+              <div
+                key="handoff-gap"
+                className="jgis-story-segment-transition-gap"
+                aria-hidden
+              />,
+            );
           }
-        />
-        {toStackPane ? (
-          <>
-            {overlayStack.includeGap ? (
-              <div className="jgis-story-segment-transition-gap" aria-hidden />
-            ) : null}
+          nodes.push(
             <SegmentOverlayPane
+              key={stackPane.segmentIndex}
               model={model}
-              pane="to"
-              segmentIndex={toStackPane.segmentIndex}
-              config={toStackPane.config}
+              pane={stackPane.role}
+              segmentIndex={stackPane.segmentIndex}
+              config={stackPane.config}
               storyData={story}
               items={items}
               onMarkdownRendered={
-                toStackPane.config.type === 'markdown' &&
-                toStackPane.config.markdown
+                stackPane.config.type === 'markdown' &&
+                stackPane.config.markdown
                   ? () => {
-                      handleMarkdownRendered(toStackPane.segmentIndex);
+                      handleMarkdownRendered(stackPane.segmentIndex);
                     }
                   : undefined
               }
-            />
-          </>
-        ) : null}
-        {lookaheadStackPane ? (
-          <SegmentOverlayPane
-            model={model}
-            pane="lookahead"
-            segmentIndex={lookaheadStackPane.segmentIndex}
-            config={lookaheadStackPane.config}
-            storyData={story}
-            items={items}
-            onMarkdownRendered={
-              lookaheadStackPane.config.type === 'markdown' &&
-              lookaheadStackPane.config.markdown
-                ? () => {
-                    handleMarkdownRendered(lookaheadStackPane.segmentIndex);
-                  }
-                : undefined
-            }
-          />
-        ) : null}
+            />,
+          );
+          return nodes;
+        })}
       </div>
     </div>
   );

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -180,10 +180,42 @@ interface ISegmentOverlayPaneProps {
   model: IJupyterGISModel;
   storyData: IJGISStoryMap;
   items: IStorySegmentViewItem[];
-  onMarkdownRendered?: () => void;
+  onMarkdownRendered?: (segmentIndex: number) => void;
 }
 
-function SegmentOverlayPane({
+function segmentConfigsEqual(
+  prev: SegmentOverlayPaneConfig,
+  next: SegmentOverlayPaneConfig,
+): boolean {
+  if (prev.type !== next.type) {
+    return false;
+  }
+  if (prev.type === 'map' && next.type === 'map') {
+    return prev.segmentIndex === next.segmentIndex;
+  }
+  if (prev.type === 'markdown' && next.type === 'markdown') {
+    return (
+      prev.segmentId === next.segmentId && prev.markdown === next.markdown
+    );
+  }
+  return false;
+}
+
+function segmentOverlayPanePropsAreEqual(
+  prev: ISegmentOverlayPaneProps,
+  next: ISegmentOverlayPaneProps,
+): boolean {
+  return (
+    prev.pane === next.pane &&
+    prev.segmentIndex === next.segmentIndex &&
+    prev.model === next.model &&
+    prev.storyData === next.storyData &&
+    prev.items === next.items &&
+    segmentConfigsEqual(prev.config, next.config)
+  );
+}
+
+const SegmentOverlayPane = React.memo(function SegmentOverlayPane({
   pane,
   segmentIndex,
   config,
@@ -214,12 +246,18 @@ function SegmentOverlayPane({
           model={model}
           segmentId={config.segmentId}
           source={config.markdown}
-          onRendered={onMarkdownRendered}
+          onRendered={
+            onMarkdownRendered
+              ? () => {
+                  onMarkdownRendered(segmentIndex);
+                }
+              : undefined
+          }
         />
       ) : null}
     </div>
   );
-}
+}, segmentOverlayPanePropsAreEqual);
 
 function buildFallbackTransition(
   activeItem: IStorySegmentViewItem,
@@ -617,14 +655,7 @@ export function ListStoryStageOverlay({
               config={stackPane.config}
               storyData={story}
               items={items}
-              onMarkdownRendered={
-                stackPane.config.type === 'markdown' &&
-                stackPane.config.markdown
-                  ? () => {
-                      handleMarkdownRendered(stackPane.segmentIndex);
-                    }
-                  : undefined
-              }
+              onMarkdownRendered={handleMarkdownRendered}
             />,
           );
           return nodes;

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -51,13 +51,13 @@ function renderedStoryMarkdownPropsAreEqual(
 }
 
 /** Jupyter rendermime markdown output (shared by overlay and story editor). */
-export const RenderedStoryMarkdown = memo(function RenderedStoryMarkdown({
+export const RenderedStoryMarkdown = memo(({
   model,
   segmentId,
   source,
   onRendered,
   variant = 'overlay',
-}: IRenderedStoryMarkdownProps): JSX.Element | null {
+}: IRenderedStoryMarkdownProps): JSX.Element | null => {
   const rendermime = useStoryRenderMime(model, segmentId);
   const hostRef = useRef<HTMLDivElement>(null);
   const onRenderedRef = useRef(onRendered);

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -1,7 +1,7 @@
 import type { IJupyterGISModel } from '@jupytergis/schema';
 import { MimeModel } from '@jupyterlab/rendermime';
 import { Widget } from '@lumino/widgets';
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { memo, useLayoutEffect, useRef } from 'react';
 
 import { useStoryRenderMime } from '@/src/features/story/components/StoryRenderMime';
 
@@ -38,8 +38,20 @@ function disposeRenderer(renderer: Widget): void {
   renderer.dispose();
 }
 
+function renderedStoryMarkdownPropsAreEqual(
+  prev: IRenderedStoryMarkdownProps,
+  next: IRenderedStoryMarkdownProps,
+): boolean {
+  return (
+    prev.model === next.model &&
+    prev.segmentId === next.segmentId &&
+    prev.source === next.source &&
+    prev.variant === next.variant
+  );
+}
+
 /** Jupyter rendermime markdown output (shared by overlay and story editor). */
-export function RenderedStoryMarkdown({
+export const RenderedStoryMarkdown = memo(function RenderedStoryMarkdown({
   model,
   segmentId,
   source,
@@ -119,4 +131,4 @@ export function RenderedStoryMarkdown({
       ></div>
     </div>
   );
-}
+}, renderedStoryMarkdownPropsAreEqual);

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -48,6 +48,8 @@ export function RenderedStoryMarkdown({
 }: IRenderedStoryMarkdownProps): JSX.Element | null {
   const rendermime = useStoryRenderMime(model, segmentId);
   const hostRef = useRef<HTMLDivElement>(null);
+  const onRenderedRef = useRef(onRendered);
+  onRenderedRef.current = onRendered;
 
   useLayoutEffect(() => {
     const host = hostRef.current;
@@ -92,7 +94,7 @@ export function RenderedStoryMarkdown({
       renderer.addClass('jp-MarkdownOutput');
       requestAnimationFrame(() => {
         if (!cancelled && !renderer.isDisposed) {
-          onRendered?.();
+          onRenderedRef.current?.();
         }
       });
     };
@@ -103,7 +105,7 @@ export function RenderedStoryMarkdown({
       cancelled = true;
       disposeRenderer(renderer);
     };
-  }, [rendermime, source, onRendered]);
+  }, [rendermime, source]);
 
   if (!source) {
     return null;

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -51,84 +51,87 @@ function renderedStoryMarkdownPropsAreEqual(
 }
 
 /** Jupyter rendermime markdown output (shared by overlay and story editor). */
-export const RenderedStoryMarkdown = memo(({
-  model,
-  segmentId,
-  source,
-  onRendered,
-  variant = 'overlay',
-}: IRenderedStoryMarkdownProps): JSX.Element | null => {
-  const rendermime = useStoryRenderMime(model, segmentId);
-  const hostRef = useRef<HTMLDivElement>(null);
-  const onRenderedRef = useRef(onRendered);
-  onRenderedRef.current = onRendered;
+export const RenderedStoryMarkdown = memo(
+  ({
+    model,
+    segmentId,
+    source,
+    onRendered,
+    variant = 'overlay',
+  }: IRenderedStoryMarkdownProps): JSX.Element | null => {
+    const rendermime = useStoryRenderMime(model, segmentId);
+    const hostRef = useRef<HTMLDivElement>(null);
+    const onRenderedRef = useRef(onRendered);
+    onRenderedRef.current = onRendered;
 
-  useLayoutEffect(() => {
-    const host = hostRef.current;
-    if (!host || !source) {
-      return;
+    useLayoutEffect(() => {
+      const host = hostRef.current;
+      if (!host || !source) {
+        return;
+      }
+
+      const registry = rendermime.clone();
+      const renderer = registry.createRenderer(MARKDOWN_MIME);
+      const mimeModel = new MimeModel({
+        data: { [MARKDOWN_MIME]: source },
+        trusted: false,
+      });
+
+      let cancelled = false;
+
+      const run = async (): Promise<void> => {
+        if (cancelled) {
+          return;
+        }
+
+        Widget.attach(renderer, host);
+
+        if (cancelled) {
+          disposeRenderer(renderer);
+          return;
+        }
+
+        try {
+          await renderer.renderModel(mimeModel);
+        } catch (error) {
+          console.error('Failed to render story markdown', error);
+          disposeRenderer(renderer);
+          return;
+        }
+
+        if (cancelled || renderer.isDisposed) {
+          disposeRenderer(renderer);
+          return;
+        }
+
+        renderer.addClass('jp-MarkdownOutput');
+        requestAnimationFrame(() => {
+          if (!cancelled && !renderer.isDisposed) {
+            onRenderedRef.current?.();
+          }
+        });
+      };
+
+      void run();
+
+      return () => {
+        cancelled = true;
+        disposeRenderer(renderer);
+      };
+    }, [rendermime, source]);
+
+    if (!source) {
+      return null;
     }
 
-    const registry = rendermime.clone();
-    const renderer = registry.createRenderer(MARKDOWN_MIME);
-    const mimeModel = new MimeModel({
-      data: { [MARKDOWN_MIME]: source },
-      trusted: false,
-    });
-
-    let cancelled = false;
-
-    const run = async (): Promise<void> => {
-      if (cancelled) {
-        return;
-      }
-
-      Widget.attach(renderer, host);
-
-      if (cancelled) {
-        disposeRenderer(renderer);
-        return;
-      }
-
-      try {
-        await renderer.renderModel(mimeModel);
-      } catch (error) {
-        console.error('Failed to render story markdown', error);
-        disposeRenderer(renderer);
-        return;
-      }
-
-      if (cancelled || renderer.isDisposed) {
-        disposeRenderer(renderer);
-        return;
-      }
-
-      renderer.addClass('jp-MarkdownOutput');
-      requestAnimationFrame(() => {
-        if (!cancelled && !renderer.isDisposed) {
-          onRenderedRef.current?.();
-        }
-      });
-    };
-
-    void run();
-
-    return () => {
-      cancelled = true;
-      disposeRenderer(renderer);
-    };
-  }, [rendermime, source]);
-
-  if (!source) {
-    return null;
-  }
-
-  return (
-    <div className={`jgis-story-rendered-markdown ${ROOT_CLASS[variant]}`}>
-      <div
-        ref={hostRef}
-        className="specta-article-host-widget specta-cell-content"
-      ></div>
-    </div>
-  );
-}, renderedStoryMarkdownPropsAreEqual);
+    return (
+      <div className={`jgis-story-rendered-markdown ${ROOT_CLASS[variant]}`}>
+        <div
+          ref={hostRef}
+          className="specta-article-host-widget specta-cell-content"
+        ></div>
+      </div>
+    );
+  },
+  renderedStoryMarkdownPropsAreEqual,
+);

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -207,10 +207,7 @@ export function ListStoryScrollTrackProvider({
         // Ignore transient shrinks (empty remount / pre-image layout). Markdown
         // height should only grow until the story is rebuilt.
         const previousHeight = prev[segmentId];
-        if (
-          previousHeight !== undefined &&
-          measuredHeightPx < previousHeight
-        ) {
+        if (previousHeight !== undefined && measuredHeightPx < previousHeight) {
           return prev;
         }
 

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -27,6 +27,8 @@ interface IListStoryScrollTrackContextValue {
     index: number,
     options?: { behavior?: ScrollBehavior },
   ) => void;
+  /** Report a measured markdown height from the live overlay (or measure pane). */
+  reportSegmentHeight: (segmentId: string, height: number) => void;
 }
 
 const ListStoryScrollTrackContext =
@@ -220,9 +222,13 @@ export function ListStoryScrollTrackProvider({
           const oldSegment = oldLayout.segments.find(s => s.id === segmentId);
           if (oldSegment && !oldSegment.measured) {
             const scrollCompensation = measuredHeightPx - oldSegment.height;
+            // Only shift scroll when the user is already past this segment so
+            // later content stays put. Inside the segment, leave scrollTop so
+            // progress recalculates against the new height so there's no
+            // visual jump.
             if (
               scrollCompensation !== 0 &&
-              scroller.scrollTop > oldSegment.start
+              scroller.scrollTop >= oldSegment.end
             ) {
               requestAnimationFrame(() => {
                 scroller.scrollTop += scrollCompensation;
@@ -289,12 +295,14 @@ export function ListStoryScrollTrackProvider({
       scrollTop,
       bindScrollTrackElement,
       scrollToSegmentIndex,
+      reportSegmentHeight: handleMeasuredHeight,
     }),
     [
       scrollTrackLayout,
       scrollTop,
       bindScrollTrackElement,
       scrollToSegmentIndex,
+      handleMeasuredHeight,
     ],
   );
 

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -204,6 +204,16 @@ export function ListStoryScrollTrackProvider({
           return prev;
         }
 
+        // Ignore transient shrinks (empty remount / pre-image layout). Markdown
+        // height should only grow until the story is rebuilt.
+        const previousHeight = prev[segmentId];
+        if (
+          previousHeight !== undefined &&
+          measuredHeightPx < previousHeight
+        ) {
+          return prev;
+        }
+
         const scroller = scrollerRef.current;
         const oldLayout =
           enabled && viewportHeight > 0


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Close #1636 

This fixes vertical-scroll story markdown flicker/jank by not remounting markdown on scroll using memoization, and keeps panes mounted across role flips by keying on `segmentIndex`.

Also keeps scroll progress and overlay travel in sync by using live overlay heights in the virtual scroll track, locking md→md no-gap translate values to measured track height, and ignoring transient shrinks from remounts.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1679.org.readthedocs.build/en/1679/
💡 JupyterLite preview: https://jupytergis--1679.org.readthedocs.build/en/1679/lite
💡 Specta preview: https://jupytergis--1679.org.readthedocs.build/en/1679/lite/specta

<!-- readthedocs-preview jupytergis end -->