### PR TITLE
Update the mobile view for the story editor

### DIFF
--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -3,7 +3,7 @@ import type { IEditorServices } from '@jupyterlab/codeeditor';
 import { IStateDB } from '@jupyterlab/statedb';
 import { CommandRegistry } from '@lumino/commands';
 import { Trash2 } from 'lucide-react';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { SegmentImageUrlField } from '@/src/features/story/components/SegmentImageUrlField';
 import { SegmentLayerOverrides } from '@/src/features/story/components/SegmentLayerOverrides';
@@ -39,6 +39,7 @@ import {
   NativeSelectOption,
 } from '@/src/shared/components/NativeSelect';
 import { Slider } from '@/src/shared/components/Slider';
+import { useIsMobile } from '@/src/shared/hooks/useIsMobile';
 
 export interface IStoryEditorDialogBodyProps {
   model: IJupyterGISModel;
@@ -55,6 +56,7 @@ function SegmentEditor({
   editorServices,
   portalContainerRef,
   canRemoveSegment,
+  isMobile,
   onContentModeChange,
   onContentChange,
   onLayerNameChange,
@@ -67,6 +69,7 @@ function SegmentEditor({
   editorServices: IEditorServices;
   portalContainerRef: React.RefObject<HTMLElement | null>;
   canRemoveSegment: boolean;
+  isMobile: boolean;
   onContentModeChange: (mode: StorySegmentDisplayMode) => void;
   onContentChange: (patch: SegmentContentPatch) => void;
   onLayerNameChange: (name: string) => void;
@@ -105,8 +108,11 @@ function SegmentEditor({
           disabled={!canRemoveSegment}
           onClick={onRemoveSegment}
         >
-          <Trash2 data-icon="inline-start" className="jgis-inline-icon" />{' '}
-          Delete
+          <Trash2
+            data-icon={isMobile ? undefined : 'inline-start'}
+            className="jgis-inline-icon"
+          />
+          {isMobile ? null : 'Delete'}
         </Button>
       </div>
 
@@ -264,6 +270,14 @@ export function StoryEditorDialogBody({
   } = useStoryEditorSegmentList(model, commands);
 
   const portalContainerRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    const dialog = portalContainerRef.current?.closest(
+      '.jgis-story-editor-dialog',
+    );
+    dialog?.classList.toggle('jgis-story-editor-dialog--mobile', isMobile);
+  }, [isMobile]);
 
   return (
     <div ref={portalContainerRef} className="jgis-story-editor">
@@ -271,6 +285,7 @@ export function StoryEditorDialogBody({
         model={model}
         story={story}
         segmentCount={segments.length}
+        isMobile={isMobile}
         onUpdateStory={updateStory}
         portalContainerRef={portalContainerRef}
       />
@@ -279,6 +294,7 @@ export function StoryEditorDialogBody({
         <StoryEditorSegmentList
           segments={segments}
           selectedSegmentId={selectedSegmentId}
+          isMobile={isMobile}
           onSelectSegment={selectSegment}
           onAddSegment={addSegment}
           onReorderSegments={reorderSegments}
@@ -294,6 +310,7 @@ export function StoryEditorDialogBody({
               editorServices={editorServices}
               portalContainerRef={portalContainerRef}
               canRemoveSegment={canRemoveSegment}
+              isMobile={isMobile}
               onContentModeChange={mode => {
                 updateSegmentContentMode(selectedSegment.id, mode);
               }}

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -207,19 +207,21 @@ function SegmentEditor({
                 </NativeSelectOption>
                 <NativeSelectOption value="linear">Linear</NativeSelectOption>
               </NativeSelect>
-              <Slider
-                min={MIN_SEGMENT_TRANSITION_TIME}
-                max={MAX_SEGMENT_TRANSITION_TIME}
-                step={SEGMENT_TRANSITION_TIME_STEP}
-                value={[transitionTime]}
-                disabled={isImmediateTransition}
-                aria-label="Transition duration"
-                style={{ maxWidth: '10rem' }}
-                onValueChange={([time]) => {
-                  onTransitionChange({ time });
-                }}
-              />
-              <span>{formatSegmentTransitionTime(transitionTime)}</span>
+              <div className="jgis-story-editor-slider">
+                <Slider
+                  min={MIN_SEGMENT_TRANSITION_TIME}
+                  max={MAX_SEGMENT_TRANSITION_TIME}
+                  step={SEGMENT_TRANSITION_TIME_STEP}
+                  value={[transitionTime]}
+                  disabled={isImmediateTransition}
+                  aria-label="Transition duration"
+                  style={{ maxWidth: '10rem' }}
+                  onValueChange={([time]) => {
+                    onTransitionChange({ time });
+                  }}
+                />
+                <span>{formatSegmentTransitionTime(transitionTime)}</span>
+              </div>
             </div>
           </StoryEditorSection>
         </>

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -39,7 +39,7 @@ import {
   NativeSelectOption,
 } from '@/src/shared/components/NativeSelect';
 import { Slider } from '@/src/shared/components/Slider';
-import { useIsMobile } from '@/src/shared/hooks/useIsMobile';
+import { JGIS_NARROW_BREAKPOINT } from '@/src/shared/hooks/useIsMobile';
 
 export interface IStoryEditorDialogBodyProps {
   model: IJupyterGISModel;
@@ -273,14 +273,22 @@ export function StoryEditorDialogBody({
   } = useStoryEditorSegmentList(model, commands);
 
   const portalContainerRef = useRef<HTMLDivElement>(null);
-  const isMobile = useIsMobile();
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    const dialog = portalContainerRef.current?.closest(
-      '.jgis-story-editor-dialog',
+    const mediaQuery = window.matchMedia(
+      `(max-width: ${JGIS_NARROW_BREAKPOINT}px)`,
     );
-    dialog?.classList.toggle('jgis-story-editor-dialog--mobile', isMobile);
-  }, [isMobile]);
+    const update = (): void => {
+      setIsMobile(mediaQuery.matches);
+    };
+
+    update();
+    mediaQuery.addEventListener('change', update);
+    return () => {
+      mediaQuery.removeEventListener('change', update);
+    };
+  }, []);
 
   return (
     <div ref={portalContainerRef} className="jgis-story-editor">

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -179,6 +179,7 @@ function SegmentEditor({
               model={model}
               state={state}
               segmentId={segment.id}
+              isMobile={isMobile}
               portalContainerRef={portalContainerRef}
             />
           </StoryEditorSection>

--- a/packages/base/src/features/story/components/SegmentLayerOverrides.tsx
+++ b/packages/base/src/features/story/components/SegmentLayerOverrides.tsx
@@ -19,6 +19,7 @@ export interface ISegmentLayerOverridesProps {
   model: IJupyterGISModel;
   state: IStateDB;
   segmentId: string;
+  isMobile?: boolean;
   portalContainerRef: RefObject<HTMLElement | null>;
 }
 
@@ -26,6 +27,7 @@ export function SegmentLayerOverrides({
   model,
   state,
   segmentId,
+  isMobile = false,
   portalContainerRef,
 }: ISegmentLayerOverridesProps): JSX.Element {
   const rows = buildSegmentLayerRows(model, segmentId);
@@ -37,18 +39,24 @@ export function SegmentLayerOverrides({
   }
 
   return (
-    <div className="jgis-story-editor-segment-layer-grid">
-      <div
-        className="jgis-story-editor-segment-layer-header"
-        aria-hidden="true"
-      >
-        <span>Layer Name</span>
-        <span>Visibility</span>
-        <span>Opacity</span>
-        <span>Symbology</span>
-        <span>Override</span>
-        <span>Reset</span>
-      </div>
+    <div
+      className={`jgis-story-editor-segment-layer-grid${
+        isMobile ? ' jgis-story-editor-segment-layer-grid--mobile' : ''
+      }`}
+    >
+      {!isMobile ? (
+        <div
+          className="jgis-story-editor-segment-layer-header"
+          aria-hidden="true"
+        >
+          <span>Layer Name</span>
+          <span>Visibility</span>
+          <span>Opacity</span>
+          <span>Symbology</span>
+          <span>Override</span>
+          <span>Reset</span>
+        </div>
+      ) : null}
       <ul className="jgis-story-editor-segment-layer-list">
         {rows.map(row => {
           const layer = model.getLayer(row.layerId);
@@ -112,12 +120,12 @@ export function SegmentLayerOverrides({
                 ) : null}
               </span>
               <span className="jgis-story-editor-segment-layer-override">
-                {row.isChanged ? (
-                  <CheckIcon
-                    className="jgis-story-editor-segment-layer-override-icon"
-                    aria-label="Override applied"
-                  />
-                ) : null}
+                <CheckIcon
+                  className="jgis-story-editor-segment-layer-override-icon"
+                  aria-label={row.isChanged ? 'Override applied' : undefined}
+                  aria-hidden={row.isChanged ? undefined : true}
+                  style={{ visibility: row.isChanged ? 'visible' : 'hidden' }}
+                />
               </span>
               <span className="jgis-story-editor-segment-layer-reset">
                 <Button

--- a/packages/base/src/features/story/components/SegmentModePicker.tsx
+++ b/packages/base/src/features/story/components/SegmentModePicker.tsx
@@ -1,4 +1,4 @@
-import { faMap } from '@fortawesome/free-solid-svg-icons';
+import { faBookOpen, faMap } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 
@@ -33,7 +33,7 @@ export function SegmentModePicker({
         >
           <div className="jgis-story-editor-row">
             <FontAwesomeIcon icon={faMap} />
-            <strong>Map segment</strong>
+            <strong>Map</strong>
           </div>
           <span>Saved map view with optional title and caption</span>
         </Button>
@@ -47,7 +47,10 @@ export function SegmentModePicker({
           aria-pressed={selectedValue === 'markdown'}
           onClick={() => onChange('markdown')}
         >
-          <strong>Text segment</strong>
+          <div className="jgis-story-editor-row">
+            <FontAwesomeIcon icon={faBookOpen} />
+            <strong>Text</strong>
+          </div>
           <span>Full-screen markdown chapter</span>
         </Button>
       </div>

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -36,6 +36,7 @@ export interface IStoryEditorHeaderBarProps {
   model: IJupyterGISModel;
   story: IJGISStoryMap | null;
   segmentCount: number;
+  isMobile: boolean;
   onUpdateStory: (patch: Partial<IJGISStoryMap>) => void;
   portalContainerRef: RefObject<HTMLElement | null>;
 }
@@ -150,6 +151,7 @@ export function StoryEditorHeaderBar({
   model,
   story,
   segmentCount,
+  isMobile,
   onUpdateStory,
   portalContainerRef,
 }: IStoryEditorHeaderBarProps): JSX.Element {
@@ -165,24 +167,28 @@ export function StoryEditorHeaderBar({
         }}
       />
       <div className="jgis-story-editor-context-meta-group">
-        <Badge variant="secondary">
+        <Badge variant="secondary" className="jgis-story-editor-context-badge">
           {story ? formatStoryTypeLabel(story.storyType) : 'No story'}
         </Badge>
-        <span className="jgis-story-editor-context-meta">
-          {segmentCount} segment{segmentCount === 1 ? '' : 's'}
-        </span>
-        {story ? (
-          <span className="jgis-story-editor-context-meta">
-            {formatGradientLabel(story.showGradient)}
-          </span>
-        ) : null}
-        {story &&
-        isVerticalScrollPresentation(
-          getStoryPresentationMode(story.storyType),
-        ) ? (
-          <span className="jgis-story-editor-context-meta">
-            {formatMarkdownSegmentGapLabel(story.markdownSegmentGap)}
-          </span>
+        {!isMobile ? (
+          <>
+            <span className="jgis-story-editor-context-meta">
+              {segmentCount} segment{segmentCount === 1 ? '' : 's'}
+            </span>
+            {story ? (
+              <span className="jgis-story-editor-context-meta">
+                {formatGradientLabel(story.showGradient)}
+              </span>
+            ) : null}
+            {story &&
+            isVerticalScrollPresentation(
+              getStoryPresentationMode(story.storyType),
+            ) ? (
+              <span className="jgis-story-editor-context-meta">
+                {formatMarkdownSegmentGapLabel(story.markdownSegmentGap)}
+              </span>
+            ) : null}
+          </>
         ) : null}
         {story && canPreview ? (
           <Button
@@ -193,7 +199,7 @@ export function StoryEditorHeaderBar({
               StoryEditorSession.getInstance().enterStoryPreviewMode();
             }}
           >
-            Preview story
+            {isMobile ? 'Preview' : 'Preview story'}
           </Button>
         ) : null}
         {story && (

--- a/packages/base/src/features/story/components/StoryEditorSegmentList.tsx
+++ b/packages/base/src/features/story/components/StoryEditorSegmentList.tsx
@@ -6,6 +6,10 @@ import type { IStorySegmentViewItem } from '@/src/features/story/types/types';
 import { getSegmentDisplayMode } from '@/src/features/story/utils/listStoryScrollTrack';
 import { getStorySegmentDisplayTitle } from '@/src/features/story/utils/storySegmentViewItems';
 import { Button } from '@/src/shared/components/Button';
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from '@/src/shared/components/NativeSelect';
 
 export interface IStoryEditorSegmentListProps {
   segments: IStorySegmentViewItem[];
@@ -16,13 +20,19 @@ export interface IStoryEditorSegmentListProps {
   onReorderSegments: (fromIndex: number, toIndex: number) => void;
 }
 
+function formatSegmentOptionLabel(segment: IStorySegmentViewItem): string {
+  const title = getStorySegmentDisplayTitle(segment);
+  const mode =
+    getSegmentDisplayMode(segment.activeSlide) === 'map' ? 'Map' : 'Text';
+  return `${segment.index + 1}. ${title} · ${mode}`;
+}
+
 function SegmentListItem({
   segment,
   selected,
   onSelect,
   index,
   canReorder,
-  isMobile,
   onDragStart,
 }: {
   segment: IStorySegmentViewItem;
@@ -30,7 +40,6 @@ function SegmentListItem({
   onSelect: () => void;
   index: number;
   canReorder: boolean;
-  isMobile: boolean;
   onDragStart: (index: number, event: React.DragEvent) => void;
 }): JSX.Element {
   const segmentMode = getSegmentDisplayMode(segment.activeSlide);
@@ -38,7 +47,7 @@ function SegmentListItem({
 
   return (
     <div className="jgis-story-editor-segment-row">
-      {canReorder && !isMobile ? (
+      {canReorder ? (
         <div
           className="jgis-story-editor-segment-drag-handle"
           draggable
@@ -59,19 +68,61 @@ function SegmentListItem({
         aria-current={selected ? 'true' : undefined}
       >
         <span className="jgis-story-editor-segment-item-index">
-          {segment.index + 1}
-          {isMobile ? null : '.'}
+          {segment.index + 1}.
         </span>
-        {!isMobile ? (
-          <>
-            <span className="jgis-story-editor-segment-item-title">{title}</span>
-            <span className="jgis-story-editor-segment-item-type">
-              {segmentMode === 'map' ? 'Map' : 'Text'}
-            </span>
-          </>
-        ) : null}
+        <span className="jgis-story-editor-segment-item-title">{title}</span>
+        <span className="jgis-story-editor-segment-item-type">
+          {segmentMode === 'map' ? 'Map' : 'Text'}
+        </span>
       </button>
     </div>
+  );
+}
+
+function MobileSegmentPicker({
+  segments,
+  selectedSegmentId,
+  onSelectSegment,
+  onAddSegment,
+}: {
+  segments: IStorySegmentViewItem[];
+  selectedSegmentId: string | null;
+  onSelectSegment: (segmentId: string) => void;
+  onAddSegment: () => void;
+}): JSX.Element {
+  return (
+    <aside className="jgis-story-editor-segment-list jgis-story-editor-segment-list--mobile">
+      {segments.length === 0 ? (
+        <p className="jgis-story-editor-segment-list-empty jgis-story-editor-help">
+          No segments yet. Add one from the current map view.
+        </p>
+      ) : (
+        <NativeSelect
+          className="jgis-story-editor-segment-picker"
+          aria-label="Segment"
+          value={selectedSegmentId ?? ''}
+          onChange={event => {
+            if (event.target.value) {
+              onSelectSegment(event.target.value);
+            }
+          }}
+        >
+          {segments.map(segment => (
+            <NativeSelectOption key={segment.id} value={segment.id}>
+              {formatSegmentOptionLabel(segment)}
+            </NativeSelectOption>
+          ))}
+        </NativeSelect>
+      )}
+      <Button
+        variant="outline"
+        className="jgis-story-editor-add-segment"
+        onClick={onAddSegment}
+        aria-label="Add segment"
+      >
+        <FontAwesomeIcon icon={faPlus} />
+      </Button>
+    </aside>
   );
 }
 
@@ -149,6 +200,17 @@ export function StoryEditorSegmentList({
     clearDragState();
   }, [clearDragState, onReorderSegments]);
 
+  if (isMobile) {
+    return (
+      <MobileSegmentPicker
+        segments={segments}
+        selectedSegmentId={selectedSegmentId}
+        onSelectSegment={onSelectSegment}
+        onAddSegment={onAddSegment}
+      />
+    );
+  }
+
   return (
     <aside className="jgis-story-editor-segment-list">
       <div className="jgis-story-editor-segment-list-header jgis-story-editor-eyebrow">
@@ -188,7 +250,6 @@ export function StoryEditorSegmentList({
                 onSelect={() => onSelectSegment(segment.id)}
                 index={index}
                 canReorder={canReorder}
-                isMobile={isMobile}
                 onDragStart={handleDragStart}
               />
             </div>

--- a/packages/base/src/features/story/components/StoryEditorSegmentList.tsx
+++ b/packages/base/src/features/story/components/StoryEditorSegmentList.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/src/shared/components/Button';
 export interface IStoryEditorSegmentListProps {
   segments: IStorySegmentViewItem[];
   selectedSegmentId: string | null;
+  isMobile: boolean;
   onSelectSegment: (segmentId: string) => void;
   onAddSegment: () => void;
   onReorderSegments: (fromIndex: number, toIndex: number) => void;
@@ -21,6 +22,7 @@ function SegmentListItem({
   onSelect,
   index,
   canReorder,
+  isMobile,
   onDragStart,
 }: {
   segment: IStorySegmentViewItem;
@@ -28,6 +30,7 @@ function SegmentListItem({
   onSelect: () => void;
   index: number;
   canReorder: boolean;
+  isMobile: boolean;
   onDragStart: (index: number, event: React.DragEvent) => void;
 }): JSX.Element {
   const segmentMode = getSegmentDisplayMode(segment.activeSlide);
@@ -35,7 +38,7 @@ function SegmentListItem({
 
   return (
     <div className="jgis-story-editor-segment-row">
-      {canReorder && (
+      {canReorder && !isMobile ? (
         <div
           className="jgis-story-editor-segment-drag-handle"
           draggable
@@ -46,7 +49,7 @@ function SegmentListItem({
         >
           <FontAwesomeIcon icon={faGripVertical} />
         </div>
-      )}
+      ) : null}
       <button
         type="button"
         className={`jgis-story-editor-segment-item${
@@ -56,12 +59,17 @@ function SegmentListItem({
         aria-current={selected ? 'true' : undefined}
       >
         <span className="jgis-story-editor-segment-item-index">
-          {segment.index + 1}.
+          {segment.index + 1}
+          {isMobile ? null : '.'}
         </span>
-        <span className="jgis-story-editor-segment-item-title">{title}</span>
-        <span className="jgis-story-editor-segment-item-type">
-          {segmentMode === 'map' ? 'Map' : 'Text'}
-        </span>
+        {!isMobile ? (
+          <>
+            <span className="jgis-story-editor-segment-item-title">{title}</span>
+            <span className="jgis-story-editor-segment-item-type">
+              {segmentMode === 'map' ? 'Map' : 'Text'}
+            </span>
+          </>
+        ) : null}
       </button>
     </div>
   );
@@ -70,6 +78,7 @@ function SegmentListItem({
 export function StoryEditorSegmentList({
   segments,
   selectedSegmentId,
+  isMobile,
   onSelectSegment,
   onAddSegment,
   onReorderSegments,
@@ -179,6 +188,7 @@ export function StoryEditorSegmentList({
                 onSelect={() => onSelectSegment(segment.id)}
                 index={index}
                 canReorder={canReorder}
+                isMobile={isMobile}
                 onDragStart={handleDragStart}
               />
             </div>

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -142,6 +142,7 @@ import {
   getStoryPresentationMode,
   isVerticalScrollPresentation,
 } from '@/src/features/story/presentation/getStoryPresentationMode';
+import { useIsMobile } from '@/src/shared/hooks/useIsMobile';
 import { markerIcon } from '@/src/shared/icons';
 import {
   debounce,
@@ -4338,30 +4339,11 @@ function MainViewWithObserver(
   props: Omit<IMainViewProps, 'isMobile' | 'containerRef'>,
 ) {
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const [isMobile, setIsMobile] = React.useState(false);
+  const isMobile = useIsMobile(containerRef);
 
   React.useEffect(() => {
-    const container = containerRef.current;
-    if (!container) {
-      return;
-    }
-
-    const update = (width: number) => {
-      const narrow = width < 960;
-      setIsMobile(narrow);
-      container.classList.toggle('jgis-narrow', narrow);
-    };
-
-    // Initial sync
-    update(container.clientWidth);
-
-    const observer = new ResizeObserver(([entry]) => {
-      update(entry.contentRect.width);
-    });
-
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, []);
+    containerRef.current?.classList.toggle('jgis-narrow', isMobile);
+  }, [isMobile]);
 
   return (
     <MainView {...props} isMobile={isMobile} containerRef={containerRef} />

--- a/packages/base/src/shared/components/NativeSelect.tsx
+++ b/packages/base/src/shared/components/NativeSelect.tsx
@@ -1,5 +1,6 @@
 import { ChevronDownIcon } from 'lucide-react';
 import * as React from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 import { cn } from './utils';
 
@@ -7,13 +8,60 @@ type NativeSelectProps = Omit<React.ComponentProps<'select'>, 'size'> & {
   size?: 'sm' | 'default';
 };
 
+/**
+ * JupyterLab Dialog runs Styling.styleNode on the body and wraps every
+ * <select> in .jp-select-wrapper + jp-mod-styled. Undo that so this
+ * component keeps its own chrome.
+ */
+function stripJupyterSelectStyling(root: HTMLElement): void {
+  const wrappers = root.querySelectorAll(':scope > .jp-select-wrapper');
+  wrappers.forEach(wrapper => {
+    const select = wrapper.querySelector(':scope > select');
+    if (!(select instanceof HTMLSelectElement) || !wrapper.parentElement) {
+      return;
+    }
+    select.classList.remove('jp-mod-styled');
+    wrapper.parentElement.insertBefore(select, wrapper);
+    wrapper.remove();
+  });
+
+  root.querySelector(':scope > select')?.classList.remove('jp-mod-styled');
+}
+
 function NativeSelect({
   className,
   size = 'default',
   ...props
 }: NativeSelectProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    if (!root) {
+      return;
+    }
+
+    const strip = (): void => {
+      stripJupyterSelectStyling(root);
+    };
+
+    strip();
+
+    const observer = new MutationObserver(() => {
+      observer.disconnect();
+      strip();
+      observer.observe(root, { childList: true, subtree: true });
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
   return (
     <div
+      ref={rootRef}
       className={cn('jgis-native-select', className)}
       data-slot="native-select-wrapper"
       data-size={size}

--- a/packages/base/src/shared/hooks/useIsMobile.ts
+++ b/packages/base/src/shared/hooks/useIsMobile.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState, type RefObject } from 'react';
+
+/** Matches story editor / main view narrow layout breakpoint. */
+export const JGIS_NARROW_BREAKPOINT = 960;
+
+const MAINVIEW_CONTAINER_SELECTOR = '.jGIS-Mainview-Container';
+
+function resolveObservedElement(
+  elementRef?: RefObject<HTMLElement | null> | null,
+): HTMLElement | null {
+  if (elementRef?.current) {
+    return elementRef.current;
+  }
+
+  return document.querySelector(MAINVIEW_CONTAINER_SELECTOR);
+}
+
+/**
+ * True when the main view container (or an explicit element) is below the
+ * narrow breakpoint. Uses ResizeObserver.
+ */
+export function useIsMobile(
+  elementRef?: RefObject<HTMLElement | null> | null,
+  breakpoint: number = JGIS_NARROW_BREAKPOINT,
+): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const element = resolveObservedElement(elementRef);
+    if (!element) {
+      return;
+    }
+
+    const update = (width: number): void => {
+      setIsMobile(width < breakpoint);
+    };
+
+    update(element.clientWidth);
+
+    const observer = new ResizeObserver(([entry]) => {
+      update(entry.contentRect.width);
+    });
+
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [elementRef, breakpoint]);
+
+  return isMobile;
+}

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -432,8 +432,7 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   justify-content: center;
 }
 
-.jgis-story-editor-segment-list--mobile
-  .jgis-story-editor-segment-list-empty {
+.jgis-story-editor-segment-list--mobile .jgis-story-editor-segment-list-empty {
   flex: 1 1 auto;
   margin: 0;
 }
@@ -555,6 +554,38 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   display: flex;
   gap: 0.375rem;
   flex-shrink: 0;
+}
+
+.jgis-narrow .jgis-story-map-interaction-bar-root--overlay-bottom {
+  left: 0.75rem;
+  right: 0.75rem;
+  width: auto;
+  transform: none;
+}
+
+.jgis-narrow .jgis-story-map-interaction-bar {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.jgis-narrow .jgis-story-map-interaction-bar-message {
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
+.jgis-narrow .jgis-story-map-interaction-bar-actions {
+  width: 100%;
+  flex-wrap: nowrap;
+  flex-shrink: 1;
+}
+
+.jgis-narrow .jgis-story-map-interaction-bar-actions > .jgis-button,
+.jgis-narrow .jgis-story-map-interaction-bar-actions > button {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .jgis-story-editor-segment-image-card-media {

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -2,6 +2,10 @@
   font-weight: bold;
 }
 
+.jgis-story-editor-dialog--mobile .jp-Dialog-header {
+  display: none;
+}
+
 .jgis-story-editor-dialog .jp-Dialog-content {
   width: calc(90% - 4rem);
   max-width: 56rem;
@@ -678,32 +682,165 @@ Radix won't set hidden so do it manually */
 }
 
 @media (max-width: 960px) {
+  .jgis-story-editor {
+    min-height: 0;
+    max-height: none;
+    height: 100%;
+  }
+
+  /* Title on its own row; actions below */
+  .jgis-story-editor-context-bar {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    gap: 0.375rem;
+  }
+
+  .jgis-story-editor-toolbar-title[data-slot='input'] {
+    flex: none;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
+
+  .jgis-story-editor-context-meta-group {
+    gap: 0.375rem;
+    justify-content: flex-start;
+  }
+
+  .jgis-story-editor-context-badge {
+    margin-right: auto;
+  }
+
   .jgis-story-editor-main {
     flex-direction: column;
   }
 
+  /* Number chips scroll; add sits on its own row below */
   .jgis-story-editor-segment-list {
     flex: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.375rem;
     max-width: none;
     min-width: 0;
-    max-height: 9rem;
+    max-height: none;
+    padding: 0.5rem;
     border-right: none;
     border-bottom: 1px solid var(--jp-border-color1);
   }
 
+  .jgis-story-editor-segment-list-header {
+    display: none;
+  }
+
   .jgis-story-editor-segment-list-items {
+    flex: none;
     flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.375rem;
+    min-width: 0;
+    max-width: 100%;
+    padding: 0;
     overflow-x: auto;
     overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
   }
 
-  .jgis-story-editor-segment-item {
+  .jgis-story-editor-segment-drag-wrapper {
     flex: 0 0 auto;
-    min-width: 8rem;
-    grid-template-columns: auto minmax(0, 1fr);
   }
 
+  .jgis-story-editor-segment-row {
+    gap: 0;
+  }
+
+  .jgis-story-editor-segment-item,
+  button.jgis-story-editor-segment-item.jp-mod-styled {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    width: 1.5rem;
+    min-width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    border-radius: var(--jp-border-radius);
+  }
+
+  .jgis-story-editor-segment-item-index {
+    font-size: 0.8125rem;
+    font-variant-numeric: tabular-nums;
+    color: inherit;
+  }
+
+  .jgis-story-editor-add-segment {
+    flex: none;
+    width: 100%;
+    margin: 0;
+  }
+
+  .jgis-story-editor-workspace {
+    min-height: 0;
+  }
+
+  .jgis-story-editor-segment {
+    padding: 0.625rem 0.75rem 1rem;
+    gap: 0.625rem;
+  }
+
+  .jgis-story-editor-segment-header {
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .jgis-story-editor-segment-header > div {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .jgis-story-editor-segment-header
+    .jgis-story-editor-toolbar-title[data-slot='input'] {
+    max-width: none;
+  }
+
+  /* Side-by-side mode chips; hide descriptions */
   .jgis-story-editor-segment-mode-picker {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .jgis-story-editor-segment-mode-picker
+    .jgis-button.jgis-story-editor-segment-mode-card {
+    align-items: center;
+    padding: 0.5rem 0.625rem;
+  }
+
+  .jgis-story-editor-segment-mode-picker
+    .jgis-button.jgis-story-editor-segment-mode-card
+    span {
+    display: none;
+  }
+
+  .jgis-story-editor-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .jgis-story-editor-row > .jgis-button,
+  .jgis-story-editor-row > button {
+    width: 100%;
+  }
+
+  .jgis-story-editor-segment-layer-grid {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .jgis-story-editor-segment-layer-header,
+  .jgis-story-editor-segment-layer-row {
+    min-width: 28rem;
   }
 }

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -406,6 +406,38 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   width: calc(100% - 1rem);
 }
 
+.jgis-story-editor-segment-list--mobile {
+  flex: none;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: none;
+  min-width: 0;
+  max-height: none;
+  padding: 0.5rem;
+  border-right: none;
+  border-bottom: 1px solid var(--jp-border-color1);
+}
+
+.jgis-story-editor-segment-list--mobile .jgis-story-editor-segment-picker {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.jgis-story-editor-segment-list--mobile .jgis-story-editor-add-segment {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 2.25rem;
+  margin: 0;
+  justify-content: center;
+}
+
+.jgis-story-editor-segment-list--mobile
+  .jgis-story-editor-segment-list-empty {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
 .jgis-story-editor-workspace {
   flex: 1;
   min-width: 0;
@@ -832,71 +864,14 @@ Radix won't set hidden so do it manually */
     flex-direction: column;
   }
 
-  /* Number chips scroll; add sits on its own row below */
-  .jgis-story-editor-segment-list {
+  /* Segment list chrome when the dialog is narrow */
+  .jgis-story-editor-segment-list:not(.jgis-story-editor-segment-list--mobile) {
     flex: none;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.375rem;
     max-width: none;
     min-width: 0;
     max-height: none;
-    padding: 0.5rem;
     border-right: none;
     border-bottom: 1px solid var(--jp-border-color1);
-  }
-
-  .jgis-story-editor-segment-list-header {
-    display: none;
-  }
-
-  .jgis-story-editor-segment-list-items {
-    flex: none;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: space-between;
-    align-items: center;
-    gap: 0.375rem;
-    min-width: 0;
-    max-width: 100%;
-    padding: 0;
-    overflow-x: auto;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .jgis-story-editor-segment-drag-wrapper {
-    flex: 0 0 auto;
-  }
-
-  .jgis-story-editor-segment-row {
-    gap: 0;
-  }
-
-  .jgis-story-editor-segment-item,
-  button.jgis-story-editor-segment-item.jp-mod-styled {
-    display: flex;
-    flex: 0 0 auto;
-    align-items: center;
-    justify-content: center;
-    box-sizing: border-box;
-    width: 1.5rem;
-    min-width: 1.5rem;
-    height: 1.5rem;
-    padding: 0;
-    border-radius: var(--jp-border-radius);
-  }
-
-  .jgis-story-editor-segment-item-index {
-    font-size: 0.8125rem;
-    font-variant-numeric: tabular-nums;
-    color: inherit;
-  }
-
-  .jgis-story-editor-add-segment {
-    flex: none;
-    width: 100%;
-    margin: 0;
   }
 
   .jgis-story-editor-workspace {

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -136,6 +136,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .jgis-story-editor-section-body[data-state='open'] {
@@ -148,11 +150,15 @@
   gap: 0.5rem;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
   padding: 0.25rem;
   border-radius: var(--jp-border-radius);
   border: 1px solid var(--jp-border-color1);
   background: var(--jp-layout-color1);
+  overflow: hidden;
 }
 
 .jgis-story-editor-toolbar {
@@ -523,7 +529,7 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   display: block;
   width: auto;
   height: auto;
-  max-width: min(100%, 16rem);
+  max-width: 100%;
   object-fit: contain;
 }
 

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -678,13 +678,123 @@ Radix won't set hidden so do it manually */
   color: var(--jp-brand-color1);
 }
 
+.jgis-story-editor-segment-layer-grid--mobile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow: visible;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-row {
+  grid-template-columns: minmax(0, 1fr) 1rem 1.75rem;
+  grid-template-areas:
+    'name override reset'
+    'opacity opacity visibility'
+    'symbology symbology symbology';
+  gap: 0.5rem 0.625rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--jp-border-color2);
+  border-radius: var(--jp-border-radius);
+  background-color: var(--jp-layout-color1);
+  min-width: 0;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-name-text {
+  grid-area: name;
+  max-width: 100%;
+  min-width: 0;
+  font-weight: 600;
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-visibility {
+  grid-area: visibility;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-opacity {
+  grid-area: opacity;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-symbology {
+  grid-area: symbology;
+  justify-content: stretch;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-override {
+  grid-area: override;
+  width: 1rem;
+  justify-self: center;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-reset {
+  grid-area: reset;
+  width: 1.75rem;
+  justify-self: end;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-list
+  > .jgis-story-editor-segment-layer-row:nth-child(odd),
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-list
+  > .jgis-story-editor-segment-layer-row:nth-child(even) {
+  background-color: var(--jp-layout-color1);
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-opacity
+  .jgis-slider,
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-opacity
+  [data-slot='slider'] {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-opacity-value {
+  flex: 0 0 auto;
+  min-width: 2.25rem;
+  text-align: right;
+  font-size: 0.75rem;
+}
+
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-symbology
+  > .jgis-button,
+.jgis-story-editor-segment-layer-grid--mobile
+  .jgis-story-editor-segment-layer-symbology
+  > button {
+  width: 100%;
+}
+
 .jgis-story-editor-sheet-container {
   padding: 0 0.5rem;
 }
 
 .jgis-story-editor-sheet-footer {
+  box-sizing: border-box;
   align-self: center;
-  width: 20rem;
+  width: 100%;
+  max-width: 20rem;
 }
 
 @media (max-width: 960px) {
@@ -838,15 +948,5 @@ Radix won't set hidden so do it manually */
   .jgis-story-editor-row > .jgis-button,
   .jgis-story-editor-row > button {
     width: 100%;
-  }
-
-  .jgis-story-editor-segment-layer-grid {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .jgis-story-editor-segment-layer-header,
-  .jgis-story-editor-segment-layer-row {
-    min-width: 28rem;
   }
 }

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -23,16 +23,14 @@
   flex-direction: column;
 }
 
-@media (max-width: 960px) {
-  .jgis-story-editor-dialog .jp-Dialog-content {
-    width: 100%;
-    max-width: 100%;
-    max-height: 90%;
-    margin: 0;
-    border-radius: 0;
-    padding-left: 8px;
-    padding-right: 8px;
-  }
+.jgis-story-editor-dialog--mobile .jp-Dialog-content {
+  width: 100%;
+  max-width: 100%;
+  max-height: 90%;
+  margin: 0;
+  border-radius: 0;
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
 .jgis-story-editor {
@@ -867,99 +865,99 @@ Radix won't set hidden so do it manually */
   max-width: 20rem;
 }
 
-@media (max-width: 960px) {
-  .jgis-story-editor {
-    min-height: 0;
-    max-height: none;
-    height: 100%;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor {
+  min-height: 0;
+  max-height: none;
+  height: 100%;
+}
 
-  /* Title on its own row; actions below */
-  .jgis-story-editor-context-bar {
-    flex-direction: column;
-    flex-wrap: nowrap;
-    align-items: stretch;
-    gap: 0.375rem;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-context-bar {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: 0.375rem;
+}
 
+.jgis-story-editor-dialog--mobile
   .jgis-story-editor-toolbar-title[data-slot='input'] {
-    flex: none;
-    width: 100%;
-    min-width: 0;
-    max-width: none;
-  }
+  flex: none;
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+}
 
-  .jgis-story-editor-context-meta-group {
-    gap: 0.375rem;
-    justify-content: flex-start;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-context-meta-group {
+  gap: 0.375rem;
+  justify-content: flex-start;
+}
 
-  .jgis-story-editor-context-badge {
-    margin-right: auto;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-context-badge {
+  margin-right: auto;
+}
 
-  .jgis-story-editor-main {
-    flex-direction: column;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-main {
+  flex-direction: column;
+}
 
-  /* Segment list chrome when the dialog is narrow */
+.jgis-story-editor-dialog--mobile
   .jgis-story-editor-segment-list:not(.jgis-story-editor-segment-list--mobile) {
-    flex: none;
-    max-width: none;
-    min-width: 0;
-    max-height: none;
-    border-right: none;
-    border-bottom: 1px solid var(--jp-border-color1);
-  }
+  flex: none;
+  max-width: none;
+  min-width: 0;
+  max-height: none;
+  border-right: none;
+  border-bottom: 1px solid var(--jp-border-color1);
+}
 
-  .jgis-story-editor-workspace {
-    min-height: 0;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-workspace {
+  min-height: 0;
+}
 
-  .jgis-story-editor-segment {
-    padding: 0.625rem 0.75rem 1rem;
-    gap: 0.625rem;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-segment {
+  padding: 0.625rem 0.75rem 1rem;
+  gap: 0.625rem;
+}
 
-  .jgis-story-editor-segment-header {
-    align-items: center;
-    gap: 0.5rem;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-segment-header {
+  align-items: center;
+  gap: 0.5rem;
+}
 
-  .jgis-story-editor-segment-header > div {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-segment-header > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 
+.jgis-story-editor-dialog--mobile
   .jgis-story-editor-segment-header
-    .jgis-story-editor-toolbar-title[data-slot='input'] {
-    max-width: none;
-  }
+  .jgis-story-editor-toolbar-title[data-slot='input'] {
+  max-width: none;
+}
 
-  /* Side-by-side mode chips; hide descriptions */
-  .jgis-story-editor-segment-mode-picker {
-    grid-template-columns: 1fr 1fr;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-segment-mode-picker {
+  grid-template-columns: 1fr 1fr;
+}
 
+.jgis-story-editor-dialog--mobile
   .jgis-story-editor-segment-mode-picker
-    .jgis-button.jgis-story-editor-segment-mode-card {
-    align-items: center;
-    padding: 0.5rem 0.625rem;
-  }
+  .jgis-button.jgis-story-editor-segment-mode-card {
+  align-items: center;
+  padding: 0.5rem 0.625rem;
+}
 
+.jgis-story-editor-dialog--mobile
   .jgis-story-editor-segment-mode-picker
-    .jgis-button.jgis-story-editor-segment-mode-card
-    span {
-    display: none;
-  }
+  .jgis-button.jgis-story-editor-segment-mode-card
+  span {
+  display: none;
+}
 
-  .jgis-story-editor-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-row {
+  flex-direction: column;
+  align-items: stretch;
+}
 
-  .jgis-story-editor-row > .jgis-button,
-  .jgis-story-editor-row > button {
-    width: 100%;
-  }
+.jgis-story-editor-dialog--mobile .jgis-story-editor-row > .jgis-button,
+.jgis-story-editor-dialog--mobile .jgis-story-editor-row > button {
+  width: 100%;
 }

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -61,6 +61,13 @@
   font-size: 0.8rem;
 }
 
+.jgis-story-editor-slider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 0;
+}
+
 .jgis-story-editor-actions {
   display: flex;
   flex-wrap: wrap;

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -2,10 +2,6 @@
   font-weight: bold;
 }
 
-.jgis-story-editor-dialog--mobile .jp-Dialog-header {
-  display: none;
-}
-
 .jgis-story-editor-dialog .jp-Dialog-content {
   width: calc(90% - 4rem);
   max-width: 56rem;
@@ -23,14 +19,20 @@
   flex-direction: column;
 }
 
-.jgis-story-editor-dialog--mobile .jp-Dialog-content {
-  width: 100%;
-  max-width: 100%;
-  max-height: 90%;
-  margin: 0;
-  border-radius: 0;
-  padding-left: 8px;
-  padding-right: 8px;
+@media (max-width: 960px) {
+  .jgis-story-editor-dialog .jp-Dialog-header {
+    display: none;
+  }
+
+  .jgis-story-editor-dialog .jp-Dialog-content {
+    width: 100%;
+    max-width: 100%;
+    max-height: 90%;
+    margin: 0;
+    border-radius: 0;
+    padding-left: 8px;
+    padding-right: 8px;
+  }
 }
 
 .jgis-story-editor {
@@ -865,99 +867,99 @@ Radix won't set hidden so do it manually */
   max-width: 20rem;
 }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor {
-  min-height: 0;
-  max-height: none;
-  height: 100%;
-}
+@media (max-width: 960px) {
+  .jgis-story-editor {
+    min-height: 0;
+    max-height: none;
+    height: 100%;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-context-bar {
-  flex-direction: column;
-  flex-wrap: nowrap;
-  align-items: stretch;
-  gap: 0.375rem;
-}
+  /* Title on its own row; actions below */
+  .jgis-story-editor-context-bar {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    gap: 0.375rem;
+  }
 
-.jgis-story-editor-dialog--mobile
   .jgis-story-editor-toolbar-title[data-slot='input'] {
-  flex: none;
-  width: 100%;
-  min-width: 0;
-  max-width: none;
-}
+    flex: none;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-context-meta-group {
-  gap: 0.375rem;
-  justify-content: flex-start;
-}
+  .jgis-story-editor-context-meta-group {
+    gap: 0.375rem;
+    justify-content: flex-start;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-context-badge {
-  margin-right: auto;
-}
+  .jgis-story-editor-context-badge {
+    margin-right: auto;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-main {
-  flex-direction: column;
-}
+  .jgis-story-editor-main {
+    flex-direction: column;
+  }
 
-.jgis-story-editor-dialog--mobile
+  /* Segment list chrome when the dialog is narrow */
   .jgis-story-editor-segment-list:not(.jgis-story-editor-segment-list--mobile) {
-  flex: none;
-  max-width: none;
-  min-width: 0;
-  max-height: none;
-  border-right: none;
-  border-bottom: 1px solid var(--jp-border-color1);
-}
+    flex: none;
+    max-width: none;
+    min-width: 0;
+    max-height: none;
+    border-right: none;
+    border-bottom: 1px solid var(--jp-border-color1);
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-workspace {
-  min-height: 0;
-}
+  .jgis-story-editor-workspace {
+    min-height: 0;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-segment {
-  padding: 0.625rem 0.75rem 1rem;
-  gap: 0.625rem;
-}
+  .jgis-story-editor-segment {
+    padding: 0.625rem 0.75rem 1rem;
+    gap: 0.625rem;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-segment-header {
-  align-items: center;
-  gap: 0.5rem;
-}
+  .jgis-story-editor-segment-header {
+    align-items: center;
+    gap: 0.5rem;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-segment-header > div {
-  flex: 1 1 auto;
-  min-width: 0;
-}
+  .jgis-story-editor-segment-header > div {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
 
-.jgis-story-editor-dialog--mobile
   .jgis-story-editor-segment-header
-  .jgis-story-editor-toolbar-title[data-slot='input'] {
-  max-width: none;
-}
+    .jgis-story-editor-toolbar-title[data-slot='input'] {
+    max-width: none;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-segment-mode-picker {
-  grid-template-columns: 1fr 1fr;
-}
+  /* Side-by-side mode chips; hide descriptions */
+  .jgis-story-editor-segment-mode-picker {
+    grid-template-columns: 1fr 1fr;
+  }
 
-.jgis-story-editor-dialog--mobile
   .jgis-story-editor-segment-mode-picker
-  .jgis-button.jgis-story-editor-segment-mode-card {
-  align-items: center;
-  padding: 0.5rem 0.625rem;
-}
+    .jgis-button.jgis-story-editor-segment-mode-card {
+    align-items: center;
+    padding: 0.5rem 0.625rem;
+  }
 
-.jgis-story-editor-dialog--mobile
   .jgis-story-editor-segment-mode-picker
-  .jgis-button.jgis-story-editor-segment-mode-card
-  span {
-  display: none;
-}
+    .jgis-button.jgis-story-editor-segment-mode-card
+    span {
+    display: none;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-row {
-  flex-direction: column;
-  align-items: stretch;
-}
+  .jgis-story-editor-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-.jgis-story-editor-dialog--mobile .jgis-story-editor-row > .jgis-button,
-.jgis-story-editor-dialog--mobile .jgis-story-editor-row > button {
-  width: 100%;
+  .jgis-story-editor-row > .jgis-button,
+  .jgis-story-editor-row > button {
+    width: 100%;
+  }
 }

--- a/ui-tests/tests/story-editor.spec.ts
+++ b/ui-tests/tests/story-editor.spec.ts
@@ -4,7 +4,7 @@ import type { Locator } from '@playwright/test';
 import path from 'path';
 
 const FILENAME = 'story_map.jGIS';
-const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const MOBILE_VIEWPORT = { width: 960, height: 844 };
 const DESKTOP_VIEWPORT = { width: 1290, height: 800 };
 
 async function uploadStoryMap(
@@ -70,7 +70,7 @@ test.describe('Story editor (desktop)', () => {
 });
 
 test.describe('Story editor (mobile)', () => {
-  // test.use({ viewport: MOBILE_VIEWPORT });
+  test.use({ viewport: MOBILE_VIEWPORT });
 
   test.beforeEach(async ({ request, tmpPath }) => {
     await uploadStoryMap(request, tmpPath);

--- a/ui-tests/tests/story-editor.spec.ts
+++ b/ui-tests/tests/story-editor.spec.ts
@@ -1,40 +1,103 @@
 import { expect, galata, test } from '@jupyterlab/galata';
+import type { IJupyterLabPageFixture } from '@jupyterlab/galata';
+import type { Locator } from '@playwright/test';
 import path from 'path';
 
 const FILENAME = 'story_map.jGIS';
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const DESKTOP_VIEWPORT = { width: 1290, height: 800 };
 
-test.describe('Story editor', () => {
+async function uploadStoryMap(
+  request: Parameters<typeof galata.newContentsHelper>[0],
+  tmpPath: string,
+): Promise<void> {
+  const content = galata.newContentsHelper(request);
+  await content.uploadFile(
+    path.resolve(__dirname, `../../examples/${FILENAME}`),
+    `/${tmpPath}/${FILENAME}`,
+  );
+}
+
+async function openStoryEditor(
+  page: IJupyterLabPageFixture,
+  tmpPath: string,
+): Promise<Locator> {
+  await page.filebrowser.open(`/${tmpPath}/${FILENAME}`);
+  await page.waitForCondition(async () => page.activity.isTabActive(FILENAME));
+
+  await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+
+  const okButton = page.getByRole('button', { name: 'Ok' });
+  if (await okButton.isVisible()) {
+    await okButton.click();
+  }
+
+  await page.getByTestId('open-story-editor-button').click();
+
+  const dialog = page.locator('#jupytergis\\:\\:storyEditor');
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test.describe('Story editor (desktop)', () => {
+  test.use({ viewport: DESKTOP_VIEWPORT });
+
   test.beforeEach(async ({ request, tmpPath }) => {
-    const content = galata.newContentsHelper(request);
-    await content.uploadFile(
-      path.resolve(__dirname, `../../examples/${FILENAME}`),
-      `/${tmpPath}/${FILENAME}`,
-    );
+    await uploadStoryMap(request, tmpPath);
   });
 
   test.afterEach(async ({ page }) => {
     await page.activity.closeAll();
   });
 
-  test('opens with the segment list populated', async ({ page, tmpPath }) => {
-    await page.filebrowser.open(`/${tmpPath}/${FILENAME}`);
-    await page.waitForCondition(async () =>
-      page.activity.isTabActive(FILENAME),
+  test('opens with side-by-side segment list and workspace', async ({
+    page,
+    tmpPath,
+  }) => {
+    const dialog = await openStoryEditor(page, tmpPath);
+    const segmentItems = dialog.locator(
+      '.jgis-story-editor-segment-list-items button',
     );
+    await expect(segmentItems).not.toHaveCount(0);
 
-    await page.locator('div.jGIS-Spinner').waitFor({ state: 'hidden' });
+    const main = dialog.locator('.jgis-story-editor-main');
+    const listItems = dialog.locator('.jgis-story-editor-segment-list-items');
 
-    const okButton = page.getByRole('button', { name: 'Ok' });
-    if (await okButton.isVisible()) {
-      await okButton.click();
-    }
+    await expect(main).toHaveCSS('flex-direction', 'row');
+    await expect(listItems).toHaveCSS('flex-direction', 'column');
+    await expect(dialog.locator('.jgis-story-editor-workspace')).toBeVisible();
+  });
+});
 
-    await page.getByTestId('open-story-editor-button').click();
+test.describe('Story editor (mobile)', () => {
+  // test.use({ viewport: MOBILE_VIEWPORT });
 
-    const dialog = page.locator('#jupytergis\\:\\:storyEditor');
-    await expect(dialog).toBeVisible();
+  test.beforeEach(async ({ request, tmpPath }) => {
+    await uploadStoryMap(request, tmpPath);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.activity.closeAll();
+  });
+
+  test('opens with segment dropdown and stacked workspace', async ({
+    page,
+    tmpPath,
+  }) => {
+    const dialog = await openStoryEditor(page, tmpPath);
+
+    // Mobile uses NativeSelect instead of the desktop button list.
+    const segmentPicker = dialog.locator(
+      '.jgis-story-editor-segment-list.jgis-story-editor-segment-list--mobile',
+    );
+    await expect(segmentPicker).toBeVisible();
+    await expect(segmentPicker.locator('option')).not.toHaveCount(0);
     await expect(
-      dialog.locator('.jgis-story-editor-segment-list-items button'),
-    ).not.toHaveCount(0);
+      dialog.locator('.jgis-story-editor-segment-list-items'),
+    ).toHaveCount(0);
+
+    const main = dialog.locator('.jgis-story-editor-main');
+    await expect(main).toHaveCSS('flex-direction', 'column');
+    await expect(dialog.locator('.jgis-story-editor-workspace')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Update the mobile view for the story editor. 

<img width="414" height="887" alt="image" src="https://github.com/user-attachments/assets/5c94a0e5-99a9-4559-b3e3-2bc303cecd8c" />

<img width="414" height="887" alt="image" src="https://github.com/user-attachments/assets/aad42b15-8f9f-4970-bf46-85907d5a2669" />

<img width="414" height="887" alt="image" src="https://github.com/user-attachments/assets/1d8f54b5-c700-4c31-9053-4dee1e1a50e1" />

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1682.org.readthedocs.build/en/1682/
💡 JupyterLite preview: https://jupytergis--1682.org.readthedocs.build/en/1682/lite
💡 Specta preview: https://jupytergis--1682.org.readthedocs.build/en/1682/lite/specta

<!-- readthedocs-preview jupytergis end -->