### PR TITLE
Let vertical stories change animation

### DIFF
--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -14,10 +14,6 @@ import { StoryEditorSection } from '@/src/features/story/components/StoryEditorS
 import { StoryEditorSegmentList } from '@/src/features/story/components/StoryEditorSegmentList';
 import { TitleInput } from '@/src/features/story/components/TitleInput';
 import { useStoryEditorSegmentList } from '@/src/features/story/hooks/useStoryEditorSegmentList';
-import {
-  getStoryPresentationMode,
-  isVerticalScrollPresentation,
-} from '@/src/features/story/presentation/getStoryPresentationMode';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import type {
   IStorySegmentViewItem,

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -59,7 +59,6 @@ function SegmentEditor({
   editorServices,
   portalContainerRef,
   canRemoveSegment,
-  showSegmentAnimation,
   onContentModeChange,
   onContentChange,
   onLayerNameChange,
@@ -72,7 +71,6 @@ function SegmentEditor({
   editorServices: IEditorServices;
   portalContainerRef: React.RefObject<HTMLElement | null>;
   canRemoveSegment: boolean;
-  showSegmentAnimation: boolean;
   onContentModeChange: (mode: StorySegmentDisplayMode) => void;
   onContentChange: (patch: SegmentContentPatch) => void;
   onLayerNameChange: (name: string) => void;
@@ -183,47 +181,44 @@ function SegmentEditor({
             />
           </StoryEditorSection>
 
-          {showSegmentAnimation ? (
-            <StoryEditorSection
-              triggerText="Animation to this segment"
-              open={animationOpen}
-              onOpenChange={setAnimationOpen}
-            >
-              <div className="jgis-story-editor-row">
-                <NativeSelect
-                  size="sm"
-                  value={transitionType}
-                  onChange={event => {
-                    onTransitionChange({
-                      type: event.target
-                        .value as SegmentTransitionPatch['type'],
-                    });
-                  }}
-                >
-                  <NativeSelectOption value="immediate">
-                    Instant
-                  </NativeSelectOption>
-                  <NativeSelectOption value="smooth">
-                    Smooth pan
-                  </NativeSelectOption>
-                  <NativeSelectOption value="linear">Linear</NativeSelectOption>
-                </NativeSelect>
-                <Slider
-                  min={MIN_SEGMENT_TRANSITION_TIME}
-                  max={MAX_SEGMENT_TRANSITION_TIME}
-                  step={SEGMENT_TRANSITION_TIME_STEP}
-                  value={[transitionTime]}
-                  disabled={isImmediateTransition}
-                  aria-label="Transition duration"
-                  style={{ maxWidth: '10rem' }}
-                  onValueChange={([time]) => {
-                    onTransitionChange({ time });
-                  }}
-                />
-                <span>{formatSegmentTransitionTime(transitionTime)}</span>
-              </div>
-            </StoryEditorSection>
-          ) : null}
+          <StoryEditorSection
+            triggerText="Animation to this segment"
+            open={animationOpen}
+            onOpenChange={setAnimationOpen}
+          >
+            <div className="jgis-story-editor-row">
+              <NativeSelect
+                size="sm"
+                value={transitionType}
+                onChange={event => {
+                  onTransitionChange({
+                    type: event.target.value as SegmentTransitionPatch['type'],
+                  });
+                }}
+              >
+                <NativeSelectOption value="immediate">
+                  Instant
+                </NativeSelectOption>
+                <NativeSelectOption value="smooth">
+                  Smooth pan
+                </NativeSelectOption>
+                <NativeSelectOption value="linear">Linear</NativeSelectOption>
+              </NativeSelect>
+              <Slider
+                min={MIN_SEGMENT_TRANSITION_TIME}
+                max={MAX_SEGMENT_TRANSITION_TIME}
+                step={SEGMENT_TRANSITION_TIME_STEP}
+                value={[transitionTime]}
+                disabled={isImmediateTransition}
+                aria-label="Transition duration"
+                style={{ maxWidth: '10rem' }}
+                onValueChange={([time]) => {
+                  onTransitionChange({ time });
+                }}
+              />
+              <span>{formatSegmentTransitionTime(transitionTime)}</span>
+            </div>
+          </StoryEditorSection>
         </>
       ) : (
         <StoryEditorSection triggerText="Content" defaultOpen>
@@ -273,9 +268,6 @@ export function StoryEditorDialogBody({
   } = useStoryEditorSegmentList(model, commands);
 
   const portalContainerRef = useRef<HTMLDivElement>(null);
-  const showSegmentAnimation = !isVerticalScrollPresentation(
-    getStoryPresentationMode(story?.storyType),
-  );
 
   return (
     <div ref={portalContainerRef} className="jgis-story-editor">
@@ -306,7 +298,6 @@ export function StoryEditorDialogBody({
               editorServices={editorServices}
               portalContainerRef={portalContainerRef}
               canRemoveSegment={canRemoveSegment}
-              showSegmentAnimation={showSegmentAnimation}
               onContentModeChange={mode => {
                 updateSegmentContentMode(selectedSegment.id, mode);
               }}


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Close #1664

Allows vertical stories to set transition type. 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1684.org.readthedocs.build/en/1684/
💡 JupyterLite preview: https://jupytergis--1684.org.readthedocs.build/en/1684/lite
💡 Specta preview: https://jupytergis--1684.org.readthedocs.build/en/1684/lite/specta

<!-- readthedocs-preview jupytergis end -->