### PR TITLE
Add option to set width of markdown content in vertical stories

### DIFF
--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -314,6 +314,7 @@ export function ListStoryStageOverlay({
       story?.storyType,
       story?.presentationBgColor,
       story?.presentationTextColor,
+      story?.overlayContentWidth,
     ],
   );
 

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -9,7 +9,7 @@ import {
   isVerticalScrollPresentation,
 } from '@/src/features/story/presentation/getStoryPresentationMode';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
-import { resolveStoryPresentationColorForInput } from '@/src/features/story/utils/spectaPresentation';
+import { resolveOverlayContentWidthForInput, resolveStoryPresentationColorForInput } from '@/src/features/story/utils/spectaPresentation';
 import {
   formatGradientLabel,
   formatMarkdownSegmentGapLabel,
@@ -103,15 +103,32 @@ function StorySettingsPopover({
             {isVerticalScrollPresentation(
               getStoryPresentationMode(story.storyType),
             ) ? (
-              <label className="jgis-story-editor-toggle-row">
-                <span>Gap between markdown segments</span>
-                <Switch
-                  checked={story.markdownSegmentGap === true}
-                  onCheckedChange={checked => {
-                    onUpdateStory({ markdownSegmentGap: checked });
-                  }}
-                />
-              </label>
+              <>
+                <label className="jgis-story-editor-toggle-row">
+                  <span>Gap between markdown segments</span>
+                  <Switch
+                    checked={story.markdownSegmentGap === true}
+                    onCheckedChange={checked => {
+                      onUpdateStory({ markdownSegmentGap: checked });
+                    }}
+                  />
+                </label>
+                <label className="jgis-story-editor-field">
+                  <span>Overlay content width</span>
+                  <Input
+                    type="text"
+                    placeholder="100%"
+                    value={resolveOverlayContentWidthForInput(
+                      story.overlayContentWidth,
+                    )}
+                    onChange={event => {
+                      onUpdateStory({
+                        overlayContentWidth: event.target.value.trim(),
+                      });
+                    }}
+                  />
+                </label>
+              </>
             ) : null}
             <label className="jgis-story-editor-field">
               <span>Background color</span>

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -9,7 +9,10 @@ import {
   isVerticalScrollPresentation,
 } from '@/src/features/story/presentation/getStoryPresentationMode';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
-import { resolveOverlayContentWidthForInput, resolveStoryPresentationColorForInput } from '@/src/features/story/utils/spectaPresentation';
+import {
+  resolveOverlayContentWidthForInput,
+  resolveStoryPresentationColorForInput,
+} from '@/src/features/story/utils/spectaPresentation';
 import {
   formatGradientLabel,
   formatMarkdownSegmentGapLabel,

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -10,8 +10,13 @@ import {
 } from '@/src/features/story/presentation/getStoryPresentationMode';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import {
-  resolveOverlayContentWidthForInput,
+  formatOverlayContentWidth,
+  matchOverlayContentWidthPreset,
+  OVERLAY_CONTENT_WIDTH_PRESETS,
+  OVERLAY_CONTENT_WIDTH_UNITS,
+  parseOverlayContentWidth,
   resolveStoryPresentationColorForInput,
+  type OverlayContentWidthUnit,
 } from '@/src/features/story/utils/spectaPresentation';
 import {
   formatGradientLabel,
@@ -41,6 +46,102 @@ export interface IStoryEditorHeaderBarProps {
   segmentCount: number;
   onUpdateStory: (patch: Partial<IJGISStoryMap>) => void;
   portalContainerRef: RefObject<HTMLElement | null>;
+}
+
+function OverlayContentWidthField({
+  value,
+  onChange,
+}: {
+  value: string | undefined;
+  onChange: (width: string) => void;
+}): JSX.Element {
+  const matchedPreset = matchOverlayContentWidthPreset(value);
+  const [isCustom, setIsCustom] = useState(matchedPreset === null);
+  const parsed = parseOverlayContentWidth(value);
+  const selectedPresetId = isCustom ? null : matchedPreset;
+
+  return (
+    <div className="jgis-story-editor-field">
+      <span>Overlay content width</span>
+      <div
+        className="jgis-story-editor-width-presets"
+        role="group"
+        aria-label="Overlay content width presets"
+      >
+        {OVERLAY_CONTENT_WIDTH_PRESETS.map(preset => (
+          <Button
+            key={preset.id}
+            type="button"
+            variant="outline"
+            size="sm"
+            className={`jgis-story-editor-width-preset${
+              selectedPresetId === preset.id
+                ? ' jgis-story-editor-width-preset--selected'
+                : ''
+            }`}
+            aria-pressed={selectedPresetId === preset.id}
+            title={preset.value}
+            onClick={() => {
+              setIsCustom(false);
+              onChange(preset.value);
+            }}
+          >
+            {preset.label}
+          </Button>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className={`jgis-story-editor-width-preset${
+            isCustom ? ' jgis-story-editor-width-preset--selected' : ''
+          }`}
+          aria-pressed={isCustom}
+          onClick={() => {
+            setIsCustom(true);
+          }}
+        >
+          Custom
+        </Button>
+      </div>
+      {isCustom ? (
+        <div className="jgis-story-editor-width-custom">
+          <Input
+            type="number"
+            min={0}
+            aria-label="Width amount"
+            value={parsed.amount}
+            onChange={event => {
+              const amount = event.target.value;
+              if (!amount.trim()) {
+                return;
+              }
+
+              onChange(formatOverlayContentWidth(amount, parsed.unit));
+            }}
+          />
+          <NativeSelect
+            aria-label="Width unit"
+            value={parsed.unit}
+            onChange={event => {
+              onChange(
+                formatOverlayContentWidth(
+                  parsed.amount,
+                  event.target.value as OverlayContentWidthUnit,
+                ),
+              );
+            }}
+          >
+            {OVERLAY_CONTENT_WIDTH_UNITS.map(unit => (
+              <NativeSelectOption key={unit} value={unit}>
+                {unit}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function StorySettingsPopover({
@@ -116,21 +217,12 @@ function StorySettingsPopover({
                     }}
                   />
                 </label>
-                <label className="jgis-story-editor-field">
-                  <span>Overlay content width</span>
-                  <Input
-                    type="text"
-                    placeholder="100%"
-                    value={resolveOverlayContentWidthForInput(
-                      story.overlayContentWidth,
-                    )}
-                    onChange={event => {
-                      onUpdateStory({
-                        overlayContentWidth: event.target.value.trim(),
-                      });
-                    }}
-                  />
-                </label>
+                <OverlayContentWidthField
+                  value={story.overlayContentWidth}
+                  onChange={overlayContentWidth => {
+                    onUpdateStory({ overlayContentWidth });
+                  }}
+                />
               </>
             ) : null}
             <label className="jgis-story-editor-field">

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -1,7 +1,7 @@
 import { faGear } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IJGISStoryMap, IJupyterGISModel } from '@jupytergis/schema';
-import React, { useState, type RefObject } from 'react';
+import React, { useEffect, useState, type RefObject } from 'react';
 
 import { TitleInput } from '@/src/features/story/components/TitleInput';
 import {
@@ -48,6 +48,32 @@ export interface IStoryEditorHeaderBarProps {
   portalContainerRef: RefObject<HTMLElement | null>;
 }
 
+/**
+ * CSS length amount accepts digits with at most one decimal point.
+ * Allows intermediate edit states ("", ".", "1.") that type="number"
+ * mishandles in Firefox when the input is controlled.
+ */
+const CSS_AMOUNT_FRAGMENT = /^\d*\.?\d*$/;
+const CSS_AMOUNT_COMPLETE = /^\d*\.?\d+$/;
+
+function sanitizeCssAmountInput(raw: string): string {
+  if (CSS_AMOUNT_FRAGMENT.test(raw)) {
+    return raw;
+  }
+
+  let result = '';
+  let hasDot = false;
+  for (const char of raw) {
+    if (char >= '0' && char <= '9') {
+      result += char;
+    } else if (char === '.' && !hasDot) {
+      result += '.';
+      hasDot = true;
+    }
+  }
+  return result;
+}
+
 function OverlayContentWidthField({
   value,
   onChange,
@@ -58,7 +84,14 @@ function OverlayContentWidthField({
   const matchedPreset = matchOverlayContentWidthPreset(value);
   const [isCustom, setIsCustom] = useState(matchedPreset === null);
   const parsed = parseOverlayContentWidth(value);
+  const [amount, setAmount] = useState(parsed.amount);
+  const [amountError, setAmountError] = useState<string | null>(null);
   const selectedPresetId = isCustom ? null : matchedPreset;
+
+  useEffect(() => {
+    setAmount(parsed.amount);
+    setAmountError(null);
+  }, [parsed.amount]);
 
   return (
     <div className="jgis-story-editor-field">
@@ -105,40 +138,49 @@ function OverlayContentWidthField({
         </Button>
       </div>
       {isCustom ? (
-        <div className="jgis-story-editor-width-custom">
-          <Input
-            type="number"
-            min={0}
-            aria-label="Width amount"
-            value={parsed.amount}
-            onChange={event => {
-              const amount = event.target.value;
-              if (!amount.trim()) {
-                return;
-              }
+        <>
+          <div className="jgis-story-editor-width-custom">
+            <Input
+              aria-label="Width amount"
+              type="text"
+              inputMode="decimal"
+              value={amount}
+              onChange={event => {
+                const next = sanitizeCssAmountInput(event.target.value);
+                setAmount(next);
 
-              onChange(formatOverlayContentWidth(amount, parsed.unit));
-            }}
-          />
-          <NativeSelect
-            aria-label="Width unit"
-            value={parsed.unit}
-            onChange={event => {
-              onChange(
-                formatOverlayContentWidth(
-                  parsed.amount,
-                  event.target.value as OverlayContentWidthUnit,
-                ),
-              );
-            }}
-          >
-            {OVERLAY_CONTENT_WIDTH_UNITS.map(unit => (
-              <NativeSelectOption key={unit} value={unit}>
-                {unit}
-              </NativeSelectOption>
-            ))}
-          </NativeSelect>
-        </div>
+                if (!CSS_AMOUNT_COMPLETE.test(next)) {
+                  setAmountError('Enter a valid width');
+                  return;
+                }
+
+                setAmountError(null);
+                onChange(formatOverlayContentWidth(next, parsed.unit));
+              }}
+            />
+            <NativeSelect
+              aria-label="Width unit"
+              value={parsed.unit}
+              onChange={event => {
+                onChange(
+                  formatOverlayContentWidth(
+                    amount.trim() || parsed.amount,
+                    event.target.value as OverlayContentWidthUnit,
+                  ),
+                );
+              }}
+            >
+              {OVERLAY_CONTENT_WIDTH_UNITS.map(unit => (
+                <NativeSelectOption key={unit} value={unit}>
+                  {unit}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </div>
+          {amountError ? (
+            <p className="jgis-story-editor-field-error">{amountError}</p>
+          ) : null}
+        </>
       ) : null}
     </div>
   );

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -85,13 +85,16 @@ function OverlayContentWidthField({
   const [isCustom, setIsCustom] = useState(matchedPreset === null);
   const parsed = parseOverlayContentWidth(value);
   const [amount, setAmount] = useState(parsed.amount);
-  const [amountError, setAmountError] = useState<string | null>(null);
+  const [unit, setUnit] = useState(parsed.unit);
+  const [widthError, setWidthError] = useState<string | null>(null);
   const selectedPresetId = isCustom ? null : matchedPreset;
 
   useEffect(() => {
-    setAmount(parsed.amount);
-    setAmountError(null);
-  }, [parsed.amount]);
+    const next = parseOverlayContentWidth(value);
+    setAmount(next.amount);
+    setUnit(next.unit);
+    setWidthError(null);
+  }, [value]);
 
   return (
     <div className="jgis-story-editor-field">
@@ -146,46 +149,50 @@ function OverlayContentWidthField({
               inputMode="decimal"
               value={amount}
               onChange={event => {
-                const next = sanitizeCssAmountInput(event.target.value);
-                setAmount(next);
+                const nextAmount = sanitizeCssAmountInput(event.target.value);
+                setAmount(nextAmount);
 
-                if (!CSS_AMOUNT_COMPLETE.test(next)) {
-                  setAmountError('Enter a valid width');
+                if (!CSS_AMOUNT_COMPLETE.test(nextAmount)) {
+                  setWidthError('Enter a valid width');
                   return;
                 }
 
-                setAmountError(null);
-                onChange(formatOverlayContentWidth(next, parsed.unit));
+                setWidthError(null);
+                onChange(formatOverlayContentWidth(nextAmount, unit));
               }}
             />
             <NativeSelect
               aria-label="Width unit"
-              value={parsed.unit}
+              value={unit}
               onChange={event => {
-                onChange(
-                  formatOverlayContentWidth(
-                    amount.trim() || parsed.amount,
-                    event.target.value as OverlayContentWidthUnit,
-                  ),
-                );
+                const nextUnit = event.target.value as OverlayContentWidthUnit;
+                setUnit(nextUnit);
+
+                if (!CSS_AMOUNT_COMPLETE.test(amount.trim())) {
+                  setWidthError('Enter a valid width');
+                  return;
+                }
+
+                setWidthError(null);
+                onChange(formatOverlayContentWidth(amount.trim(), nextUnit));
               }}
             >
-              {OVERLAY_CONTENT_WIDTH_UNITS.map(unit => (
-                <NativeSelectOption key={unit} value={unit}>
-                  {unit}
+              {OVERLAY_CONTENT_WIDTH_UNITS.map(unitOption => (
+                <NativeSelectOption key={unitOption} value={unitOption}>
+                  {unitOption}
                 </NativeSelectOption>
               ))}
             </NativeSelect>
           </div>
-          {amountError ? (
-            <p className="jgis-story-editor-field-error">{amountError}</p>
+          {widthError ? (
+            <p className="jgis-story-editor-field-error">{widthError}</p>
           ) : null}
         </>
       ) : null}
     </div>
   );
 }
-
+//sdsds
 function StorySettingsPopover({
   story,
   onUpdateStory,

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -192,7 +192,7 @@ function OverlayContentWidthField({
     </div>
   );
 }
-//sdsds
+
 function StorySettingsPopover({
   story,
   onUpdateStory,

--- a/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
+++ b/packages/base/src/features/story/context/ListStoryScrollTrackContext.tsx
@@ -14,6 +14,7 @@ import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSeg
 import { useQueuedMarkdownHeightMeasure } from '@/src/features/story/hooks/useQueuedMarkdownHeightMeasure';
 import type { IListStoryScrollTrackLayout } from '@/src/features/story/types/types';
 import { buildListStoryScrollTrack } from '@/src/features/story/utils/listStoryScrollTrack';
+import { getSpectaPresentationCssVars } from '@/src/features/story/utils/spectaPresentation';
 import {
   buildStorySegmentViewItems,
   getListStoryMarkdownSegmentsFromItems,
@@ -89,6 +90,16 @@ export function ListStoryScrollTrackProvider({
     mapViewportHeight > 0 ? mapViewportHeight : undefined;
 
   const markdownSegmentGap = storyData?.markdownSegmentGap === true;
+
+  const measurePresentationStyle = useMemo(
+    () => getSpectaPresentationCssVars(storyData),
+    [
+      storyData?.storyType,
+      storyData?.presentationBgColor,
+      storyData?.presentationTextColor,
+      storyData?.overlayContentWidth,
+    ],
+  );
 
   const buildScrollTrackLayout = useCallback(
     (
@@ -317,7 +328,11 @@ export function ListStoryScrollTrackProvider({
     <ListStoryScrollTrackContext.Provider value={value}>
       {children}
       {enabled && segmentBeingMeasured ? (
-        <div className="jgis-story-markdown-measure-host" aria-hidden>
+        <div
+          className="jgis-story-markdown-measure-host"
+          style={measurePresentationStyle}
+          aria-hidden
+        >
           <ListStoryMarkdownMeasurePane
             key={segmentBeingMeasured.id}
             model={model}

--- a/packages/base/src/features/story/utils/spectaPresentation.ts
+++ b/packages/base/src/features/story/utils/spectaPresentation.ts
@@ -6,14 +6,13 @@ import {
   isColumnPresentation,
   isVerticalScrollPresentation,
 } from '@/src/features/story/presentation/getStoryPresentationMode';
-import { getCssVarAsColor } from '@/src/tools';
+import { getCssVarValue } from '@/src/tools';
 
 /** Jupyter theme vars used when presentation colors are unset (see storyPanel.css). */
 const JP_THEME_BG_VAR = '--jp-layout-color0';
 const JP_THEME_TEXT_VAR = '--jp-ui-font-color1';
 
-/** Keep in sync with `.jgis-story-stage-overlay-content` fallback in storyPanel.css. */
-const OVERLAY_CONTENT_WIDTH_VAR = '--jgis-story-overlay-content-width';
+/** CSS fallback when overlay width is unset (see storyPanel.css). */
 const OVERLAY_CONTENT_WIDTH_FALLBACK = '100%';
 
 export function resolveStoryPresentationColorForInput(
@@ -24,12 +23,12 @@ export function resolveStoryPresentationColorForInput(
     return color;
   }
 
-  return getCssVarAsColor(kind === 'bg' ? JP_THEME_BG_VAR : JP_THEME_TEXT_VAR);
+  return getCssVarValue(kind === 'bg' ? JP_THEME_BG_VAR : JP_THEME_TEXT_VAR);
 }
 
 /**
  * Value for the story-settings width field. Uses the story override when set;
- * otherwise the CSS custom property / stylesheet fallback.
+ * otherwise the same CSS fallback as storyPanel.css.
  */
 export function resolveOverlayContentWidthForInput(
   width: string | undefined,
@@ -38,9 +37,7 @@ export function resolveOverlayContentWidthForInput(
     return width.trim();
   }
 
-  return (
-    getCssVarAsColor(OVERLAY_CONTENT_WIDTH_VAR) || OVERLAY_CONTENT_WIDTH_FALLBACK
-  );
+  return OVERLAY_CONTENT_WIDTH_FALLBACK;
 }
 
 /** CSS variables (+ optional text color) for specta theming */
@@ -66,8 +63,9 @@ export function getSpectaPresentationCssVars(
       (style as Record<string, string>)['--jgis-specta-bg-color'] = bgColor;
     }
     if (overlayContentWidth) {
-      (style as Record<string, string>)[OVERLAY_CONTENT_WIDTH_VAR] =
-        overlayContentWidth;
+      (style as Record<string, string>)[
+        '--jgis-story-overlay-content-width'
+      ] = overlayContentWidth;
     }
     return style;
   }

--- a/packages/base/src/features/story/utils/spectaPresentation.ts
+++ b/packages/base/src/features/story/utils/spectaPresentation.ts
@@ -8,12 +8,10 @@ import {
 } from '@/src/features/story/presentation/getStoryPresentationMode';
 import { getCssVarValue } from '@/src/tools';
 
-/** Jupyter theme vars used when presentation colors are unset (see storyPanel.css). */
-const JP_THEME_BG_VAR = '--jp-layout-color0';
-const JP_THEME_TEXT_VAR = '--jp-ui-font-color1';
-
-/** CSS fallback when overlay width is unset (see storyPanel.css). */
-export const OVERLAY_CONTENT_WIDTH_FALLBACK = '100%';
+/** Fallbacks when presentation settings are unset (see storyPanel.css). */
+const PRESENTATION_BG_COLOR_FALLBACK = '--jp-layout-color0';
+const PRESENTATION_TEXT_COLOR_FALLBACK = '--jp-ui-font-color1';
+const OVERLAY_CONTENT_WIDTH_FALLBACK = '100%';
 
 export const OVERLAY_CONTENT_WIDTH_UNITS = [
   'ch',
@@ -45,7 +43,11 @@ export function resolveStoryPresentationColorForInput(
     return color;
   }
 
-  return getCssVarValue(kind === 'bg' ? JP_THEME_BG_VAR : JP_THEME_TEXT_VAR);
+  return getCssVarValue(
+    kind === 'bg'
+      ? PRESENTATION_BG_COLOR_FALLBACK
+      : PRESENTATION_TEXT_COLOR_FALLBACK,
+  );
 }
 
 export function resolveOverlayContentWidthValue(

--- a/packages/base/src/features/story/utils/spectaPresentation.ts
+++ b/packages/base/src/features/story/utils/spectaPresentation.ts
@@ -32,12 +32,13 @@ export function resolveStoryPresentationColorForInput(
  */
 export function resolveOverlayContentWidthForInput(
   width: string | undefined,
-): string {
+): string | undefined {
   if (width?.trim()) {
     return width.trim();
   }
 
-  return OVERLAY_CONTENT_WIDTH_FALLBACK;
+  // Return undefined so placeholder works
+  return undefined;
 }
 
 /** CSS variables (+ optional text color) for specta theming */
@@ -63,9 +64,8 @@ export function getSpectaPresentationCssVars(
       (style as Record<string, string>)['--jgis-specta-bg-color'] = bgColor;
     }
     if (overlayContentWidth) {
-      (style as Record<string, string>)[
-        '--jgis-story-overlay-content-width'
-      ] = overlayContentWidth;
+      (style as Record<string, string>)['--jgis-story-overlay-content-width'] =
+        overlayContentWidth;
     }
     return style;
   }

--- a/packages/base/src/features/story/utils/spectaPresentation.ts
+++ b/packages/base/src/features/story/utils/spectaPresentation.ts
@@ -13,7 +13,29 @@ const JP_THEME_BG_VAR = '--jp-layout-color0';
 const JP_THEME_TEXT_VAR = '--jp-ui-font-color1';
 
 /** CSS fallback when overlay width is unset (see storyPanel.css). */
-const OVERLAY_CONTENT_WIDTH_FALLBACK = '100%';
+export const OVERLAY_CONTENT_WIDTH_FALLBACK = '100%';
+
+export const OVERLAY_CONTENT_WIDTH_UNITS = [
+  'ch',
+  '%',
+  'rem',
+  'px',
+  'em',
+  'vw',
+] as const;
+
+export type OverlayContentWidthUnit =
+  (typeof OVERLAY_CONTENT_WIDTH_UNITS)[number];
+
+export const OVERLAY_CONTENT_WIDTH_PRESETS = [
+  { id: 'narrow', label: 'Narrow', value: '50ch' },
+  { id: 'comfort', label: 'Comfort', value: '75ch' },
+  { id: 'wide', label: 'Wide', value: '100ch' },
+  { id: 'full', label: 'Full', value: '100%' },
+] as const;
+
+export type OverlayContentWidthPresetId =
+  (typeof OVERLAY_CONTENT_WIDTH_PRESETS)[number]['id'];
 
 export function resolveStoryPresentationColorForInput(
   color: string | undefined,
@@ -26,19 +48,46 @@ export function resolveStoryPresentationColorForInput(
   return getCssVarValue(kind === 'bg' ? JP_THEME_BG_VAR : JP_THEME_TEXT_VAR);
 }
 
-/**
- * Value for the story-settings width field. Uses the story override when set;
- * otherwise the same CSS fallback as storyPanel.css.
- */
-export function resolveOverlayContentWidthForInput(
+export function resolveOverlayContentWidthValue(
   width: string | undefined,
-): string | undefined {
-  if (width?.trim()) {
-    return width.trim();
+): string {
+  const trimmed = width?.trim();
+
+  return trimmed || OVERLAY_CONTENT_WIDTH_FALLBACK;
+}
+
+export function matchOverlayContentWidthPreset(
+  width: string | undefined,
+): OverlayContentWidthPresetId | null {
+  const value = resolveOverlayContentWidthValue(width);
+  const preset = OVERLAY_CONTENT_WIDTH_PRESETS.find(
+    candidate => candidate.value === value,
+  );
+
+  return preset?.id ?? null;
+}
+
+export function parseOverlayContentWidth(width: string | undefined): {
+  amount: string;
+  unit: OverlayContentWidthUnit;
+} {
+  const value = resolveOverlayContentWidthValue(width);
+  const match = /^(\d*\.?\d+)\s*(ch|%|rem|px|em|vw)$/i.exec(value);
+  if (!match) {
+    return { amount: '100', unit: '%' };
   }
 
-  // Return undefined so placeholder works
-  return undefined;
+  return {
+    amount: match[1],
+    unit: match[2].toLowerCase() as OverlayContentWidthUnit,
+  };
+}
+
+export function formatOverlayContentWidth(
+  amount: string,
+  unit: OverlayContentWidthUnit,
+): string {
+  return `${amount.trim()}${unit}`;
 }
 
 /** CSS variables (+ optional text color) for specta theming */

--- a/packages/base/src/features/story/utils/spectaPresentation.ts
+++ b/packages/base/src/features/story/utils/spectaPresentation.ts
@@ -12,6 +12,10 @@ import { getCssVarAsColor } from '@/src/tools';
 const JP_THEME_BG_VAR = '--jp-layout-color0';
 const JP_THEME_TEXT_VAR = '--jp-ui-font-color1';
 
+/** Keep in sync with `.jgis-story-stage-overlay-content` fallback in storyPanel.css. */
+const OVERLAY_CONTENT_WIDTH_VAR = '--jgis-story-overlay-content-width';
+const OVERLAY_CONTENT_WIDTH_FALLBACK = '100%';
+
 export function resolveStoryPresentationColorForInput(
   color: string | undefined,
   kind: 'bg' | 'text',
@@ -23,6 +27,22 @@ export function resolveStoryPresentationColorForInput(
   return getCssVarAsColor(kind === 'bg' ? JP_THEME_BG_VAR : JP_THEME_TEXT_VAR);
 }
 
+/**
+ * Value for the story-settings width field. Uses the story override when set;
+ * otherwise the CSS custom property / stylesheet fallback.
+ */
+export function resolveOverlayContentWidthForInput(
+  width: string | undefined,
+): string {
+  if (width?.trim()) {
+    return width.trim();
+  }
+
+  return (
+    getCssVarAsColor(OVERLAY_CONTENT_WIDTH_VAR) || OVERLAY_CONTENT_WIDTH_FALLBACK
+  );
+}
+
 /** CSS variables (+ optional text color) for specta theming */
 export function getSpectaPresentationCssVars(
   story: IJGISStoryMap | null,
@@ -31,6 +51,7 @@ export function getSpectaPresentationCssVars(
   const verticalScroll = isVerticalScrollPresentation(presentationMode);
   const bgColor = story?.presentationBgColor;
   const textColor = story?.presentationTextColor;
+  const overlayContentWidth = story?.overlayContentWidth?.trim();
   const style: CSSProperties = {};
 
   if (textColor) {
@@ -43,6 +64,10 @@ export function getSpectaPresentationCssVars(
       'transparent';
     if (bgColor) {
       (style as Record<string, string>)['--jgis-specta-bg-color'] = bgColor;
+    }
+    if (overlayContentWidth) {
+      (style as Record<string, string>)[OVERLAY_CONTENT_WIDTH_VAR] =
+        overlayContentWidth;
     }
     return style;
   }

--- a/packages/base/src/features/story/utils/spectaPresentation.ts
+++ b/packages/base/src/features/story/utils/spectaPresentation.ts
@@ -32,7 +32,7 @@ export const OVERLAY_CONTENT_WIDTH_PRESETS = [
   { id: 'full', label: 'Full', value: '100%' },
 ] as const;
 
-export type OverlayContentWidthPresetId =
+type OverlayContentWidthPresetId =
   (typeof OVERLAY_CONTENT_WIDTH_PRESETS)[number]['id'];
 
 export function resolveStoryPresentationColorForInput(
@@ -50,9 +50,7 @@ export function resolveStoryPresentationColorForInput(
   );
 }
 
-export function resolveOverlayContentWidthValue(
-  width: string | undefined,
-): string {
+function resolveOverlayContentWidthValue(width: string | undefined): string {
   const trimmed = width?.trim();
 
   return trimmed || OVERLAY_CONTENT_WIDTH_FALLBACK;
@@ -111,13 +109,16 @@ export function getSpectaPresentationCssVars(
   if (verticalScroll) {
     (style as Record<string, string>)['--jgis-specta-panel-color'] =
       'transparent';
+
     if (bgColor) {
       (style as Record<string, string>)['--jgis-specta-bg-color'] = bgColor;
     }
+
     if (overlayContentWidth) {
       (style as Record<string, string>)['--jgis-story-overlay-content-width'] =
         overlayContentWidth;
     }
+
     return style;
   }
 

--- a/packages/base/src/tools.ts
+++ b/packages/base/src/tools.ts
@@ -84,8 +84,8 @@ export function nearest(n: number, tol: number): number {
   }
 }
 
-/** Read a CSS variable from the document root and return the value. */
-export function getCssVarAsColor(cssVar: string): string {
+/** Read a CSS custom property from the document root. */
+export function getCssVarValue(cssVar: string): string {
   if (typeof document === 'undefined') {
     return '';
   }

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -228,6 +228,36 @@
   border-top: 1px solid var(--jp-border-color2);
 }
 
+.jgis-story-editor-width-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.jgis-story-editor-width-presets .jgis-button.jgis-story-editor-width-preset {
+  height: 1.5rem;
+  padding: 0.2rem 0.2rem;
+  font-size: 0.75rem;
+  border-radius: 6px;
+}
+
+.jgis-story-editor-width-presets
+  .jgis-button.jgis-story-editor-width-preset--selected {
+  border-color: var(--jp-brand-color1);
+  background: color-mix(
+    in srgb,
+    var(--jp-brand-color1) 8%,
+    var(--jp-layout-color1)
+  );
+}
+
+.jgis-story-editor-width-custom {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.35rem;
+  align-items: center;
+}
+
 .jgis-story-editor-toggle-row {
   display: flex;
   align-items: center;

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -85,6 +85,12 @@
   line-height: 1.4;
 }
 
+.jgis-story-editor-field-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--jp-error-color1);
+}
+
 .jgis-story-editor-field {
   display: flex;
   flex-direction: column;

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -357,7 +357,6 @@
 }
 
 .jgis-story-stage-overlay-content {
-  /* width: var(--jgis-story-overlay-content-width, 100%); */
   box-sizing: border-box;
   background-color: var(--jgis-specta-bg-color, var(--jp-layout-color0));
   margin: 0 auto;
@@ -377,7 +376,6 @@
   box-sizing: border-box;
   width: var(--jgis-story-overlay-content-width, 100%);
   margin: 0 auto;
-  /* background-color: transparent; */
 }
 
 .jgis-story-segment-transition-stack .jgis-story-map-scroll-pane {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -357,7 +357,9 @@
 }
 
 .jgis-story-stage-overlay-content {
-  max-width: 60rem;
+  --jgis-story-overlay-content-width: 100%;
+  width: var(--jgis-story-overlay-content-width);
+  box-sizing: border-box;
   background-color: var(--jgis-specta-bg-color, var(--jp-layout-color0));
   margin: 0 auto;
   padding: 1rem;
@@ -374,7 +376,7 @@
   top: 0;
   height: auto;
   box-sizing: border-box;
-  background-color: var(--jgis-specta-bg-color, var(--jp-layout-color0));
+  background-color: transparent;
 }
 
 .jgis-story-segment-transition-stack .jgis-story-map-scroll-pane {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -357,8 +357,7 @@
 }
 
 .jgis-story-stage-overlay-content {
-  --jgis-story-overlay-content-width: 100%;
-  width: var(--jgis-story-overlay-content-width);
+  /* width: var(--jgis-story-overlay-content-width, 100%); */
   box-sizing: border-box;
   background-color: var(--jgis-specta-bg-color, var(--jp-layout-color0));
   margin: 0 auto;
@@ -376,7 +375,9 @@
   top: 0;
   height: auto;
   box-sizing: border-box;
-  background-color: transparent;
+  width: var(--jgis-story-overlay-content-width, 100%);
+  margin: 0 auto;
+  /* background-color: transparent; */
 }
 
 .jgis-story-segment-transition-stack .jgis-story-map-scroll-pane {

--- a/packages/base/style/storySpectaArticleOverlay.css
+++ b/packages/base/style/storySpectaArticleOverlay.css
@@ -13,6 +13,8 @@
   font-family: var(--jp-content-font-family);
   font-size: 1rem;
   line-height: 1.6;
+  max-width: 60rem;
+  margin: 0 auto;
 }
 
 #jgis-story-segment-content

--- a/packages/base/style/storySpectaArticleOverlay.css
+++ b/packages/base/style/storySpectaArticleOverlay.css
@@ -13,7 +13,7 @@
   font-family: var(--jp-content-font-family);
   font-size: 1rem;
   line-height: 1.6;
-  max-width: 60rem;
+  max-width: 100ch;
   margin: 0 auto;
 }
 

--- a/packages/schema/src/schema/project/jgis.json
+++ b/packages/schema/src/schema/project/jgis.json
@@ -193,6 +193,11 @@
           "type": "string",
           "title": "Presentation Text Color",
           "description": "The text color of the story map"
+        },
+        "overlayContentWidth": {
+          "type": "string",
+          "title": "Overlay content width",
+          "description": "CSS width for vertical-scroll markdown overlay content."
         }
       }
     },


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Adds option to set width of markdown content in vertical stories. 

Presets:
<img width="480" height="567" alt="image" src="https://github.com/user-attachments/assets/d3503c34-ca00-4973-8194-912599c73fd6" />

Custom:
<img width="480" height="567" alt="image" src="https://github.com/user-attachments/assets/30d8149f-4e2b-4193-b934-4693ff302068" />


<img width="1138" height="1206" alt="image" src="https://github.com/user-attachments/assets/06f6d842-97aa-46c7-9a07-8076db4e9db0" />

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `jlpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1685.org.readthedocs.build/en/1685/
💡 JupyterLite preview: https://jupytergis--1685.org.readthedocs.build/en/1685/lite
💡 Specta preview: https://jupytergis--1685.org.readthedocs.build/en/1685/lite/specta

<!-- readthedocs-preview jupytergis end -->