### PR TITLE
Set default `nclasses` for some exceptional ColorMaps

### DIFF
--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -32,7 +32,10 @@ import { py2vega } from 'py2vega-ts';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { vega2ol, FUNCTION_MAPPING, CONSTANTS_MAPPING } from 'vega2ol';
 
-import { ColorRampName } from '@/src/features/layers/symbology/colorRampUtils';
+import {
+  COLOR_RAMP_DEFAULTS,
+  ColorRampName,
+} from '@/src/features/layers/symbology/colorRampUtils';
 import { NumericInput } from '@/src/features/layers/symbology/components/NumericInput';
 import ColorRampSelector from '@/src/features/layers/symbology/components/color_ramp/ColorRampSelector';
 import RgbaColorPicker, {
@@ -167,10 +170,16 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
     const values = Array.from(featureValues[field] ?? []).filter(
       (v): v is number => Number.isFinite(v),
     );
+
+    const minRequired = COLOR_RAMP_DEFAULTS[params.name as ColorRampName];
+    const nClasses = minRequired
+      ? Math.max(params.nShades ?? minRequired, minRequired)
+      : params.nShades;
+
     const computed: IComputedStop[] = computeGraduatedColorStops(
       {
         renderType: 'Graduated',
-        nClasses: params.nShades,
+        nClasses,
         mode: params.mode as any,
         colorRamp: params.name,
         reverseRamp: params.reverse,
@@ -209,7 +218,13 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
         <label>Color map</label>
         <ColorRampSelector
           selectedRamp={params.name as ColorRampName}
-          setSelected={name => update({ name })}
+          setSelected={name => {
+            const min = COLOR_RAMP_DEFAULTS[name];
+            update({
+              name,
+              nShades: min ?? 9,
+            });
+          }}
           reverse={params.reverse}
           setReverse={v =>
             update({ reverse: typeof v === 'function' ? v(params.reverse) : v })

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -222,7 +222,7 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
             const min = COLOR_RAMP_DEFAULTS[name];
             update({
               name,
-              nShades: min ?? 9,
+              nShades: Math.max(params.nShades ?? 9, min ?? 0),
             });
           }}
           reverse={params.reverse}


### PR DESCRIPTION
## Description

We lost this feature after getting introduced to the new Grammar Symbology, but now this PR adds it again.


https://github.com/user-attachments/assets/7a54ea21-09f4-4171-9a1e-a91ebe2ef1e7



## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1687.org.readthedocs.build/en/1687/
💡 JupyterLite preview: https://jupytergis--1687.org.readthedocs.build/en/1687/lite
💡 Specta preview: https://jupytergis--1687.org.readthedocs.build/en/1687/lite/specta

<!-- readthedocs-preview jupytergis end -->