### PR TITLE
Remove rogue blank line from docs

### DIFF
--- a/docs/contributor_guide/development_setup.md
+++ b/docs/contributor_guide/development_setup.md
@@ -48,7 +48,6 @@ It is recommended for setting up the JupyterGIS development environment. If you 
 
 ```bash
 # Create a virtual environment
-
 micromamba create --name jupytergis_dev -c conda-forge pip "python=3.13.*" "nodejs=24" pnpm qgis
 
 # Activate it


### PR DESCRIPTION
## Description

You don't belong here, blank line! Get out!

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1693.org.readthedocs.build/en/1693/
💡 JupyterLite preview: https://jupytergis--1693.org.readthedocs.build/en/1693/lite
💡 Specta preview: https://jupytergis--1693.org.readthedocs.build/en/1693/lite/specta

<!-- readthedocs-preview jupytergis end -->