### PR TITLE
Despaghetti transition progress

### DIFF
--- a/packages/base/src/features/story/__tests__/listStoryScrollTrack.spec.ts
+++ b/packages/base/src/features/story/__tests__/listStoryScrollTrack.spec.ts
@@ -223,7 +223,7 @@ describe('getTransitionTranslatePx', () => {
   });
 
   it('uses to.start - from.start for map↔markdown handoffs', () => {
-    const { segments } = mapMdLayout!;
+    const { segments } = mapMdLayout;
     expect(
       getTransitionTranslatePx(
         {

--- a/packages/base/src/features/story/__tests__/listStoryScrollTrack.spec.ts
+++ b/packages/base/src/features/story/__tests__/listStoryScrollTrack.spec.ts
@@ -2,6 +2,7 @@ import {
   buildListStoryScrollTrack,
   estimateMarkdownHeight,
   getSegmentDisplayMode,
+  getTransitionTranslatePx,
 } from '../utils/listStoryScrollTrack';
 import { storyItem } from './fixtures/listStoryTestItems';
 
@@ -175,5 +176,129 @@ describe('buildListStoryScrollTrack', () => {
       height: 180,
       end: 650,
     });
+  });
+});
+
+describe('getTransitionTranslatePx', () => {
+  const mapMdLayout = buildListStoryScrollTrack({
+    items: [
+      storyItem('a', 0, 'map'),
+      storyItem('b', 1, 'markdown', 'line\nline'),
+      storyItem('c', 2, 'map'),
+    ],
+    viewportHeight: 400,
+    mapViewportHeight: 350,
+    heightsById: { b: 500 },
+  });
+
+  it('returns 0 without transition or layout', () => {
+    expect(getTransitionTranslatePx(null, mapMdLayout)).toBe(0);
+    expect(
+      getTransitionTranslatePx(
+        {
+          progress: 0,
+          fromIndex: 0,
+          toIndex: 1,
+          fromMode: 'map',
+          toMode: 'markdown',
+        },
+        null,
+      ),
+    ).toBe(0);
+  });
+
+  it('uses segment height for intra-segment scroll', () => {
+    expect(
+      getTransitionTranslatePx(
+        {
+          progress: 0.4,
+          fromIndex: 1,
+          toIndex: 1,
+          fromMode: 'markdown',
+          toMode: 'markdown',
+        },
+        mapMdLayout,
+      ),
+    ).toBe(500);
+  });
+
+  it('uses to.start - from.start for map↔markdown handoffs', () => {
+    const { segments } = mapMdLayout!;
+    expect(
+      getTransitionTranslatePx(
+        {
+          progress: 0.5,
+          fromIndex: 0,
+          toIndex: 1,
+          fromMode: 'map',
+          toMode: 'markdown',
+        },
+        mapMdLayout,
+      ),
+    ).toBe(segments[1].start - segments[0].start);
+
+    expect(
+      getTransitionTranslatePx(
+        {
+          progress: 0.5,
+          fromIndex: 1,
+          toIndex: 2,
+          fromMode: 'markdown',
+          toMode: 'map',
+        },
+        mapMdLayout,
+      ),
+    ).toBe(segments[2].start - segments[1].start);
+  });
+
+  it('uses from height only for md→md with no gap', () => {
+    const layout = buildListStoryScrollTrack({
+      items: [
+        storyItem('a', 0, 'markdown', 'one'),
+        storyItem('b', 1, 'markdown', 'two'),
+      ],
+      viewportHeight: 400,
+      heightsById: { a: 120, b: 180 },
+      markdownSegmentGap: false,
+    });
+
+    expect(
+      getTransitionTranslatePx(
+        {
+          progress: 0.5,
+          fromIndex: 0,
+          toIndex: 1,
+          fromMode: 'markdown',
+          toMode: 'markdown',
+        },
+        layout,
+      ),
+    ).toBe(120);
+  });
+
+  it('includes gap for md→md when markdownSegmentGap is true', () => {
+    const layout = buildListStoryScrollTrack({
+      items: [
+        storyItem('a', 0, 'markdown', 'one'),
+        storyItem('b', 1, 'markdown', 'two'),
+      ],
+      viewportHeight: 400,
+      mapViewportHeight: 350,
+      heightsById: { a: 120, b: 180 },
+      markdownSegmentGap: true,
+    });
+
+    expect(
+      getTransitionTranslatePx(
+        {
+          progress: 0.5,
+          fromIndex: 0,
+          toIndex: 1,
+          fromMode: 'markdown',
+          toMode: 'markdown',
+        },
+        layout,
+      ),
+    ).toBe(120 + 350);
   });
 });

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -19,8 +19,8 @@ import type {
 import { isIntraSegmentScroll } from '@/src/features/story/utils/computeListStoryScrollState';
 import { getHandoffGapHeight } from '@/src/features/story/utils/getHandoffGapHeight';
 import {
-  getScrollTrackSegmentHeight,
   getSegmentDisplayMode,
+  getTransitionTranslatePx,
 } from '@/src/features/story/utils/listStoryScrollTrack';
 import { getSpectaPresentationCssVars } from '@/src/features/story/utils/spectaPresentation';
 import {
@@ -289,15 +289,10 @@ export function ListStoryStageOverlay({
   const stackRef = useRef<HTMLDivElement>(null);
   const markdownRenderedRef = useRef<Set<number>>(new Set());
   const imageWaitCancelRef = useRef<(() => void) | null>(null);
-  const measureTransitionRef = useRef<(() => void) | null>(null);
-  const measuredTransitionKeyRef = useRef('');
-  const measureTransitionKeyRef = useRef('');
-  const stableTravelRef = useRef(0);
   const clearMarkdownRendered = useCallback((segmentIndex: number): void => {
     markdownRenderedRef.current.delete(segmentIndex);
   }, []);
   const [stageHeight, setStageHeight] = useState(0);
-  const [transitionTranslatePx, setTransitionTranslatePx] = useState(0);
   const currentIndex = useCurrentSegmentIndex(model);
   const { scrollTrackLayout, reportSegmentHeight } =
     useListStoryScrollTrackContext();
@@ -369,15 +364,13 @@ export function ListStoryStageOverlay({
   ]);
 
   const fromStackPane = overlayStack.panes.find(pane => pane.role === 'from');
-  const toStackPane = overlayStack.panes.find(pane => pane.role === 'to');
-  const lookaheadStackPane = overlayStack.panes.find(
-    pane => pane.role === 'lookahead',
-  );
 
   const overlayHeight = Math.max(stageHeight, 0);
   const transitionProgress = transition?.progress ?? 0;
-  const fromIndex = fromStackPane?.segmentIndex ?? currentIndex;
-  const toIndex = toStackPane?.segmentIndex ?? fromIndex;
+  const transitionTranslatePx = getTransitionTranslatePx(
+    transition,
+    scrollTrackLayout,
+  );
 
   useLayoutEffect(() => {
     const parent = overlayRef.current?.parentElement;
@@ -433,15 +426,10 @@ export function ListStoryStageOverlay({
         imageWaitCancelRef.current = whenImagesSettled(paneEl, () => {
           imageWaitCancelRef.current = null;
           reportPaneHeight();
-          measureTransitionRef.current?.();
         });
       }
-
-      if (segmentIndex === fromIndex) {
-        measureTransitionRef.current?.();
-      }
     },
-    [fromIndex, overlayStack.panes, reportSegmentHeight],
+    [overlayStack.panes, reportSegmentHeight],
   );
 
   useLayoutEffect(() => {
@@ -497,137 +485,12 @@ export function ListStoryStageOverlay({
 
     return () => {
       ro.disconnect();
-    };
-  }, [overlayStack.panes, reportSegmentHeight]);
-
-  useLayoutEffect(() => {
-    const stack = stackRef.current;
-    if (!stack || !transition || !fromStackPane) {
-      return;
-    }
-
-    const fromPaneIsMarkdown =
-      fromStackPane.config.type === 'markdown' &&
-      Boolean(fromStackPane.config.markdown);
-
-    const transitionKey = intraSegmentScroll
-      ? `intra:${fromIndex}`
-      : `handoff:${fromIndex}:${toIndex}:${transition.fromMode}:${transition.toMode}`;
-
-    if (measureTransitionKeyRef.current !== transitionKey) {
-      measureTransitionKeyRef.current = transitionKey;
-      measuredTransitionKeyRef.current = '';
-      stableTravelRef.current = 0;
-      setTransitionTranslatePx(0);
-    }
-
-    const measure = (): void => {
-      const fromPane = stack.querySelector('[data-pane="from"]');
-
-      if (!(fromPane instanceof HTMLElement)) {
-        return;
-      }
-
-      const gapHeight = overlayStack.includeGap ? handoffGapHeight : 0;
-      const rawTravel = fromPane.offsetHeight + gapHeight;
-      const fromReady =
-        !fromPaneIsMarkdown ||
-        markdownRenderedRef.current.has(fromStackPane.segmentIndex);
-
-      if (fromReady && rawTravel > 0) {
-        stableTravelRef.current = Math.max(stableTravelRef.current, rawTravel);
-      }
-      const travel = stableTravelRef.current;
-
-      if (!fromReady) {
-        return;
-      }
-
-      measuredTransitionKeyRef.current = transitionKey;
-      setTransitionTranslatePx(prev => (prev === travel ? prev : travel));
-    };
-
-    measureTransitionRef.current = measure;
-    measure();
-
-    const fromPane = stack.querySelector('[data-pane="from"]');
-    if (!(fromPane instanceof HTMLElement)) {
-      return;
-    }
-
-    const ro = new ResizeObserver(() => {
-      if (
-        !fromPaneIsMarkdown ||
-        markdownRenderedRef.current.has(fromStackPane.segmentIndex)
-      ) {
-        measure();
-      }
-    });
-    ro.observe(fromPane);
-
-    return () => {
-      ro.disconnect();
       imageWaitCancelRef.current?.();
       imageWaitCancelRef.current = null;
     };
-  }, [
-    transition,
-    fromStackPane,
-    toStackPane,
-    lookaheadStackPane,
-    overlayStack.includeGap,
-    intraSegmentScroll,
-    fromIndex,
-    toIndex,
-    handoffGapHeight,
-  ]);
-
-  useLayoutEffect(() => {
-    measureTransitionRef.current?.();
-  }, [stageHeight]);
+  }, [overlayStack.panes, reportSegmentHeight]);
 
   const overlaySized = stageHeight > 0;
-  const currentTransitionKey = intraSegmentScroll
-    ? `intra:${fromIndex}`
-    : `handoff:${fromIndex}:${toIndex}:${transition?.fromMode ?? ''}:${transition?.toMode ?? ''}`;
-
-  const scrollFromHeight = getScrollTrackSegmentHeight(
-    scrollTrackLayout,
-    fromIndex,
-  );
-  const fromTrackSegment = scrollTrackLayout?.segments.find(
-    segment => segment.index === fromIndex,
-  );
-
-  const isMdToMdNoGap =
-    !intraSegmentScroll &&
-    handoffGapHeight === 0 &&
-    transition?.fromMode === 'markdown' &&
-    transition?.toMode === 'markdown';
-
-  const translateIsCurrent =
-    measuredTransitionKeyRef.current === currentTransitionKey &&
-    transitionTranslatePx > 0;
-
-  // Pixel travel for progress 0->1 (`--jgis-transition-translate`).
-  //
-  // Md->md with no gap: scroll progress is computed from the virtual track, so
-  // prefer the track's from-segment height once measured. Until then, use the
-  // live DOM measure if ready, else use the track estimate.
-  //
-  // All other transitions: use the live DOM measure when it matches this
-  // transition, gap handoffs fall back to stageHeight, otherwise 0.
-  const effectiveTranslatePx = isMdToMdNoGap
-    ? fromTrackSegment?.measured && scrollFromHeight
-      ? scrollFromHeight
-      : translateIsCurrent
-        ? transitionTranslatePx
-        : (scrollFromHeight ?? 0)
-    : translateIsCurrent
-      ? transitionTranslatePx
-      : handoffGapHeight > 0
-        ? stageHeight
-        : 0;
 
   if (!model || !story || !activeItem || !transition || !fromStackPane) {
     return null;
@@ -647,7 +510,7 @@ export function ListStoryStageOverlay({
             ? {
                 height: overlayHeight,
                 '--jgis-handoff-gap-height': `${stageHeight}px`,
-                '--jgis-transition-translate': `${effectiveTranslatePx}px`,
+                '--jgis-transition-translate': `${transitionTranslatePx}px`,
               }
             : {}),
         } as React.CSSProperties

--- a/packages/base/src/features/story/types/types.ts
+++ b/packages/base/src/features/story/types/types.ts
@@ -21,7 +21,7 @@ export interface IOverrideLayerEntry {
 
 /** Active handoff between two segments while scrolling the virtual track. */
 export interface IListStorySegmentTransition {
-  /** 0–1 across the handoff span (outgoing segment + gap + incoming segment). */
+  /** 0–1 across the handoff span (outgoing segment height + gap). */
   progress: number;
   fromIndex: number;
   toIndex: number;

--- a/packages/base/src/features/story/utils/listStoryScrollTrack.ts
+++ b/packages/base/src/features/story/utils/listStoryScrollTrack.ts
@@ -1,6 +1,7 @@
 import type {
   IListStoryScrollTrackLayout,
   IListStoryScrollTrackSegment,
+  IListStorySegmentTransition,
   StorySegmentDisplayMode,
   IStorySegmentViewItem,
 } from '@/src/features/story/types/types';
@@ -41,6 +42,40 @@ export function getScrollTrackSegmentHeight(
   index: number,
 ): number | undefined {
   return layout?.segments.find(segment => segment.index === index)?.height;
+}
+
+/**
+ * Pixel travel for progress 0→1 (`--jgis-transition-translate`).
+ * Same geometry that drives scroll progress: segment height (intra) or
+ * `to.start - from.start` (handoff = from height + gap).
+ */
+export function getTransitionTranslatePx(
+  transition: IListStorySegmentTransition | null,
+  layout: IListStoryScrollTrackLayout | null,
+): number {
+  if (!transition || !layout?.segments.length) {
+    return 0;
+  }
+
+  const fromSegment = layout.segments.find(
+    segment => segment.index === transition.fromIndex,
+  );
+  if (!fromSegment) {
+    return 0;
+  }
+
+  if (transition.fromIndex === transition.toIndex) {
+    return fromSegment.height;
+  }
+
+  const toSegment = layout.segments.find(
+    segment => segment.index === transition.toIndex,
+  );
+  if (!toSegment) {
+    return 0;
+  }
+
+  return Math.max(0, toSegment.start - fromSegment.start);
 }
 
 function segmentHeightForItem(


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Simplify overlay progress tracking after several iterations and bug fixes, just derive overlay transition progress from scroll track instead of measuring DOM.
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1699.org.readthedocs.build/en/1699/
💡 JupyterLite preview: https://jupytergis--1699.org.readthedocs.build/en/1699/lite
💡 Specta preview: https://jupytergis--1699.org.readthedocs.build/en/1699/lite/specta

<!-- readthedocs-preview jupytergis end -->