### PR TITLE
Migrate labextension build to @jupyter/builder

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,9 +647,9 @@ importers:
         specifier: ^0.12.5
         version: 0.12.5
     devDependencies:
-      '@jupyterlab/builder':
-        specifier: ^4.5
-        version: 4.5.9(postcss@8.5.19)(uglify-js@3.19.3)
+      '@jupyter/builder':
+        specifier: ^1.1.1
+        version: 1.1.1(webpack@5.106.2)
       '@types/json-schema':
         specifier: ^7.0.11
         version: 7.0.15
@@ -667,7 +667,7 @@ importers:
         version: 10.2.4(webpack@5.106.2)
       css-loader:
         specifier: ^6.7.1
-        version: 6.11.0(webpack@5.106.2)
+        version: 6.11.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2)
       mkdirp:
         specifier: ^1.0.3
         version: 1.0.4
@@ -697,7 +697,7 @@ importers:
         version: 5.9.3
       vue-loader:
         specifier: ^15.11.1
-        version: 15.11.1(css-loader@6.11.0(webpack@5.106.2))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(prettier@3.9.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.106.2)
+        version: 15.11.1(css-loader@6.11.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(prettier@3.9.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.106.2)
       vue-style-loader:
         specifier: ^4.1.3
         version: 4.1.3
@@ -768,12 +768,12 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0(postcss@8.5.19)(react@18.3.1)(uglify-js@3.19.3)(yjs@13.6.31)
     devDependencies:
-      '@jupyterlab/builder':
-        specifier: ^4.5
-        version: 4.5.9(postcss@8.5.19)(uglify-js@3.19.3)
+      '@jupyter/builder':
+        specifier: ^1.1.1
+        version: 1.1.1(webpack@5.106.2)
       css-loader:
         specifier: ^6.7.1
-        version: 6.11.0(webpack@5.106.2)
+        version: 6.11.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2)
       mkdirp:
         specifier: ^1.0.3
         version: 1.0.4
@@ -844,12 +844,12 @@ importers:
         specifier: ^18.0.1
         version: 18.3.1
     devDependencies:
-      '@jupyterlab/builder':
-        specifier: ^4.5
-        version: 4.5.9(postcss@8.5.19)(uglify-js@3.19.3)
+      '@jupyter/builder':
+        specifier: ^1.1.1
+        version: 1.1.1(webpack@5.106.2)
       css-loader:
         specifier: ^6.7.1
-        version: 6.11.0(webpack@5.106.2)
+        version: 6.11.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2)
       mkdirp:
         specifier: ^1.0.3
         version: 1.0.4
@@ -1684,6 +1684,9 @@ packages:
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
+  '@jupyter/builder@1.1.1':
+    resolution: {integrity: sha512-k8Cc9/YuSEb1LjMgthQg5LshQsQKp6UKl7OFF9MNf2LnkyvkpglqnGjXIVgW6vrvXLGe3lFw2h2Aw32J4ouXiQ==}
+
   '@jupyter/collaboration@4.4.1':
     resolution: {integrity: sha512-YaTxkcP3cbvwpFIFqs2wROHpuSUTB8g0tEIVLbbHNzgr3KDb1Oh63P3depUKBcfKtyt8kkJCHt5Dcop2pP+4CA==}
 
@@ -1711,10 +1714,6 @@ packages:
   '@jupyterlab/attachments@4.6.1':
     resolution: {integrity: sha512-GrG/t+7SCD7nTX2e73oo06S7l8FCjO3vJu9KC6XM2t4o3XOzzgvoUENY2AoTAGDA82HcivMRZKHAfqUhCH9UXQ==}
 
-  '@jupyterlab/builder@4.5.9':
-    resolution: {integrity: sha512-M2mi+TtcxSE/fiKe5RfEqrzMEms6S++W163Qc+07sj2g78t6G84Bya9dgliUmBmLN4qqYhG0NXURdCmMmWRIAg==}
-    hasBin: true
-
   '@jupyterlab/cells@4.6.1':
     resolution: {integrity: sha512-SP4KAQSxgS0ail3Fe3oPn9bcCbYsL+vsu/qhV9dy9EnIWPxn6ZZsVo64wG5o1gWpLmNbFuc1y8xxYYhSQ+eOBQ==}
 
@@ -1729,6 +1728,9 @@ packages:
 
   '@jupyterlab/console@4.6.1':
     resolution: {integrity: sha512-kOKmIFqyij9wCEE6g/befsLDP9DsH20G8lGdvaD77vOA5RgLk5VWJeRXCuKARjxctTtWXwl2cQ6n65EkCFVU9w==}
+
+  '@jupyterlab/core-meta@4.6.1':
+    resolution: {integrity: sha512-5JXqqOcK/lcIMBSBr8EdOzPSmU1ucb4GY0M7NIYNs+M1CcSSZbJ2jn/BGdXrbDhaeFWqeCCoM5PEwQ3FyZzi+Q==}
 
   '@jupyterlab/coreutils@6.6.1':
     resolution: {integrity: sha512-1DjMEoiHi3CwycFVM0RWfn53+0zGhJ064SKqVeYKxxFFJdN3u7ezClduRiIGEQXAiums8w+9QLlljBx/M+kaUw==}
@@ -1925,6 +1927,24 @@ packages:
 
   '@microsoft/fast-web-utilities@5.4.1':
     resolution: {integrity: sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==}
+
+  '@module-federation/error-codes@2.8.0':
+    resolution: {integrity: sha512-Gaog9904EmxYOQV0hli3XQ7jXeFaADfh5bnBtTCtbZ37Qd/Sz9kQfd+gYQRyIj7RGmkv9DPiN/SsmrTMrTymKw==}
+
+  '@module-federation/runtime-core@2.8.0':
+    resolution: {integrity: sha512-Tf98+epGGiPSHqmQHuXa2uXZMMvjGf1IqJDR1/FpXfmobv5ECN0mGZCjUHGNSyxvoDyXKIkKwJu7IwEoh0ouQA==}
+
+  '@module-federation/runtime-tools@2.8.0':
+    resolution: {integrity: sha512-3yOqjdSHXxX4HA3GhlXg3hghGAXW2RJUsnwXCcik2/lTxOHizKI8f3RM+GGCKPxDVqtw43IShe3tA12jNL5A/A==}
+
+  '@module-federation/runtime@2.8.0':
+    resolution: {integrity: sha512-cGtUBQ1/TVy7KrXy6xPgy3FEmOGyIYkBA2T4iGH3ZH5PNPPTmqN9jF2AfneTSOj0RtBr7Pxq3CUt81E/UCvK1A==}
+
+  '@module-federation/sdk@2.8.0':
+    resolution: {integrity: sha512-yBP+9+0Z8nlvKEXAZS3AsQVy7bFbZf8eMivGk4q4ZdwG3TsLMlsPjb1dQb2i7gcAG6ux9y2LWLkj/0LVk74cnQ==}
+
+  '@module-federation/webpack-bundler-runtime@2.8.0':
+    resolution: {integrity: sha512-82fDy9v+7qV5fiN8TKVhOdrxhmAZnUIX/IKivYX5ulCt8aoOzVFTiwm/P1GQUDD8z6dqR48xgJdZdf0548Mc9w==}
 
   '@multiformats/base-x@4.0.1':
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
@@ -3002,6 +3022,86 @@ packages:
     peerDependencies:
       '@rjsf/utils': ^5.24.x
 
+  '@rspack/binding-darwin-arm64@2.1.5':
+    resolution: {integrity: sha512-XLAN6YSU36qkciJtV9DY9z57pdHOjKy/f1HyoqpZenRg8p46jnXPziV45lfrTZpG+FF6g/jtTUc4dKbeyoWqPw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.1.5':
+    resolution: {integrity: sha512-KLW7PV86jyCOyqJSqrkZdvYUWYCFX/Q4LsGmVc8tyDA8jBYLMHJDewC/lNf9ot3rU2SoLDZKhDUh7q7dX0FRmg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
+    resolution: {integrity: sha512-KOooAC8L+Ljx5sY7ZuMeaXCQ310FNWaPWXcYQJpFPApF3qyLeSfuOftUGwxcxeo5U0mS5OY3zxp7/5CaHWKYjg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-musl@2.1.5':
+    resolution: {integrity: sha512-0GFc07gT71+uRbHtejDecBfSL0fs7dQAwCtXYieXboACauL7UvS3Hwr6v8A91aGtAcvLotnCaIa3CWWYwtYlYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    resolution: {integrity: sha512-isQQDp3fBzPSZpLVFzPqVXIVA4I9b9mKs58TfUgOzDP/1g1582YSV3iFopgFogvEliihXDuuXvM6aAkP+w8Z+Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
+    resolution: {integrity: sha512-/SP6VknY4kH60BYplI2FDNAJCo4U4DUszLxhKsgVlgA5ImgHC8Ew2AsKgidk7ceiYV9OcKzYuWYe9tVpysBYVA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    resolution: {integrity: sha512-/GJmS+buA4pilT10gs5mfAhAZxSHXpDD8veZ3QpYvNUuoU9gvempAq9TgjbyNN/vc5pf76GdXPXKFMiehudYSA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-musl@2.1.5':
+    resolution: {integrity: sha512-iwS3t75nZ2TnUjB05KtvpvjpdkOy/nLxbaOnwjbdnNZZXpUaMadLbllGAWayHPGCMsL2yKBEhVEESZpR7tK3SA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    resolution: {integrity: sha512-jOhW69t1H/jcRaSMB5U8jVzWP18j0YQIlo0nT8W+KvNVScJeyOze4FFc+5RIS7VmuT8/jid7hUyydZOfm6UgqA==}
+    cpu: [wasm32]
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
+    resolution: {integrity: sha512-OLfMXmtFBcrWr9BRGKXJYrWgYR0JSaoAWr3EVFDjKGi/YR5aUwQSGc3AJPBph9g0YsdSqRuUhtQGtCk84DeeEA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    resolution: {integrity: sha512-p4OSmnj21+AY8vpIADveLEBXfXJRXonOTYim2VLVWV4TbXfhYNMLiX3qESHCdNnn6lVJM0q6zxxzEUfTyAKydw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@2.1.5':
+    resolution: {integrity: sha512-YCkLLDGMkHsw5CpcsFtFhzCu+JZEsNrcH9O1GpWMkyxR2ku2Fq1i2wEHYSm26HyW+PJ3+Fv347MPWMFZIz9q2g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding@2.1.5':
+    resolution: {integrity: sha512-lF3ZLeeyV0AN3BL0m2jAmNZD5pP9IHsQ8gUXN7mo0g4xsW6nf6hsN7o9CnEHECz5uUZb+EoWsuWzAAmnA9Ip8Q==}
+
+  '@rspack/core@2.1.5':
+    resolution: {integrity: sha512-YHjL7xVXycAWsjJtF39cRZ2u+ddiNFxY+FcNgEBe6Y8OaLeUfMfjba3gK+B1Oj32UcKD6BmXGsPfu9p+OII/Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -3751,11 +3851,6 @@ packages:
     peerDependenciesMeta:
       ajv:
         optional: true
-
-  ajv-keywords@3.5.2:
-    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
-    peerDependencies:
-      ajv: ^6.9.1
 
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
@@ -4531,6 +4626,18 @@ packages:
       webpack:
         optional: true
 
+  css-loader@7.1.4:
+    resolution: {integrity: sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
+      webpack: '>=5.76.3 <5.107.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
 
@@ -4712,10 +4819,6 @@ packages:
   dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
-
-  data-urls@2.0.0:
-    resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
-    engines: {node: '>=10'}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -5514,10 +5617,6 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
-
-  glob@7.1.7:
-    resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -6676,12 +6775,6 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  mini-css-extract-plugin@2.10.2:
-    resolution: {integrity: sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: '>=5.76.3 <5.107.0'
-
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
@@ -7765,14 +7858,6 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
-  schema-utils@2.7.1:
-    resolution: {integrity: sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==}
-    engines: {node: '>= 8.9.0'}
-
-  schema-utils@3.3.0:
-    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
-    engines: {node: '>= 10.13.0'}
-
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
@@ -7911,12 +7996,6 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  source-map-loader@1.0.2:
-    resolution: {integrity: sha512-oX8d6ndRjN+tVyjj6PlXSyFPhDdVAPsZA30nD3/II8g4uOv8fCz0DMn5sy8KtVbDfKQxOpGwGJnK3xIW3tauDw==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: '>=5.76.3 <5.107.0'
 
   source-map-loader@3.0.2:
     resolution: {integrity: sha512-BokxPoLjyl3iOrgkWaakaxqnelAJSS+0V+De0kKIq6lyWrXuiPgYTGp6z3iHmqljKAaLXwZa+ctD8GccRJeVvg==}
@@ -8073,6 +8152,12 @@ packages:
   style-loader@3.3.4:
     resolution: {integrity: sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==}
     engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      webpack: '>=5.76.3 <5.107.0'
+
+  style-loader@4.0.0:
+    resolution: {integrity: sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==}
+    engines: {node: '>= 18.12.0'}
     peerDependencies:
       webpack: '>=5.76.3 <5.107.0'
 
@@ -8260,10 +8345,6 @@ packages:
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
-
-  tr46@2.1.0:
-    resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
-    engines: {node: '>=8'}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
@@ -8664,10 +8745,6 @@ packages:
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
 
-  webidl-conversions@6.1.0:
-    resolution: {integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==}
-    engines: {node: '>=10.4'}
-
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -8715,9 +8792,6 @@ packages:
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
-  whatwg-mimetype@2.3.0:
-    resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
-
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
@@ -8725,10 +8799,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@8.7.0:
-    resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}
-    engines: {node: '>=10'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -8788,12 +8858,6 @@ packages:
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-
-  worker-loader@3.0.8:
-    resolution: {integrity: sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: '>=5.76.3 <5.107.0'
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -10015,6 +10079,28 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
+  '@jupyter/builder@1.1.1(webpack@5.106.2)':
+    dependencies:
+      '@jupyterlab/core-meta': 4.6.1
+      '@module-federation/runtime-tools': 2.8.0
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)
+      ajv: 8.16.0
+      commander: 9.5.0
+      css-loader: 7.1.4(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2)
+      duplicate-package-checker-webpack-plugin: 3.0.0
+      fs-extra: 10.1.0
+      glob: 13.0.6
+      license-webpack-plugin: 4.0.2(webpack@5.106.2)
+      mini-svg-data-uri: 1.4.4
+      path-browserify: 1.0.1
+      process: 0.11.10
+      style-loader: 4.0.0(webpack@5.106.2)
+      supports-color: 7.2.0
+      webpack-merge: 5.10.0
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - webpack
+
   '@jupyter/collaboration@4.4.1':
     dependencies:
       '@codemirror/state': 6.7.1
@@ -10143,58 +10229,6 @@ snapshots:
       - bufferutil
       - react
       - utf-8-validate
-
-  '@jupyterlab/builder@4.5.9(postcss@8.5.19)(uglify-js@3.19.3)':
-    dependencies:
-      '@lumino/algorithm': 2.0.5
-      '@lumino/application': 2.4.10
-      '@lumino/commands': 2.3.4
-      '@lumino/coreutils': 2.2.3
-      '@lumino/disposable': 2.1.6
-      '@lumino/domutils': 2.0.5
-      '@lumino/dragdrop': 2.1.9
-      '@lumino/messaging': 2.0.5
-      '@lumino/properties': 2.0.5
-      '@lumino/signaling': 2.1.6
-      '@lumino/virtualdom': 2.0.5
-      '@lumino/widgets': 2.9.0
-      ajv: 8.16.0
-      commander: 9.5.0
-      css-loader: 6.11.0(webpack@5.106.2)
-      duplicate-package-checker-webpack-plugin: 3.0.0
-      fs-extra: 10.1.0
-      glob: 7.1.7
-      license-webpack-plugin: 4.0.2(webpack@5.106.2)
-      mini-css-extract-plugin: 2.10.2(webpack@5.106.2)
-      mini-svg-data-uri: 1.4.4
-      path-browserify: 1.0.1
-      process: 0.11.10
-      source-map-loader: 1.0.2(webpack@5.106.2)
-      style-loader: 3.3.4(webpack@5.106.2)
-      supports-color: 7.2.0
-      terser-webpack-plugin: 5.6.1(postcss@8.5.19)(uglify-js@3.19.3)(webpack@5.106.2)
-      webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack@5.106.2)
-      webpack-merge: 5.10.0
-      webpack-sources: 3.5.1
-      worker-loader: 3.0.8(webpack@5.106.2)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - '@webpack-cli/generators'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-      - webpack-bundle-analyzer
-      - webpack-dev-server
 
   '@jupyterlab/cells@4.6.1':
     dependencies:
@@ -10345,6 +10379,8 @@ snapshots:
       - bufferutil
       - react
       - utf-8-validate
+
+  '@jupyterlab/core-meta@4.6.1': {}
 
   '@jupyterlab/coreutils@6.6.1':
     dependencies:
@@ -10943,6 +10979,32 @@ snapshots:
     dependencies:
       exenv-es6: 1.1.1
 
+  '@module-federation/error-codes@2.8.0': {}
+
+  '@module-federation/runtime-core@2.8.0':
+    dependencies:
+      '@module-federation/error-codes': 2.8.0
+      '@module-federation/sdk': 2.8.0
+
+  '@module-federation/runtime-tools@2.8.0':
+    dependencies:
+      '@module-federation/runtime': 2.8.0
+      '@module-federation/webpack-bundler-runtime': 2.8.0
+
+  '@module-federation/runtime@2.8.0':
+    dependencies:
+      '@module-federation/error-codes': 2.8.0
+      '@module-federation/runtime-core': 2.8.0
+      '@module-federation/sdk': 2.8.0
+
+  '@module-federation/sdk@2.8.0': {}
+
+  '@module-federation/webpack-bundler-runtime@2.8.0':
+    dependencies:
+      '@module-federation/error-codes': 2.8.0
+      '@module-federation/runtime': 2.8.0
+      '@module-federation/sdk': 2.8.0
+
   '@multiformats/base-x@4.0.1': {}
 
   '@musement/iso-duration@1.0.0': {}
@@ -10966,6 +11028,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -12133,6 +12202,67 @@ snapshots:
       lodash: 4.18.1
       lodash-es: 4.18.1
 
+  '@rspack/binding-darwin-arm64@2.1.5':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@2.1.5':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.1.5':
+    optional: true
+
+  '@rspack/binding-wasm32-wasi@2.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.1.5':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@2.1.5':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.1.5':
+    optional: true
+
+  '@rspack/binding@2.1.5':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.1.5
+      '@rspack/binding-darwin-x64': 2.1.5
+      '@rspack/binding-linux-arm64-gnu': 2.1.5
+      '@rspack/binding-linux-arm64-musl': 2.1.5
+      '@rspack/binding-linux-riscv64-gnu': 2.1.5
+      '@rspack/binding-linux-riscv64-musl': 2.1.5
+      '@rspack/binding-linux-x64-gnu': 2.1.5
+      '@rspack/binding-linux-x64-musl': 2.1.5
+      '@rspack/binding-wasm32-wasi': 2.1.5
+      '@rspack/binding-win32-arm64-msvc': 2.1.5
+      '@rspack/binding-win32-ia32-msvc': 2.1.5
+      '@rspack/binding-win32-x64-msvc': 2.1.5
+
+  '@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0)':
+    dependencies:
+      '@rspack/binding': 2.1.5
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.8.0
+
   '@rtsao/scc@1.1.0': {}
 
   '@sigstore/bundle@4.0.0':
@@ -12617,7 +12747,7 @@ snapshots:
 
   '@types/glob@9.0.0':
     dependencies:
-      glob: 7.2.3
+      glob: 13.0.6
 
   '@types/hast@3.0.5':
     dependencies:
@@ -13124,10 +13254,6 @@ snapshots:
   ajv-formats@2.1.1(ajv@8.16.0):
     optionalDependencies:
       ajv: 8.16.0
-
-  ajv-keywords@3.5.2(ajv@6.15.0):
-    dependencies:
-      ajv: 6.15.0
 
   ajv-keywords@5.1.0(ajv@8.16.0):
     dependencies:
@@ -13812,7 +13938,7 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-loader@6.11.0(webpack@5.106.2):
+  css-loader@6.11.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.19)
       postcss: 8.5.19
@@ -13823,6 +13949,21 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)
+      webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
+
+  css-loader@7.1.4(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.19)
+      postcss: 8.5.19
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.19)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.19)
+      postcss-modules-scope: 3.2.1(postcss@8.5.19)
+      postcss-modules-values: 4.0.0(postcss@8.5.19)
+      postcss-value-parser: 4.2.0
+      semver: 7.8.5
+    optionalDependencies:
+      '@rspack/core': 2.1.5(@module-federation/runtime-tools@2.8.0)
       webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
 
   css-to-react-native@3.2.0:
@@ -14032,12 +14173,6 @@ snapshots:
       lodash-es: 4.18.1
 
   dargs@7.0.0: {}
-
-  data-urls@2.0.0:
-    dependencies:
-      abab: 2.0.6
-      whatwg-mimetype: 2.3.0
-      whatwg-url: 8.7.0
 
   data-urls@5.0.0:
     dependencies:
@@ -14961,15 +15096,6 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
-
-  glob@7.1.7:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   glob@7.2.3:
     dependencies:
@@ -16128,6 +16254,7 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+    optional: true
 
   locate-path@2.0.0:
     dependencies:
@@ -16564,12 +16691,6 @@ snapshots:
     optional: true
 
   min-indent@1.0.1: {}
-
-  mini-css-extract-plugin@2.10.2(webpack@5.106.2):
-    dependencies:
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -17935,18 +18056,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  schema-utils@2.7.1:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      ajv: 6.15.0
-      ajv-keywords: 3.5.2(ajv@6.15.0)
-
-  schema-utils@3.3.0:
-    dependencies:
-      '@types/json-schema': 7.0.15
-      ajv: 6.15.0
-      ajv-keywords: 3.5.2(ajv@6.15.0)
-
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -18099,15 +18208,6 @@ snapshots:
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
-
-  source-map-loader@1.0.2(webpack@5.106.2):
-    dependencies:
-      data-urls: 2.0.0
-      iconv-lite: 0.6.3
-      loader-utils: 2.0.4
-      schema-utils: 2.7.1
-      source-map: 0.6.1
-      webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
 
   source-map-loader@3.0.2(webpack@5.106.2):
     dependencies:
@@ -18292,6 +18392,10 @@ snapshots:
     dependencies:
       webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
 
+  style-loader@4.0.0(webpack@5.106.2):
+    dependencies:
+      webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
+
   style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
@@ -18459,10 +18563,6 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
-
-  tr46@2.1.0:
-    dependencies:
-      punycode: 2.3.1
 
   tr46@5.1.1:
     dependencies:
@@ -18830,10 +18930,10 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(css-loader@6.11.0(webpack@5.106.2))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(prettier@3.9.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.106.2):
+  vue-loader@15.11.1(css-loader@6.11.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2))(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(prettier@3.9.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vue-template-compiler@2.7.16)(webpack@5.106.2):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(handlebars@4.7.9)(lodash@4.18.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      css-loader: 6.11.0(webpack@5.106.2)
+      css-loader: 6.11.0(@rspack/core@2.1.5(@module-federation/runtime-tools@2.8.0))(webpack@5.106.2)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
@@ -18944,8 +19044,6 @@ snapshots:
 
   web-worker@1.5.0: {}
 
-  webidl-conversions@6.1.0: {}
-
   webidl-conversions@7.0.0: {}
 
   webpack-cli@5.1.4(webpack@5.106.2):
@@ -19021,20 +19119,12 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
-  whatwg-mimetype@2.3.0: {}
-
   whatwg-mimetype@4.0.0: {}
 
   whatwg-url@14.2.0:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@8.7.0:
-    dependencies:
-      lodash: 4.18.1
-      tr46: 2.1.0
-      webidl-conversions: 6.1.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -19112,12 +19202,6 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
-
-  worker-loader@3.0.8(webpack@5.106.2):
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.106.2(postcss@8.5.19)(uglify-js@3.19.3)(webpack-cli@5.1.4)
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -650,6 +650,9 @@ importers:
       '@jupyter/builder':
         specifier: ^1.1.1
         version: 1.1.1(webpack@5.106.2)
+      '@rspack/core':
+        specifier: ^2.1.2
+        version: 2.1.5(@module-federation/runtime-tools@2.8.0)
       '@types/json-schema':
         specifier: ^7.0.11
         version: 7.0.15

--- a/python/jupytergis_core/package.json
+++ b/python/jupytergis_core/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "build": "pnpm run build:lib && pnpm run build:labextension:dev",
     "build:prod": "pnpm run clean && pnpm run build:lib:prod && pnpm run build:labextension",
-    "build:labextension": "jupyter labextension build . && pnpm run cp:sqlwasm",
-    "build:labextension:dev": "jupyter labextension build --development True . && pnpm run cp:sqlwasm",
+    "build:labextension": "jupyter-builder build . && pnpm run cp:sqlwasm",
+    "build:labextension:dev": "jupyter-builder build --development True . && pnpm run cp:sqlwasm",
     "build:lib": "tsc --sourceMap",
     "build:lib:prod": "tsc",
     "build:dev": "pnpm run build",
@@ -51,7 +51,7 @@
     "stylelint:check": "stylelint --cache \"style/**/*.css\"",
     "watch": "run-p watch:src watch:labextension",
     "watch:src": "tsc -w --sourceMap",
-    "watch:labextension": "jupyter labextension watch ."
+    "watch:labextension": "jupyter-builder watch ."
   },
   "dependencies": {
     "@jupyter/collaborative-drive": "^4.1.2 || ^5.0.0-alpha.0",
@@ -71,7 +71,7 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^4.5",
+    "@jupyter/builder": "^1.1.1",
     "@types/json-schema": "^7.0.11",
     "@types/react": "^18.0.26",
     "@types/react-addons-linked-state-mixin": "^0.14.22",

--- a/python/jupytergis_core/package.json
+++ b/python/jupytergis_core/package.json
@@ -129,6 +129,18 @@
       "@jupyter/docprovider": {
         "singleton": true,
         "bundled": false
+      },
+      "@jupyterlab/docregistry": {
+        "singleton": true,
+        "bundled": true
+      },
+      "@jupyterlab/attachments": {
+        "singleton": true,
+        "bundled": true
+      },
+      "@jupyterlab/observables": {
+        "singleton": true,
+        "bundled": true
       }
     }
   }

--- a/python/jupytergis_core/package.json
+++ b/python/jupytergis_core/package.json
@@ -71,7 +71,7 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^1.1.1",
+    "@jupyter/builder": "^1.2.1",
     "@rspack/core": "^2.1.2",
     "@types/json-schema": "^7.0.11",
     "@types/react": "^18.0.26",

--- a/python/jupytergis_core/package.json
+++ b/python/jupytergis_core/package.json
@@ -72,6 +72,7 @@
   },
   "devDependencies": {
     "@jupyter/builder": "^1.1.1",
+    "@rspack/core": "^2.1.2",
     "@types/json-schema": "^7.0.11",
     "@types/react": "^18.0.26",
     "@types/react-addons-linked-state-mixin": "^0.14.22",

--- a/python/jupytergis_core/package.json
+++ b/python/jupytergis_core/package.json
@@ -71,7 +71,7 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@jupyter/builder": "^1.2.1",
+    "@jupyter/builder": "^1.1.1",
     "@rspack/core": "^2.1.2",
     "@types/json-schema": "^7.0.11",
     "@types/react": "^18.0.26",

--- a/python/jupytergis_core/webpack.config.js
+++ b/python/jupytergis_core/webpack.config.js
@@ -4,7 +4,10 @@
 // - Auto-provide `process` and `Buffer` globals
 // - Emit .wasm files as separate assets so `import wasmURL` yields the correct URL
 
-const webpack = require('webpack');
+// @jupyter/builder bundles labextensions with rspack, so the ProvidePlugin
+// must come from @rspack/core rather than webpack (the webpack instance is
+// incompatible with the rspack compiler this config is merged into).
+const rspack = require('@rspack/core');
 const { VueLoaderPlugin } = require('vue-loader');
 
 module.exports = {
@@ -59,7 +62,7 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.ProvidePlugin({
+    new rspack.ProvidePlugin({
       process: 'process/browser',
       Buffer: ['buffer', 'Buffer']
     }),

--- a/python/jupytergis_core/webpack.config.js
+++ b/python/jupytergis_core/webpack.config.js
@@ -21,6 +21,16 @@ module.exports = {
     }
   },
   module: {
+    parser: {
+      javascript: {
+        // geoparquet's barrel re-exports `asyncBufferFromFile` from hyparquet,
+        // which only exists in hyparquet's Node entry — not the browser export
+        // condition rspack resolves. base never uses it, so downgrade rspack's
+        // strict ESM "export not found" check from error to warning (webpack's
+        // old, lenient behavior) instead of failing the browser bundle.
+        exportsPresence: 'warn'
+      }
+    },
     rules: [
       {
         test: /\.wasm$/,

--- a/python/jupytergis_core/webpack.config.js
+++ b/python/jupytergis_core/webpack.config.js
@@ -10,6 +10,30 @@
 const rspack = require('@rspack/core');
 const { VueLoaderPlugin } = require('vue-loader');
 
+// In development mode @jupyter/builder injects an rspack-native source-map rule
+// (`{ test: /\.js$/, enforce: 'pre', extractSourceMap: true }`) that has no
+// `use`. vue-loader 15's VueLoaderPlugin clones every non-Vue rule through
+// webpack's own RuleSetCompiler, which doesn't understand rspack's `enforce`
+// (without `use`) or `extractSourceMap` and throws
+// "Properties enforce, extractSourceMap are unknown". Pull any such rspack-only
+// rule out of the rule list before VueLoaderPlugin runs, then restore it once
+// VueLoaderPlugin has rebuilt the list, so source-map extraction still happens.
+class HideRspackNativeRulesFromVueLoader {
+  apply(compiler) {
+    const isRspackNative = rule => rule && rule.extractSourceMap;
+    const hidden = compiler.options.module.rules.filter(isRspackNative);
+    if (!hidden.length) {
+      return;
+    }
+    compiler.options.module.rules = compiler.options.module.rules.filter(
+      rule => !isRspackNative(rule)
+    );
+    compiler.hooks.afterPlugins.tap('HideRspackNativeRulesFromVueLoader', () => {
+      compiler.options.module.rules.push(...hidden);
+    });
+  }
+}
+
 module.exports = {
   resolve: {
     fallback: {
@@ -76,6 +100,7 @@ module.exports = {
       process: 'process/browser',
       Buffer: ['buffer', 'Buffer']
     }),
+    new HideRspackNativeRulesFromVueLoader(),
     new VueLoaderPlugin()
   ]
 };

--- a/python/jupytergis_lab/package.json
+++ b/python/jupytergis_lab/package.json
@@ -72,7 +72,7 @@
     "yjs-widgets": "^0.6.0"
   },
   "devDependencies": {
-    "@jupyter/builder": "^1.2.1",
+    "@jupyter/builder": "^1.1.1",
     "css-loader": "^6.7.1",
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",

--- a/python/jupytergis_lab/package.json
+++ b/python/jupytergis_lab/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "build": "pnpm run build:lib && pnpm run build:labextension:dev",
     "build:prod": "pnpm run clean && pnpm run build:lib:prod && pnpm run build:labextension",
-    "build:labextension": "jupyter labextension build .",
-    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:labextension": "jupyter-builder build .",
+    "build:labextension:dev": "jupyter-builder build --development True .",
     "build:lib": "tsc --sourceMap",
     "build:lib:prod": "tsc",
     "build:dev": "pnpm run build",
@@ -49,7 +49,7 @@
     "stylelint:check": "stylelint --cache \"style/**/*.css\"",
     "watch": "run-p watch:src watch:labextension",
     "watch:src": "tsc -w --sourceMap",
-    "watch:labextension": "jupyter labextension watch ."
+    "watch:labextension": "jupyter-builder watch ."
   },
   "dependencies": {
     "@jupyter/collaborative-drive": "^4.1.2 || ^5.0.0-alpha.0",
@@ -72,7 +72,7 @@
     "yjs-widgets": "^0.6.0"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^4.5",
+    "@jupyter/builder": "^1.1.1",
     "css-loader": "^6.7.1",
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",

--- a/python/jupytergis_lab/package.json
+++ b/python/jupytergis_lab/package.json
@@ -72,7 +72,7 @@
     "yjs-widgets": "^0.6.0"
   },
   "devDependencies": {
-    "@jupyter/builder": "^1.1.1",
+    "@jupyter/builder": "^1.2.1",
     "css-loader": "^6.7.1",
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",

--- a/python/jupytergis_qgis/package.json
+++ b/python/jupytergis_qgis/package.json
@@ -72,7 +72,7 @@
     "react": "^18.0.1"
   },
   "devDependencies": {
-    "@jupyter/builder": "^1.2.1",
+    "@jupyter/builder": "^1.1.1",
     "css-loader": "^6.7.1",
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",

--- a/python/jupytergis_qgis/package.json
+++ b/python/jupytergis_qgis/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "build": "pnpm run build:lib && pnpm run build:labextension:dev",
     "build:prod": "pnpm run clean && pnpm run build:lib:prod && pnpm run build:labextension",
-    "build:labextension": "jupyter labextension build .",
-    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:labextension": "jupyter-builder build .",
+    "build:labextension:dev": "jupyter-builder build --development True .",
     "build:lib": "tsc --sourceMap",
     "build:lib:prod": "tsc",
     "build:dev": "pnpm run build",
@@ -50,7 +50,7 @@
     "stylelint:check": "stylelint --cache \"style/**/*.css\"",
     "watch": "run-p watch:src watch:labextension",
     "watch:src": "tsc -w --sourceMap",
-    "watch:labextension": "jupyter labextension watch ."
+    "watch:labextension": "jupyter-builder watch ."
   },
   "dependencies": {
     "@jupyter/collaborative-drive": "^4.1.2 || ^5.0.0-alpha.0",
@@ -72,7 +72,7 @@
     "react": "^18.0.1"
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^4.5",
+    "@jupyter/builder": "^1.1.1",
     "css-loader": "^6.7.1",
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",

--- a/python/jupytergis_qgis/package.json
+++ b/python/jupytergis_qgis/package.json
@@ -72,7 +72,7 @@
     "react": "^18.0.1"
   },
   "devDependencies": {
-    "@jupyter/builder": "^1.1.1",
+    "@jupyter/builder": "^1.2.1",
     "css-loader": "^6.7.1",
     "mkdirp": "^1.0.3",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
## Description

Shall close #1700

The build fails ([logs](https://github.com/geojupyter/jupytergis/actions/runs/30528160029/job/90823867547?pr=1678#step:7:271)) because our legacy `@jupyterlab/builder@^4.5` pin can't resolve `@jupyterlab/core-meta` under JupyterLab 4.6. Switching to `@jupyter/builder` fixes it: https://github.com/jupyter-book/jupyterlab-myst/pull/295


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1701.org.readthedocs.build/en/1701/
💡 JupyterLite preview: https://jupytergis--1701.org.readthedocs.build/en/1701/lite
💡 Specta preview: https://jupytergis--1701.org.readthedocs.build/en/1701/lite/specta

<!-- readthedocs-preview jupytergis end -->