### PR TITLE
Warn users about problematic color maps

### DIFF
--- a/packages/base/src/features/layers/symbology/colorRampUtils.ts
+++ b/packages/base/src/features/layers/symbology/colorRampUtils.ts
@@ -129,6 +129,39 @@ export const COLOR_RAMP_DEFAULTS: Partial<Record<ColorRampName, number>> = {
   cubehelix: 16,
 } as const;
 
+export interface IColorRampWarning {
+  reason: string;
+  link?: string;
+}
+
+/** Color ramps with a known issue, mapped to the reason and (if available) a link with more info. */
+export const COLOR_RAMP_WARNINGS: Partial<
+  Record<ColorRampName, IColorRampWarning>
+> = {
+  jet: {
+    reason:
+      'This color map is not perceptually uniform and may misrepresent your data.',
+    link: 'https://jakevdp.github.io/blog/2014/10/16/how-bad-is-your-colormap/',
+  },
+  rainbow: {
+    reason:
+      'This color map is not perceptually uniform and may misrepresent your data.',
+    link: 'https://jakevdp.github.io/blog/2014/10/16/how-bad-is-your-colormap/',
+  },
+  hsv: {
+    reason: 'This color map needs more than 9 classes to render accurately.',
+  },
+  picnic: {
+    reason: 'This color map needs more than 9 classes to render accurately.',
+  },
+  cubehelix: {
+    reason: 'This color map needs more than 9 classes to render accurately.',
+  },
+  'rainbow-soft': {
+    reason: 'This color map needs more than 9 classes to render accurately.',
+  },
+};
+
 export const D3_CATEGORICAL_SCHEMES = {
   schemeCategory10: d3Chromatic.schemeCategory10,
   schemeAccent: d3Chromatic.schemeAccent,

--- a/packages/base/src/features/layers/symbology/colorRampUtils.ts
+++ b/packages/base/src/features/layers/symbology/colorRampUtils.ts
@@ -149,16 +149,16 @@ export const COLOR_RAMP_WARNINGS: Partial<
     link: 'https://jakevdp.github.io/blog/2014/10/16/how-bad-is-your-colormap/',
   },
   hsv: {
-    reason: 'This color map needs more than 9 classes to render accurately.',
+    reason: `This color map needs at least ${COLOR_RAMP_DEFAULTS.hsv} classes to render accurately.`,
   },
   picnic: {
-    reason: 'This color map needs more than 9 classes to render accurately.',
+    reason: `This color map needs at least ${COLOR_RAMP_DEFAULTS.picnic} classes to render accurately.`,
   },
   cubehelix: {
-    reason: 'This color map needs more than 9 classes to render accurately.',
+    reason: `This color map needs at least ${COLOR_RAMP_DEFAULTS.cubehelix} classes to render accurately.`,
   },
   'rainbow-soft': {
-    reason: 'This color map needs more than 9 classes to render accurately.',
+    reason: `This color map needs at least ${COLOR_RAMP_DEFAULTS['rainbow-soft']} classes to render accurately.`,
   },
 };
 

--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
@@ -13,10 +13,16 @@
 import React, { useEffect } from 'react';
 
 import {
+  COLOR_RAMP_WARNINGS,
   ColorRampName,
   IColorMap,
   drawColorRamp,
 } from '@/src/features/layers/symbology/colorRampUtils';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/src/shared/components/HoverCard';
 
 interface IColorRampSelectorEntryProps {
   index: number;
@@ -43,6 +49,8 @@ const ColorRampSelectorEntry: React.FC<IColorRampSelectorEntryProps> = ({
     drawColorRamp(canvas, colorMap);
   }, [colorMap, index]);
 
+  const warning = COLOR_RAMP_WARNINGS[colorMap.name];
+
   return (
     <div
       key={colorMap.name}
@@ -50,6 +58,29 @@ const ColorRampSelectorEntry: React.FC<IColorRampSelectorEntryProps> = ({
       className="jp-gis-color-ramp-entry"
     >
       <span className="jp-gis-color-label">{colorMap.name}</span>
+      {warning && (
+        <span
+          className="jp-gis-color-ramp-warning"
+          onClick={e => e.stopPropagation()}
+        >
+          <HoverCard openDelay={100} closeDelay={100}>
+            <HoverCardTrigger aria-label="Color map warning">
+              ⚠️
+            </HoverCardTrigger>
+            <HoverCardContent className="jgis-info-tip-content">
+              {warning.reason}
+              {warning.link && (
+                <>
+                  {' '}
+                  <a href={warning.link} target="_blank" rel="noreferrer">
+                    Learn more
+                  </a>
+                </>
+              )}
+            </HoverCardContent>
+          </HoverCard>
+        </span>
+      )}
       <canvas
         id={`cv-${index}`}
         width={canvasWidth}

--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
@@ -18,11 +18,7 @@ import {
   IColorMap,
   drawColorRamp,
 } from '@/src/features/layers/symbology/colorRampUtils';
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from '@/src/shared/components/HoverCard';
+import { InfoTip } from '@/src/shared/components/InfoTip';
 
 interface IColorRampSelectorEntryProps {
   index: number;
@@ -63,22 +59,13 @@ const ColorRampSelectorEntry: React.FC<IColorRampSelectorEntryProps> = ({
           className="jp-gis-color-ramp-warning"
           onClick={e => e.stopPropagation()}
         >
-          <HoverCard openDelay={100} closeDelay={100}>
-            <HoverCardTrigger aria-label="Color map warning">
-              ⚠️
-            </HoverCardTrigger>
-            <HoverCardContent className="jgis-info-tip-content">
-              {warning.reason}
-              {warning.link && (
-                <>
-                  {' '}
-                  <a href={warning.link} target="_blank" rel="noreferrer">
-                    Learn more
-                  </a>
-                </>
-              )}
-            </HoverCardContent>
-          </HoverCard>
+          <InfoTip text={warning.reason}>
+            {warning.link && (
+              <a href={warning.link} target="_blank" rel="noreferrer">
+                Learn more
+              </a>
+            )}
+          </InfoTip>
         </span>
       )}
       <canvas

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -180,6 +180,27 @@ select option {
   transform: translateX(6px);
 }
 
+.jp-gis-color-ramp-warning {
+  position: absolute;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  background: #f5f5f5;
+  border: 1.5px solid #ffcc00;
+  border-radius: 50%;
+}
+
+.jp-gis-color-ramp-warning .jgis-hover-card-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  line-height: 1;
+}
+
 .jp-gis-color-canvas {
   margin: 0 -7px;
   border-radius: 4px;

--- a/packages/base/style/symbologyDialog.css
+++ b/packages/base/style/symbologyDialog.css
@@ -186,19 +186,11 @@ select option {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
-  background: #f5f5f5;
-  border: 1.5px solid #ffcc00;
-  border-radius: 50%;
 }
 
 .jp-gis-color-ramp-warning .jgis-hover-card-trigger {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 9px;
-  line-height: 1;
+  color: white !important;
+  filter: drop-shadow(0 0 2px black);
 }
 
 .jp-gis-color-canvas {


### PR DESCRIPTION
## Description
- Resolves #1495 

Adds a warning icon to jet/rainbow (not perceptually uniform) and hsv/picnic/cubehelix/rainbow-soft (need more than 9 classes) in the color ramp selector.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1706.org.readthedocs.build/en/1706/
💡 JupyterLite preview: https://jupytergis--1706.org.readthedocs.build/en/1706/lite
💡 Specta preview: https://jupytergis--1706.org.readthedocs.build/en/1706/lite/specta

<!-- readthedocs-preview jupytergis end -->