### PR TITLE
Make Alpha band transparent

### DIFF
--- a/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
@@ -147,11 +147,28 @@ function compileRasterLayer(
   const flatStyle = grammarToOLStyle(singleLayerState, values);
   const colorExpr = flatStyle['pixel-color'];
 
+  if (!Array.isArray(colorExpr)) {
+    // No symbology → return raw raster layer (no style)
+    return new WebGLTileLayer({
+      opacity,
+      visible,
+      source,
+    });
+  }
+
+  // Apply alpha masking to the raster
+  const finalExpr = [
+    'case',
+    ['==', ['band', 4], 0],
+    ['color', 0, 0, 0, 0],
+    colorExpr,
+  ];
+
   return new WebGLTileLayer({
     opacity,
     visible,
     source,
-    ...(colorExpr !== undefined ? { style: { color: colorExpr as any } } : {}),
+    style: { color: finalExpr },
   });
 }
 


### PR DESCRIPTION
## Description

Pixels with alpha = 0 are fully transparent in the source GeoTIFF
But WebGLTileLayer does NOT automatically honor alpha, so we must mask them manually.

https://github.com/user-attachments/assets/ae586c3b-12a1-404b-89fa-94604da97045


- Closes #1707  


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1710.org.readthedocs.build/en/1710/
💡 JupyterLite preview: https://jupytergis--1710.org.readthedocs.build/en/1710/lite
💡 Specta preview: https://jupytergis--1710.org.readthedocs.build/en/1710/lite/specta

<!-- readthedocs-preview jupytergis end -->