### PR TITLE
Remove hard coded band count

### DIFF
--- a/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
@@ -146,6 +146,7 @@ function compileRasterLayer(
   const values = featureValues.length > 0 ? featureValues : [0, 1];
   const flatStyle = grammarToOLStyle(singleLayerState, values);
   const colorExpr = flatStyle['pixel-color'];
+  const bandCount = source.bandCount;
 
   if (!Array.isArray(colorExpr)) {
     // No symbology → return raw raster layer (no style)
@@ -159,7 +160,7 @@ function compileRasterLayer(
   // Apply alpha masking to the raster
   const finalExpr = [
     'case',
-    ['==', ['band', 4], 0],
+    ['==', ['band', bandCount], 0],
     ['color', 0, 0, 0, 0],
     colorExpr,
   ];


### PR DESCRIPTION
## Description

Remove hard coded band count and use original band count from data source.


https://github.com/user-attachments/assets/a7c4994f-aa8e-4d54-9db2-fe90cda21d40

For testing

- Single Band Tiff URL = https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/22/W/EC/2019/4/S2B_22WEC_20190422_0_L2A/B01.tif 

- Min = 100
- Max = 15000

Resolves https://github.com/geojupyter/jupytergis/pull/1710#discussion_r3703892997

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1711.org.readthedocs.build/en/1711/
💡 JupyterLite preview: https://jupytergis--1711.org.readthedocs.build/en/1711/lite
💡 Specta preview: https://jupytergis--1711.org.readthedocs.build/en/1711/lite/specta

<!-- readthedocs-preview jupytergis end -->