### PR TITLE
Reduce dependabot autoupdate frequency to quarterly (matching pre-commit)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'quarterly'
     cooldown:
       default-days: 7
     groups:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 ci:
-  # pre-commit.ci will open PRs updating our hooks once a month
   autoupdate_schedule: quarterly
   autofix_prs: false
 


### PR DESCRIPTION
## Description

I don't see much value in going through this hassle monthly.


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1714.org.readthedocs.build/en/1714/
💡 JupyterLite preview: https://jupytergis--1714.org.readthedocs.build/en/1714/lite
💡 Specta preview: https://jupytergis--1714.org.readthedocs.build/en/1714/lite/specta

<!-- readthedocs-preview jupytergis end -->