### PR TITLE
Better draw ux

### DIFF
--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -64,6 +64,34 @@ import { JupyterGISDocumentWidget } from '../workspace/widget';
 
 const POINT_SELECTION_TOOL_CLASS = 'jGIS-point-selection-tool';
 
+const INTERACTION_MODE_COMMANDS = [
+  CommandIDs.identify,
+  CommandIDs.addMarker,
+  CommandIDs.toggleDrawFeatures,
+] as const;
+
+function notifyInteractionModeCommands(commands: CommandRegistry): void {
+  for (const id of INTERACTION_MODE_COMMANDS) {
+    commands.notifyCommandChanged(id);
+  }
+}
+
+/**
+ * Keep the point-selection cursor class and toolbar toggles in sync with
+ * the exclusive map interaction mode.
+ */
+function syncInteractionModeUi(
+  widget: { model: IJupyterGISModel; node: HTMLElement },
+  commands: CommandRegistry,
+): void {
+  const mode = widget.model.currentMode;
+  widget.node.classList.toggle(
+    POINT_SELECTION_TOOL_CLASS,
+    mode === 'identifying' || mode === 'marking',
+  );
+  notifyInteractionModeCommands(commands);
+}
+
 /**
  * Commands for JupyterGIS-only features that cannot be round-tripped through
  * the QGIS format. They are disabled while a QGIS document (`.qgs`/`.qgz`) is
@@ -439,16 +467,13 @@ export function addCommands(
         const keysPressed = luminoEvent.keys as string[] | undefined;
         if (keysPressed?.includes('Escape')) {
           current.model.currentMode = 'panning';
-          current.node.classList.remove(POINT_SELECTION_TOOL_CLASS);
-          commands.notifyCommandChanged(CommandIDs.identify);
+          syncInteractionModeUi(current, commands);
           return;
         }
       }
 
-      current.node.classList.toggle(POINT_SELECTION_TOOL_CLASS);
       current.model.toggleMode('identifying');
-
-      commands.notifyCommandChanged(CommandIDs.identify);
+      syncInteractionModeUi(current, commands);
     },
     ...icons.get(CommandIDs.identify),
   });
@@ -1806,10 +1831,8 @@ export function addCommands(
         return;
       }
 
-      current.node.classList.toggle(POINT_SELECTION_TOOL_CLASS);
       current.model.toggleMode('marking');
-
-      commands.notifyCommandChanged(CommandIDs.addMarker);
+      syncInteractionModeUi(current, commands);
     },
     ...icons.get(CommandIDs.addMarker),
   });
@@ -1836,17 +1859,7 @@ export function addCommands(
         return false;
       }
 
-      const selectedLayer = getSingleSelectedLayer(tracker);
-
-      if (!selectedLayer) {
-        return false;
-      }
-
-      if (!model.checkIfIsADrawVectorLayer(selectedLayer)) {
-        return false;
-      }
-
-      return model.editingVectorLayer;
+      return model.currentMode === 'drawing';
     },
     isEnabled: () => {
       if (!(tracker.currentWidget instanceof JupyterGISDocumentWidget)) {
@@ -1860,22 +1873,18 @@ export function addCommands(
         return;
       }
 
-      const model = tracker.currentWidget?.content.currentViewModel?.jGISModel;
+      const current = tracker.currentWidget;
+      const model = current.content.currentViewModel?.jGISModel;
       if (!model) {
         return false;
       }
 
-      if (model.editingVectorLayer) {
-        model.editingVectorLayer = false;
-        model.updateEditingVectorLayer();
-        commands.notifyCommandChanged(CommandIDs.toggleDrawFeatures);
-        return;
+      if (model.currentMode !== 'drawing') {
+        Private.ensureDrawCompatibleLayer(model, tracker);
       }
 
-      Private.ensureDrawCompatibleLayer(model, tracker);
-      model.editingVectorLayer = true;
-      model.updateEditingVectorLayer();
-      commands.notifyCommandChanged(CommandIDs.toggleDrawFeatures);
+      model.toggleMode('drawing');
+      syncInteractionModeUi(current, commands);
     },
     ...icons.get(CommandIDs.toggleDrawFeatures),
   });

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -2111,7 +2111,7 @@ namespace Private {
 
   /**
    * Return the id of a draw-compatible selected layer, creating an empty
-   * inline GeoJSON FeatureCollection layer when the current selection is
+   * inline GeoJSON layer when the current selection is
    * missing or not editable for drawing.
    */
   export function ensureDrawCompatibleLayer(

--- a/packages/base/src/commands/index.ts
+++ b/packages/base/src/commands/index.ts
@@ -1,9 +1,11 @@
 import {
   IDict,
   IJGISFormSchemaRegistry,
+  IJGISLayer,
   IJGISLayerBrowserRegistry,
   IJGISLayerGroup,
   IJGISLayerItem,
+  IJGISSource,
   IJupyterGISModel,
   JgisCoordinates,
   LayerType,
@@ -1814,7 +1816,8 @@ export function addCommands(
 
   commands.addCommand(CommandIDs.toggleDrawFeatures, {
     label: trans.__('Edit Features'),
-    caption: 'Toggle feature editing for the selected draw-compatible layer.',
+    caption:
+      'Toggle feature editing. Creates an empty draw layer if the selection is not draw-compatible.',
     describedBy: {
       args: {
         type: 'object',
@@ -1850,19 +1853,7 @@ export function addCommands(
         return false;
       }
 
-      const model = tracker.currentWidget?.content?.currentViewModel
-        ?.jGISModel as IJupyterGISModel | undefined;
-
-      if (!model) {
-        return false;
-      }
-
-      const selectedLayer = getSingleSelectedLayer(tracker);
-      if (!selectedLayer) {
-        return false;
-      }
-
-      return model.checkIfIsADrawVectorLayer(selectedLayer) === true;
+      return tracker.currentWidget.model.sharedModel.editable;
     },
     execute: async () => {
       if (!(tracker.currentWidget instanceof JupyterGISDocumentWidget)) {
@@ -1874,13 +1865,15 @@ export function addCommands(
         return false;
       }
 
-      const selectedLayer = getSingleSelectedLayer(tracker);
-
-      if (!selectedLayer) {
-        return false;
+      if (model.editingVectorLayer) {
+        model.editingVectorLayer = false;
+        model.updateEditingVectorLayer();
+        commands.notifyCommandChanged(CommandIDs.toggleDrawFeatures);
+        return;
       }
 
-      model.editingVectorLayer = !model.editingVectorLayer;
+      Private.ensureDrawCompatibleLayer(model, tracker);
+      model.editingVectorLayer = true;
       model.updateEditingVectorLayer();
       commands.notifyCommandChanged(CommandIDs.toggleDrawFeatures);
     },
@@ -2105,6 +2098,65 @@ namespace Private {
       rendermime,
       urlResolverFactory,
     );
+  }
+
+  /**
+   * Return the id of a draw-compatible selected layer, creating an empty
+   * inline GeoJSON FeatureCollection layer when the current selection is
+   * missing or not editable for drawing.
+   */
+  export function ensureDrawCompatibleLayer(
+    model: IJupyterGISModel,
+    tracker: JupyterGISTracker,
+  ): string {
+    const selectedLayer = getSingleSelectedLayer(tracker);
+    const selected = model.localState?.selected?.value;
+    const selectedLayerId =
+      selected && Object.keys(selected).length === 1
+        ? Object.keys(selected)[0]
+        : undefined;
+
+    if (
+      selectedLayer &&
+      selectedLayerId &&
+      model.checkIfIsADrawVectorLayer(selectedLayer)
+    ) {
+      return selectedLayerId;
+    }
+
+    const sourceId = UUID.uuid4();
+    const layerId = UUID.uuid4();
+
+    const sourceModel: IJGISSource = {
+      type: 'GeoJSONSource',
+      name: 'Draw Layer Source',
+      parameters: {
+        data: {
+          type: 'FeatureCollection',
+          features: [],
+        },
+      },
+    };
+
+    const layerModel: IJGISLayer = {
+      type: 'VectorLayer',
+      name: 'Draw Layer',
+      visible: true,
+      parameters: {
+        source: sourceId,
+        opacity: 1.0,
+        symbologyState: { layers: [] },
+      },
+    };
+
+    model.sharedModel.addSource(sourceId, sourceModel);
+    model.addLayer(layerId, layerModel);
+    model.syncSelected(
+      { [layerId]: { type: 'layer' } },
+      model.getClientId().toString(),
+    );
+
+    return layerId;
   }
 
   export function createLayerBrowser(

--- a/packages/base/src/mainview/components/MainViewOverlayLayer.tsx
+++ b/packages/base/src/mainview/components/MainViewOverlayLayer.tsx
@@ -6,7 +6,7 @@ import { VectorDrawControls } from '@/src/features/labels/components/VectorDrawC
 export interface IMainViewOverlayLayerProps {
   annotationFloaters: React.ReactNode;
   featureFloaters: React.ReactNode;
-  editingVectorLayer: boolean;
+  isDrawing: boolean;
   drawGeometryLabel: string | undefined;
   onDrawGeometryTypeChange: (geometryType: string) => void;
   model: IJupyterGISModel;
@@ -16,7 +16,7 @@ export interface IMainViewOverlayLayerProps {
 export function MainViewOverlayLayer({
   annotationFloaters,
   featureFloaters,
-  editingVectorLayer,
+  isDrawing,
   drawGeometryLabel,
   onDrawGeometryTypeChange,
   model,
@@ -26,7 +26,7 @@ export function MainViewOverlayLayer({
     <>
       {annotationFloaters}
       {featureFloaters}
-      {editingVectorLayer ? (
+      {isDrawing ? (
         <VectorDrawControls
           drawGeometryLabel={drawGeometryLabel}
           onDrawGeometryTypeChange={onDrawGeometryTypeChange}

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2489,8 +2489,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       selectedLayerId,
     );
     if (decision.disableEditing) {
-      this._model.editingVectorLayer = false;
-      this._updateEditingVectorLayer();
+      if (this._model.currentMode === 'drawing') {
+        this._model.currentMode = 'panning';
+        this._notifyInteractionModeCommands();
+      }
       return;
     }
     if (!decision.shouldRebind) {
@@ -2519,7 +2521,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return { disableEditing: true, shouldRebind: false };
     }
 
-    if (!this._model.editingVectorLayer) {
+    if (this._model.currentMode !== 'drawing') {
       return { disableEditing: false, shouldRebind: false };
     }
 
@@ -2865,12 +2867,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
       if (!newLayer || Object.keys(newLayer).length === 0) {
         this.removeLayer(id);
-        if (this._model.checkIfIsADrawVectorLayer(oldLayer as IJGISLayer)) {
-          this._model.editingVectorLayer = false;
-          this._updateEditingVectorLayer();
-          this._mainViewModel.commands.notifyCommandChanged(
-            CommandIDs.toggleDrawFeatures,
-          );
+        if (
+          this._model.currentMode === 'drawing' &&
+          this._model.checkIfIsADrawVectorLayer(oldLayer as IJGISLayer)
+        ) {
+          this._model.currentMode = 'panning';
+          this._notifyInteractionModeCommands();
         }
         return;
       }
@@ -3536,10 +3538,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   });
 
   private async _addMarker(e: MapBrowserEvent<any>) {
-    if (
-      this.state.editingVectorLayer ||
-      this._model.currentMode !== 'marking'
-    ) {
+    if (this._model.currentMode !== 'marking') {
       return;
     }
 
@@ -3578,10 +3577,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   }
 
   private _identifyFeature(e: MapBrowserEvent<any>) {
-    if (
-      this.state.editingVectorLayer ||
-      this._model.currentMode !== 'identifying'
-    ) {
+    if (this._model.currentMode !== 'identifying') {
       return;
     }
 
@@ -3857,6 +3853,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._removeDrawInteraction();
       this._setCurrentDrawLayerId(undefined);
     }
+  }
+
+  private _notifyInteractionModeCommands(): void {
+    const commands = this._mainViewModel.commands;
+    commands.notifyCommandChanged(CommandIDs.identify);
+    commands.notifyCommandChanged(CommandIDs.addMarker);
+    commands.notifyCommandChanged(CommandIDs.toggleDrawFeatures);
   }
 
   private _setCurrentDrawLayerId(layerId: string | undefined): void {

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -3886,6 +3886,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     this._currentDrawGeometry = drawGeometryLabel as Type;
 
+    if (this._currentDrawLayerID) {
+      this._currentVectorSource = this._getVectorSourceFromLayerID(
+        this._currentDrawLayerID,
+      );
+    }
+
     this._updateInteractions();
     this._updateDrawSource();
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -237,7 +237,7 @@ interface IStates {
   loadingErrors: Array<{ id: string; error: any; index: number }>;
   displayTemporalController: boolean;
   filterStates: IDict<IJGISFilterItem | undefined>;
-  editingVectorLayer: boolean;
+  isDrawing: boolean;
   drawGeometryLabel: string | undefined;
   currentDrawLayerId: string | undefined;
   jgisSettings: IJupyterGISSettings;
@@ -355,11 +355,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this,
     );
 
-    // Keep draw editing UI/interactions in sync with the shared editing mode.
-    this._model.editingVectorLayerChanged.connect(
-      this._updateEditingVectorLayer,
-      this,
-    );
+    // Keep draw UI/interactions in sync with the exclusive map mode.
+    this._model.modeChanged.connect(this._handleModeChanged, this);
 
     this._model.flyToGeometrySignal.connect(this.flyToGeometry, this);
     this._model.highlightFeatureSignal.connect(
@@ -383,7 +380,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       loadingErrors: [],
       displayTemporalController: false,
       filterStates: {},
-      editingVectorLayer: false,
+      isDrawing: false,
       drawGeometryLabel: '',
       currentDrawLayerId: undefined,
       jgisSettings: this._model.jgisSettings,
@@ -503,6 +500,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._handleLocationIndicatorToggled,
       this,
     );
+    this._model.modeChanged.disconnect(this._handleModeChanged, this);
     this._stopLocationIndicator();
 
     this._mainViewModel.dispose();
@@ -3841,19 +3839,19 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   };
 
-  private _updateEditingVectorLayer() {
-    const editingVectorLayer: boolean = this._model.editingVectorLayer;
-    this.setState(old => ({ ...old, editingVectorLayer }));
+  private _handleModeChanged = (): void => {
+    const isDrawing = this._model.currentMode === 'drawing';
+    this.setState(old => ({ ...old, isDrawing }));
 
-    if (editingVectorLayer === true) {
+    if (isDrawing) {
       this._editVectorLayer();
     }
 
-    if (editingVectorLayer === false && this._draw) {
+    if (!isDrawing && this._draw) {
       this._removeDrawInteraction();
       this._setCurrentDrawLayerId(undefined);
     }
-  }
+  };
 
   private _notifyInteractionModeCommands(): void {
     const commands = this._mainViewModel.commands;
@@ -4151,7 +4149,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       clientPointers,
       displayTemporalController,
       drawGeometryLabel,
-      editingVectorLayer,
+      isDrawing,
       currentDrawLayerId,
       filterStates,
       initialLayersReady,
@@ -4182,7 +4180,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         <MainViewOverlayLayer
           annotationFloaters={this._renderAnnotationFloaters()}
           featureFloaters={this._renderFeatureFloaters()}
-          editingVectorLayer={editingVectorLayer}
+          isDrawing={isDrawing}
           drawGeometryLabel={drawGeometryLabel}
           drawLayerId={currentDrawLayerId}
           onDrawGeometryTypeChange={this._handleDrawGeometryTypeChange}

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -358,7 +358,7 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   flyToGeometrySignal: Signal<IJupyterGISModel, any>;
   highlightFeatureSignal: Signal<IJupyterGISModel, any>;
   updateBboxSignal: Signal<IJupyterGISModel, any>;
-  editingVectorLayerChanged: ISignal<IJupyterGISModel, boolean>;
+  modeChanged: ISignal<IJupyterGISModel, Modes>;
 
   contentsManager: Contents.IManager | undefined;
   filePath: string;
@@ -455,8 +455,6 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   centerOnPosition(id: string): void;
 
   toggleMode(mode: Modes): void;
-  editingVectorLayer: boolean;
-  updateEditingVectorLayer(): void;
   checkIfIsADrawVectorLayer(layer: IJGISLayer): boolean;
 
   isTemporalControllerActive: boolean;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -1218,7 +1218,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   /**
    * Toggle a map interaction mode on or off.
    * Toggling off sets the mode to 'panning'.
-   * Modes are exclusive; entering one leaves any other.
+   * Modes are exclusive, entering one leaves any other.
    * @param mode The mode to be toggled
    */
   toggleMode(mode: Modes) {

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -98,8 +98,6 @@ export class JupyterGISModel implements IJupyterGISModel {
     this._pathChanged = new Signal<JupyterGISModel, string>(this);
     this._settingsChanged = new Signal<JupyterGISModel, string>(this);
 
-    this._editingVectorLayer = false;
-
     this._jgisSettings = { ...DEFAULT_SETTINGS };
 
     this._viewState = {};
@@ -1220,10 +1218,11 @@ export class JupyterGISModel implements IJupyterGISModel {
   /**
    * Toggle a map interaction mode on or off.
    * Toggling off sets the mode to 'panning'.
+   * Modes are exclusive; entering one leaves any other.
    * @param mode The mode to be toggled
    */
   toggleMode(mode: Modes) {
-    this._currentMode = this._currentMode === mode ? 'panning' : mode;
+    this.currentMode = this._currentMode === mode ? 'panning' : mode;
   }
 
   get currentMode(): Modes {
@@ -1231,7 +1230,17 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   set currentMode(value: Modes) {
+    if (this._currentMode === value) {
+      return;
+    }
+
+    const wasDrawing = this._currentMode === 'drawing';
     this._currentMode = value;
+    const isDrawing = value === 'drawing';
+
+    if (wasDrawing !== isDrawing) {
+      this.editingVectorLayerChanged.emit(isDrawing);
+    }
   }
 
   setUIState(value: Partial<IJGISUIState>): void {
@@ -1423,16 +1432,23 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   updateEditingVectorLayer(): void {
-    this.editingVectorLayerChanged.emit(this._editingVectorLayer);
+    this.editingVectorLayerChanged.emit(this.editingVectorLayer);
   }
 
+  /**
+   * Whether the map is in drawing mode.
+   * Derived from `currentMode === 'drawing'`; kept for existing call sites.
+   */
   get editingVectorLayer(): boolean {
-    return this._editingVectorLayer;
+    return this._currentMode === 'drawing';
   }
 
   set editingVectorLayer(editingVectorLayer: boolean) {
-    this._editingVectorLayer = editingVectorLayer;
-    this.editingVectorLayerChanged.emit(this._editingVectorLayer);
+    if (editingVectorLayer) {
+      this.currentMode = 'drawing';
+    } else if (this._currentMode === 'drawing') {
+      this.currentMode = 'panning';
+    }
   }
 
   get geolocation(): JgisCoordinates {
@@ -1459,7 +1475,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   private _settingsChanged: Signal<JupyterGISModel, string>;
   private _jgisSettings: IJupyterGISSettings;
 
-  private _currentMode: Modes;
+  private _currentMode: Modes = 'panning';
 
   private _sharedModel: IJupyterGISDoc;
   private _filePath: string;
@@ -1525,8 +1541,6 @@ export class JupyterGISModel implements IJupyterGISModel {
     this,
     { type: SelectionType; itemId: string } | null
   >(this);
-
-  private _editingVectorLayer: boolean;
 
   static worker: Worker;
 

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -455,7 +455,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   readonly flyToGeometrySignal = new Signal<this, any>(this);
   readonly highlightFeatureSignal = new Signal<this, any>(this);
   readonly updateBboxSignal = new Signal<this, any>(this);
-  readonly editingVectorLayerChanged = new Signal<this, boolean>(this);
+  readonly modeChanged = new Signal<this, Modes>(this);
 
   getContent(): IJGISContent {
     return {
@@ -1234,13 +1234,8 @@ export class JupyterGISModel implements IJupyterGISModel {
       return;
     }
 
-    const wasDrawing = this._currentMode === 'drawing';
     this._currentMode = value;
-    const isDrawing = value === 'drawing';
-
-    if (wasDrawing !== isDrawing) {
-      this.editingVectorLayerChanged.emit(isDrawing);
-    }
+    this.modeChanged.emit(value);
   }
 
   setUIState(value: Partial<IJGISUIState>): void {
@@ -1429,26 +1424,6 @@ export class JupyterGISModel implements IJupyterGISModel {
       selectedSource?.type === 'GeoJSONSource' &&
       selectedSource?.parameters?.data?.type === 'FeatureCollection'
     );
-  }
-
-  updateEditingVectorLayer(): void {
-    this.editingVectorLayerChanged.emit(this.editingVectorLayer);
-  }
-
-  /**
-   * Whether the map is in drawing mode.
-   * Derived from `currentMode === 'drawing'`; kept for existing call sites.
-   */
-  get editingVectorLayer(): boolean {
-    return this._currentMode === 'drawing';
-  }
-
-  set editingVectorLayer(editingVectorLayer: boolean) {
-    if (editingVectorLayer) {
-      this.currentMode = 'drawing';
-    } else if (this._currentMode === 'drawing') {
-      this.currentMode = 'panning';
-    }
   }
 
   get geolocation(): JgisCoordinates {

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -59,4 +59,4 @@ export * from './interfaces';
 export * from './model';
 export * from './token';
 
-export type Modes = 'panning' | 'identifying' | 'marking';
+export type Modes = 'panning' | 'identifying' | 'marking' | 'drawing';


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Improve UX for entering draw mode, so now the toolbar button will create the necessary layer if a valid one is not selected. Also adds `drawing` to the mode list and enforces mode exclusivity (so entering identify mode will cancel drawing mode)

https://github.com/user-attachments/assets/edfeb057-504e-4886-8370-2089e8cd4215


## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1716.org.readthedocs.build/en/1716/
💡 JupyterLite preview: https://jupytergis--1716.org.readthedocs.build/en/1716/lite
💡 Specta preview: https://jupytergis--1716.org.readthedocs.build/en/1716/lite/specta

<!-- readthedocs-preview jupytergis end -->