### PR TITLE
Keep notification toasts above JupyterLab modal dialogs

### DIFF
--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -47,6 +47,14 @@
 @import url('./shared/separator.css');
 @import url('./shared/buttonGroup.css');
 
+/* JupyterLab modal dialogs (.jp-Dialog) use z-index: 10000, which sits above
+   the notification toast container (react-toastify default: 9999). Without this
+   override, error/info toasts are hidden behind the dialog backdrop while a
+   dialog is open. Lift the toast container above the dialog. */
+.Toastify__toast-container {
+  z-index: 10001 !important;
+}
+
 .jgis-underline-indicator {
   position: relative;
   opacity: 0.7;


### PR DESCRIPTION
## Description

Shall close #1720

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1722.org.readthedocs.build/en/1722/
💡 JupyterLite preview: https://jupytergis--1722.org.readthedocs.build/en/1722/lite
💡 Specta preview: https://jupytergis--1722.org.readthedocs.build/en/1722/lite/specta

<!-- readthedocs-preview jupytergis end -->