### PR TITLE
Rename `colorRamp` to `colorMap`

### DIFF
--- a/examples/cloud_optimized_geotiff.jGIS
+++ b/examples/cloud_optimized_geotiff.jGIS
@@ -142,7 +142,7 @@
                           "name": "hot",
                           "reverse": true
                         },
-                        "scheme": "colorRamp"
+                        "scheme": "colorMap"
                       }
                     }
                   ]

--- a/examples/earthquakes.jGIS
+++ b/examples/earthquakes.jGIS
@@ -141,7 +141,7 @@
                           "name": "viridis",
                           "reverse": false
                         },
-                        "scheme": "colorRamp"
+                        "scheme": "colorMap"
                       }
                     }
                   ]

--- a/examples/macrostrat.jGIS
+++ b/examples/macrostrat.jGIS
@@ -155,7 +155,7 @@
                           "name": "viridis",
                           "reverse": true
                         },
-                        "scheme": "colorRamp"
+                        "scheme": "colorMap"
                       }
                     }
                   ]

--- a/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
+++ b/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
@@ -276,10 +276,10 @@ describe('grammarToOLStyle — when predicates', () => {
 });
 
 // ---------------------------------------------------------------------------
-// colorRamp scale
+// colorMap scale
 // ---------------------------------------------------------------------------
 
-describe('grammarToOLStyle — colorRamp scale', () => {
+describe('grammarToOLStyle — colorMap scale', () => {
   it('emits encodingZero when no field and no stops', () => {
     const style = grammarToOLStyle(
       makeState({
@@ -287,7 +287,7 @@ describe('grammarToOLStyle — colorRamp scale', () => {
         mappings: [
           {
             scale: {
-              scheme: 'colorRamp',
+              scheme: 'colorMap',
               params: {
                 name: 'viridis',
                 nShades: 5,
@@ -313,7 +313,7 @@ describe('grammarToOLStyle — colorRamp scale', () => {
         mappings: [
           {
             scale: {
-              scheme: 'colorRamp',
+              scheme: 'colorMap',
               params: {
                 name: 'viridis',
                 nShades: 3,
@@ -347,7 +347,7 @@ describe('grammarToOLStyle — colorRamp scale', () => {
         mappings: [
           {
             scale: {
-              scheme: 'colorRamp',
+              scheme: 'colorMap',
               params: {
                 name: 'viridis',
                 nShades: 5,
@@ -585,7 +585,7 @@ describe('grammarToOLStyle — OL runtime parsing', () => {
     ).not.toThrow();
   });
 
-  it('colorRamp interpolate expression compiled from featureValues parses natively', () => {
+  it('colorMap interpolate expression compiled from featureValues parses natively', () => {
     const style = grammarToOLStyle(
       makeState({
         id: '1',
@@ -593,7 +593,7 @@ describe('grammarToOLStyle — OL runtime parsing', () => {
         mappings: [
           {
             scale: {
-              scheme: 'colorRamp',
+              scheme: 'colorMap',
               params: {
                 name: 'viridis',
                 nShades: 5,
@@ -800,7 +800,7 @@ describe('extractEncodingFieldValues', () => {
       mappings: [
         {
           scale: {
-            scheme: 'colorRamp',
+            scheme: 'colorMap',
             params: {
               name: 'viridis',
               nShades: 3,

--- a/packages/base/src/features/layers/symbology/components/MappingRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/MappingRow.tsx
@@ -7,7 +7,7 @@
 import { faPlus, faTrash, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  IColorRampScale,
+  IColorMapScale,
   ICompareOp,
   IConstantNumScale,
   IConstantRGBAScale,
@@ -31,7 +31,7 @@ import {
 } from '@/src/shared/components/NativeSelect';
 import {
   CategoricalEditor,
-  ColorRampEditor,
+  ColorMapEditor,
   ConstantEditor,
   ScalarEditor,
   ExpressionEditor,
@@ -83,7 +83,7 @@ const ENCODING_LABELS: Partial<Record<Encoding, string>> = {
 function compatibleEncodings(scale: IScale, isRaster = false): Encoding[] {
   if (isRaster) {
     switch (scale.scheme) {
-      case 'colorRamp':
+      case 'colorMap':
       case 'categorical':
       case 'constant_rgba':
         return PIXEL_RGBA_ENCODINGS;
@@ -95,7 +95,7 @@ function compatibleEncodings(scale: IScale, isRaster = false): Encoding[] {
     }
   }
   switch (scale.scheme) {
-    case 'colorRamp':
+    case 'colorMap':
     case 'categorical':
     case 'constant_rgba':
       return RGBA_ENCODINGS;
@@ -122,9 +122,9 @@ function defaultScaleForScheme(
         scheme: 'constant_num',
         params: { value: 1 },
       } as IConstantNumScale;
-    case 'colorRamp':
+    case 'colorMap':
       return {
-        scheme: 'colorRamp',
+        scheme: 'colorMap',
         params: {
           name: 'viridis',
           nShades: 9,
@@ -133,7 +133,7 @@ function defaultScaleForScheme(
           fallback: [0, 0, 0, 0] as RGBA,
           domain: [0, 1],
         },
-      } as IColorRampScale;
+      } as IColorMapScale;
     case 'categorical':
       return {
         scheme: 'categorical',
@@ -183,7 +183,7 @@ const SCHEME_OPTIONS: {
 }[] = [
   { value: 'constant_rgba', label: 'const (color)' },
   { value: 'constant_num', label: 'const (num)' },
-  { value: 'colorRamp', label: 'color map' },
+  { value: 'colorMap', label: 'color map' },
   { value: 'categorical', label: 'categorical' },
   { value: 'scalar', label: 'scalar' },
   { value: 'identity', label: 'identity' },
@@ -250,7 +250,7 @@ const ScalePreview: React.FC<{ scale: IScale }> = ({ scale }) => {
           <span className="jp-gis-scale-meta">= {scale.params.value}</span>
         </span>
       );
-    case 'colorRamp': {
+    case 'colorMap': {
       const { name, reverse, domain } = scale.params;
       return (
         <span className="jp-gis-scale-preview">
@@ -836,7 +836,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
       return;
     }
 
-    if (scale.scheme !== 'colorRamp' && scale.scheme !== 'scalar') {
+    if (scale.scheme !== 'colorMap' && scale.scheme !== 'scalar') {
       return;
     }
 
@@ -844,7 +844,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
     const domain = scale.params.domain;
 
     const isDefaultDomain =
-      scale.scheme === 'colorRamp'
+      scale.scheme === 'colorMap'
         ? domain?.[0] === 0 && domain?.[1] === 1
         : scale.scheme === 'scalar'
           ? domain?.[0] === 0 && domain?.[1] === 100
@@ -885,7 +885,7 @@ const MappingRow: React.FC<IMappingRowProps> = ({
 
       if (
         stats &&
-        (newScale.scheme === 'colorRamp' || newScale.scheme === 'scalar')
+        (newScale.scheme === 'colorMap' || newScale.scheme === 'scalar')
       ) {
         newScale = {
           ...newScale,
@@ -1133,8 +1133,8 @@ const MappingRow: React.FC<IMappingRowProps> = ({
             row.scale.scheme === 'constant_num') && (
             <ConstantEditor scale={row.scale} onChange={handleScaleChange} />
           )}
-          {row.scale.scheme === 'colorRamp' && (
-            <ColorRampEditor
+          {row.scale.scheme === 'colorMap' && (
+            <ColorMapEditor
               scale={row.scale}
               field={row.fields?.[0]}
               featureValues={featureValues}

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -18,7 +18,7 @@ import { EditorView, placeholder, keymap } from '@codemirror/view';
 import {
   ClassificationMode,
   ICategoricalScale,
-  IColorRampScale,
+  IColorMapScale,
   IConstantNumScale,
   IConstantRGBAScale,
   IExpressionScale,
@@ -119,17 +119,17 @@ export const ConstantEditor: React.FC<IConstantEditorProps> = ({
 };
 
 // ---------------------------------------------------------------------------
-// ColorRamp editor
+// ColorMap editor
 // ---------------------------------------------------------------------------
 
-interface IColorRampEditorProps {
-  scale: IColorRampScale;
+interface IColorMapEditorProps {
+  scale: IColorMapScale;
   field: string | undefined;
   featureValues: Record<string, Set<any>>;
   onChange: (scale: IScale) => void;
 }
 
-export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
+export const ColorMapEditor: React.FC<IColorMapEditorProps> = ({
   scale,
   field,
   featureValues,
@@ -141,8 +141,8 @@ export const ColorRampEditor: React.FC<IColorRampEditorProps> = ({
   );
 
   const update = useCallback(
-    (patch: Partial<IColorRampScale['params']>) =>
-      onChange({ scheme: 'colorRamp', params: { ...params, ...patch } }),
+    (patch: Partial<IColorMapScale['params']>) =>
+      onChange({ scheme: 'colorMap', params: { ...params, ...patch } }),
     [params, onChange],
   );
 

--- a/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
@@ -215,7 +215,7 @@ function extractGradient(rules: IEncodingRule[]): string[] | undefined {
       const isPixelEncoding = (mapping.encodings as string[]).some(
         ch => ch === 'pixel-color' || ch.startsWith('pixel-'),
       );
-      if (!isPixelEncoding || mapping.scale.scheme !== 'colorRamp') {
+      if (!isPixelEncoding || mapping.scale.scheme !== 'colorMap') {
         continue;
       }
 

--- a/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
@@ -14,7 +14,7 @@
 
 import {
   ICategoricalScale,
-  IColorRampScale,
+  IColorMapScale,
   IMapping,
   IScalarScale,
   IGrammarSymbologyState,
@@ -171,7 +171,7 @@ export function grammarToOLStyle(
 
 /**
  * Extract the encoding field column from feature property rows.
- * colorRamp and categorical scales take a single input field; this returns
+ * colorMap and categorical scales take a single input field; this returns
  * all values for that field so the compiler can compute classification breaks.
  */
 export function extractEncodingFieldValues(
@@ -384,9 +384,9 @@ function compileMapping(
 ): ExpressionValue {
   const { scale } = mapping;
   switch (scale.scheme) {
-    case 'colorRamp':
+    case 'colorMap':
       return field
-        ? compileColorRamp(field, scale, featureValues, encoding)
+        ? compileColorMap(field, scale, featureValues, encoding)
         : scale.params.fallback;
     case 'categorical':
       return field
@@ -449,16 +449,16 @@ function compileMapping(
 // ---------------------------------------------------------------------------
 
 /**
- * colorRamp: numeric field → RGBA color via a named palette + classification.
+ * colorMap: numeric field → RGBA color via a named palette + classification.
  *
  * Output:
  *   ['case', ['has', field],
  *     ['interpolate', ['linear'], ['get', field], stop0, color0, ...],
  *     fallback]
  */
-function compileColorRamp(
+function compileColorMap(
   field: string,
-  scale: IColorRampScale,
+  scale: IColorMapScale,
   featureValues: unknown[],
   encoding?: Encoding,
 ): ExpressionValue {
@@ -511,7 +511,7 @@ function compileColorRamp(
  * breaks are computed from featureValues using computeGraduatedColorStops.
  */
 function resolveColorStops(
-  scale: IColorRampScale,
+  scale: IColorMapScale,
   featureValues: unknown[],
 ): Array<{ stop: number; color: RGBA }> {
   if (scale.params.colorStops && scale.params.colorStops.length >= 2) {

--- a/packages/base/src/workspace/panels/components/legendItem.tsx
+++ b/packages/base/src/workspace/panels/components/legendItem.tsx
@@ -312,7 +312,7 @@ function kdeToLegendEntries(
       const isPixelEncoding = (mapping.encodings as string[]).some(
         ch => ch === 'pixel-color' || ch.startsWith('pixel-'),
       );
-      if (!isPixelEncoding || mapping.scale.scheme !== 'colorRamp') {
+      if (!isPixelEncoding || mapping.scale.scheme !== 'colorMap') {
         continue;
       }
       const p = mapping.scale.params;
@@ -420,7 +420,7 @@ function grammarToLegendEntries(state: IGrammarSymbologyState): LegendEntry[] {
 
         if (isColor) {
           switch (scale.scheme) {
-            case 'colorRamp': {
+            case 'colorMap': {
               const p = scale.params;
               if (p.colorStops && p.colorStops.length >= 2) {
                 // When alpha is driven by a companion scalar, clip the displayed

--- a/packages/schema/src/grammar/grammarConversions.ts
+++ b/packages/schema/src/grammar/grammarConversions.ts
@@ -118,8 +118,8 @@ export function graduatedToGrammar(
       color: s.color as RGBA,
     }));
 
-  const colorRampScale = {
-    scheme: 'colorRamp' as const,
+  const colorMapScale = {
+    scheme: 'colorMap' as const,
     params: {
       name: state.colorRamp ?? 'viridis',
       ...(state.vmin !== undefined && state.vmax !== undefined
@@ -138,7 +138,7 @@ export function graduatedToGrammar(
     : ['fill-color', 'circle-fill-color'];
 
   const mappings: IMapping[] = [
-    { scale: colorRampScale, encodings: fillEncodings },
+    { scale: colorMapScale, encodings: fillEncodings },
   ];
 
   if (!state.strokeFollowsFill) {

--- a/packages/schema/src/schema/project/symbology.json
+++ b/packages/schema/src/schema/project/symbology.json
@@ -179,9 +179,9 @@
         "color": { "$ref": "#/definitions/RGBA" }
       }
     },
-    "IColorRampScaleParams": {
+    "IColorMapScaleParams": {
       "type": "object",
-      "title": "IColorRampScaleParams",
+      "title": "IColorMapScaleParams",
       "description": "Parameters controlling color-ramp classification and fallback behavior.",
       "required": ["name", "nShades", "mode", "reverse", "fallback"],
       "additionalProperties": false,
@@ -203,15 +203,15 @@
         }
       }
     },
-    "IColorRampScale": {
+    "IColorMapScale": {
       "type": "object",
-      "title": "IColorRampScale",
+      "title": "IColorMapScale",
       "description": "Maps a numeric field through a named color palette to RGBA.",
       "required": ["scheme", "params"],
       "additionalProperties": false,
       "properties": {
-        "scheme": { "const": "colorRamp" },
-        "params": { "$ref": "#/definitions/IColorRampScaleParams" }
+        "scheme": { "const": "colorMap" },
+        "params": { "$ref": "#/definitions/IColorMapScaleParams" }
       }
     },
     "ICategoricalColorStop": {
@@ -388,7 +388,7 @@
       "title": "IScale",
       "description": "Scale union that maps input values to styled outputs.",
       "oneOf": [
-        { "$ref": "#/definitions/IColorRampScale" },
+        { "$ref": "#/definitions/IColorMapScale" },
         { "$ref": "#/definitions/ICategoricalScale" },
         { "$ref": "#/definitions/IScalarScale" },
         { "$ref": "#/definitions/IConstantRGBAScale" },

--- a/python/jupytergis_core/jupytergis_core/migrations/v0_5_to_v0_6.py
+++ b/python/jupytergis_core/jupytergis_core/migrations/v0_5_to_v0_6.py
@@ -198,7 +198,7 @@ def _graduated(state: dict[str, Any]) -> dict[str, Any]:
     if vmin is not None and vmax is not None:
         color_ramp_params["domain"] = [vmin, vmax]
 
-    color_ramp_scale = {"scheme": "colorRamp", "params": color_ramp_params}
+    color_ramp_scale = {"scheme": "colorMap", "params": color_ramp_params}
 
     fill_encodings = (
         ["fill-color", "stroke-color", "circle-fill-color", "circle-stroke-color"]

--- a/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/symbology.py
@@ -858,8 +858,8 @@ def _colormap_scale(
     reverse: bool = False,
     fallback: RGBA | Sequence[float] | str = (0.0, 0.0, 0.0, 1.0),
     color_stops: Sequence[schema_symbology.IColorStop] | None = None,
-) -> schema_symbology.IColorRampScale:
-    params = schema_symbology.IColorRampScaleParams(
+) -> schema_symbology.IColorMapScale:
+    params = schema_symbology.IColorMapScaleParams(
         name=name,
         domain=list(domain) if domain is not None else None,
         nShades=n_shades,
@@ -868,7 +868,7 @@ def _colormap_scale(
         fallback=schema_symbology.RGBA(root=coerce_rgba(fallback)),
         colorStops=list(color_stops) if color_stops is not None else None,
     )
-    return schema_symbology.IColorRampScale(
+    return schema_symbology.IColorMapScale(
         params=params,
     )
 

--- a/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/tests/test_api.py
@@ -110,7 +110,7 @@ class TestGrammarSymbologyBuilders:
         )
         assert (
             state["layers"][0]["rules"][1]["mappings"][0]["scale"]["scheme"]
-            == "colorRamp"
+            == "colorMap"
         )
 
     def test_chain_when_and_when_op(self):
@@ -150,7 +150,7 @@ class TestGrammarSymbologyBuilders:
             ],
         )
         scale = state["layers"][0]["rules"][0]["mappings"][0]["scale"]
-        assert scale["scheme"] == "colorRamp"
+        assert scale["scheme"] == "colorMap"
 
     def test_categorical_accepts_colormap_attribute(self):
         state = to_symbology_state(

--- a/python/jupytergis_qgis/jupytergis_qgis/data_defined.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/data_defined.py
@@ -218,7 +218,7 @@ def _color_instruction(scale: dict, field: str | None) -> tuple[str, Any] | None
         return ("const", value) if value is not None else None
     if scheme == "identity" and field:
         return ("field", field)
-    if scheme == "colorRamp" and field:
+    if scheme == "colorMap" and field:
         return ("expr", _colorramp_case_expr(field, _colorramp_stops(params)))
     if scheme == "categorical" and field:
         stops = params.get("colorStops")
@@ -295,7 +295,7 @@ def _ramp_meta(
     meta: dict[str, dict] = {}
     # The KDE heatmap ramp lives on the pixel-rgb encoding, outside the vector slots.
     hscale, _hfield = _find_mapping(base_rules, {"pixel-rgb"})
-    if hscale and hscale.get("scheme") == "colorRamp":
+    if hscale and hscale.get("scheme") == "colorMap":
         hparams = hscale.get("params", {})
         meta["heatmap"] = {
             "name": hparams.get("name", "viridis"),
@@ -307,7 +307,7 @@ def _ramp_meta(
             continue
         params = scale.get("params", {})
         slot = "primary" if is_primary else "outline"
-        if scale.get("scheme") == "colorRamp":
+        if scale.get("scheme") == "colorMap":
             meta[slot] = {
                 "name": params.get("name", "viridis"),
                 "reverse": bool(params.get("reverse", False)),
@@ -331,7 +331,7 @@ def grammar_layer_to_dd_symbol(
     Every encoding is resolved by geometry-aware *slot* — the primary colour (fill
     for area/point, stroke for a line), the outline colour (area/point only), the
     width and the marker radius. Each slot accepts any scale (constant / identity
-    / categorical / colorRamp) and rule-level ``when`` guards wrap the primary
+    / categorical / colorMap) and rule-level ``when`` guards wrap the primary
     colour in a nested CASE. A scale that cannot translate warns rather than
     silently dropping to black.
     """
@@ -503,7 +503,7 @@ def _parse_color_expr(
     """Classify a data-defined colour ``CASE`` expression.
 
     Returns one of:
-    - ``("colorRamp", field, color_stops)`` — all ``"f" < v`` branches (>=2),
+    - ``("colorMap", field, color_stops)`` — all ``"f" < v`` branches (>=2),
     - ``("categorical", field, color_stops)`` — all ``"f" = v`` branches (>=2),
     - ``("guarded", else_rgba, [(when, when_op, rgba), ...])`` — anything else,
     - ``None`` — not a recognised CASE (caller uses the symbol's constant colour).
@@ -536,7 +536,7 @@ def _parse_color_expr(
             stops = [
                 {"stop": float(cmp[2]), "color": rgba} for _, cmp, rgba in branches
             ]
-            return "colorRamp", field, stops
+            return "colorMap", field, stops
 
     guards: list[tuple[str, str, list[float] | None]] = []
     for when_node, _, rgba in branches:
@@ -561,7 +561,7 @@ def _color_scale_from_property(
     """Read a colour slot back into ``(scale, field, guards)``.
 
     The inverse of the export colour slot: a field reference -> identity, a
-    ``CASE`` -> categorical / colorRamp / guarded, otherwise the symbol's constant.
+    ``CASE`` -> categorical / colorMap / guarded, otherwise the symbol's constant.
     Used for both the primary and the outline colour so each round-trips with its
     own scale (not just identity). ``ramp`` is the slot's stashed ``{name, reverse}``
     (see :func:`_ramp_meta`) restoring the named ramp the baked stops can't carry.
@@ -577,11 +577,11 @@ def _color_scale_from_property(
             expr = prop.expressionString()
             if expr:
                 parsed = _parse_color_expr(expr)
-                if parsed and parsed[0] == "colorRamp":
+                if parsed and parsed[0] == "colorMap":
                     _, field, stops = parsed
                     return (
                         {
-                            "scheme": "colorRamp",
+                            "scheme": "colorMap",
                             "params": {
                                 "name": ramp_name,
                                 "nShades": len(stops),

--- a/python/jupytergis_qgis/jupytergis_qgis/grammar.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/grammar.py
@@ -141,7 +141,7 @@ def _single_band_pseudocolor_grammar(band: int, color_stops: list) -> dict[str, 
         "fields": [f"$band-{int(band)}"],
         "mappings": [
             {
-                "scale": {"scheme": "colorRamp", "params": params},
+                "scale": {"scheme": "colorMap", "params": params},
                 "encodings": ["pixel-color"],
             },
         ],
@@ -155,7 +155,7 @@ def raster_flat_color_to_grammar(color: Any) -> dict[str, Any]:
     Pre-Grammar GeoTiff layers stored symbology as an OL ``interpolate``
     expression, e.g. ``["interpolate", ["linear"], ["band", 1], stop, rgba, ...]``.
     Fold its (stop, color) pairs into a single-band pseudocolor ``pixel-color``
-    colorRamp (stops are already in normalized [0, 1] band space). Returns an
+    colorMap (stops are already in normalized [0, 1] band space). Returns an
     empty symbology state when ``color`` is not a recognised interpolate.
     """
     if not isinstance(color, list) or len(color) < 5 or color[0] != "interpolate":
@@ -309,7 +309,7 @@ def kde_grammar(
         "fields": ["$density"],
         "mappings": [
             {
-                "scale": {"scheme": "colorRamp", "params": params},
+                "scale": {"scheme": "colorMap", "params": params},
                 "encodings": ["pixel-rgb"],
             },
         ],
@@ -539,7 +539,7 @@ def _heatmap_color_ramp(grammar_layer):
     for rule in grammar_layer.get("rules", []):
         for mapping in rule.get("mappings", []):
             scale = mapping.get("scale", {})
-            if scale.get("scheme") != "colorRamp":
+            if scale.get("scheme") != "colorMap":
                 continue
             params = scale.get("params", {})
             colors = sample_colors(
@@ -726,7 +726,7 @@ def _scale_classes(
 ) -> Sequence[tuple[str | None, list]] | None:
     """Classes ``[(filter | None, rgba)]`` for a colour scale, or None.
 
-    A constant colour is a single class with no filter; colorRamp / categorical
+    A constant colour is a single class with no filter; colorMap / categorical
     expand to several filtered classes.
     """
     if not scale:
@@ -735,7 +735,7 @@ def _scale_classes(
     params = scale.get("params", {})
     if scheme == "constant_rgba":
         return [(None, params.get("value"))]
-    if scheme == "colorRamp" and field:
+    if scheme == "colorMap" and field:
         classes = _ramp_classes(field, params.get("colorStops") or [])
         if classes:
             return classes
@@ -801,7 +801,7 @@ def grammar_to_vector_tile_styles(
 ) -> list[dict[str, Any]]:
     """Vector-tile style specs from a grammar — constant colours only.
 
-    A data-driven colour (colorRamp / categorical) becomes several styles, one per
+    A data-driven colour (colorMap / categorical) becomes several styles, one per
     class, each a value filter plus a constant colour, because QGIS data-defined
     symbol colours do NOT round-trip across QGIS versions (3.40 writes them, 3.44
     drops them) while plain constant-colour styles render everywhere. A constant
@@ -872,10 +872,10 @@ def _vt_instr_to_scale(instr: tuple) -> tuple[dict | None, str | None]:
     kind = instr[0]
     if kind == "const":
         return {"scheme": "constant_rgba", "params": {"value": instr[1]}}, None
-    if kind == "colorRamp":
+    if kind == "colorMap":
         _, field, stops = instr
         return {
-            "scheme": "colorRamp",
+            "scheme": "colorMap",
             "params": {
                 "name": "custom",
                 "nShades": len(stops),
@@ -919,7 +919,7 @@ def vector_tile_grammar(
     any constant stroke width.
 
     When every geometry reconstructs to the *same* data-driven colour (QGIS export
-    splits one ungated colorRamp/categorical into a style set per geometry), the
+    splits one ungated colorMap/categorical into a style set per geometry), the
     geometries are folded back into a single ungated layer rather than emitting one
     identical rule per geometry.
     """
@@ -930,7 +930,7 @@ def vector_tile_grammar(
         for geom, slots in geom_styles.items()
         for slot, instr in slots.items()
     ]
-    data_driven = [t for t in colour_instrs if t[2][0] in ("colorRamp", "categorical")]
+    data_driven = [t for t in colour_instrs if t[2][0] in ("colorMap", "categorical")]
     if (
         len(data_driven) > 1
         and len(data_driven) == len(colour_instrs)
@@ -1052,12 +1052,12 @@ def grammar_to_raster_renderer(
     """Build a raster renderer from Grammar.
 
     ``source_min``/``source_max`` are the raster source's normalization range;
-    grammar colorRamp stops (normalized [0, 1]) are scaled back to raw values so
+    grammar colorMap stops (normalized [0, 1]) are scaled back to raw values so
     QGIS classifies on the real band range.
 
     Returns a ``QgsMultiBandColorRenderer`` for pixel-red/green/blue band
     mappings, otherwise a ``QgsSingleBandPseudoColorRenderer`` from a pixel-color
-    colorRamp. The result is ``(renderer, vmin, vmax)`` (vmin/vmax are ``None``
+    colorMap. The result is ``(renderer, vmin, vmax)`` (vmin/vmax are ``None``
     for multiband), or ``None`` when there is no recognised pixel mapping.
     """
     color_params = None
@@ -1083,7 +1083,7 @@ def grammar_to_raster_renderer(
                 scale = mapping.get("scale", {})
                 if (
                     encodings & _PIXEL_COLOR_ENCODINGS
-                    and scale.get("scheme") == "colorRamp"
+                    and scale.get("scheme") == "colorMap"
                 ):
                     color_params = scale.get("params", {})
                     if rule_band is not None:
@@ -1627,5 +1627,5 @@ def _vt_reconstruct(styles) -> tuple:
             if value is not None and (not stops or stops[-1]["stop"] != float(value)):
                 stops.append({"stop": float(value), "color": color})
         if len(stops) >= 2:
-            return ("colorRamp", field, stops)
+            return ("colorMap", field, stops)
     return ("const", _vt_style_color(styles[0]))

--- a/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
+++ b/python/jupytergis_qgis/jupytergis_qgis/tests/test_qgis.py
@@ -201,7 +201,7 @@ def test_qgis_saver():
                 "mappings": [
                     {
                         "scale": {
-                            "scheme": "colorRamp",
+                            "scheme": "colorMap",
                             "params": {
                                 "name": "viridis",
                                 "nShades": 9,
@@ -434,11 +434,11 @@ def test_qgis_saver():
     assert fields is None
     assert [round(c) for c in params["value"][:3]] == [78, 164, 208]
 
-    # Graduated -> colorRamp scale keyed on the original field.
+    # Graduated -> colorMap scale keyed on the original field.
     scheme, fields, _ = _fill_mapping(
         imported_layers[layer_ids[5]]["parameters"]["symbologyState"],
     )
-    assert scheme == "colorRamp"
+    assert scheme == "colorMap"
     assert fields == ["POP_RANK"]
 
     # Categorized line -> categorical scale on stroke-color keyed on the field.
@@ -552,7 +552,7 @@ def test_qgis_multilayer_kde_roundtrip():
                         "mappings": [
                             {
                                 "scale": {
-                                    "scheme": "colorRamp",
+                                    "scheme": "colorMap",
                                     "params": {
                                         "name": "viridis",
                                         "nShades": 9,
@@ -693,7 +693,7 @@ def test_qgis_scalar_size_and_heatmap_alpha():
                         "mappings": [
                             {
                                 "scale": {
-                                    "scheme": "colorRamp",
+                                    "scheme": "colorMap",
                                     "params": {
                                         "name": "viridis",
                                         "nShades": 9,
@@ -976,7 +976,7 @@ def test_vector_tile_colorramp_to_class_styles():
                             {
                                 "encodings": ["fill-color", "stroke-color"],
                                 "scale": {
-                                    "scheme": "colorRamp",
+                                    "scheme": "colorMap",
                                     "params": {
                                         "name": "viridis",
                                         "colorStops": [
@@ -1179,7 +1179,7 @@ def test_single_band_gray_import_has_min_max():
         grammar = grayscale_raster_to_grammar(renderer.grayBand())
         mapping = grammar["layers"][0]["rules"][0]["mappings"][0]
         assert mapping["encodings"] == ["pixel-color"]
-        assert mapping["scale"]["scheme"] == "colorRamp"
+        assert mapping["scale"]["scheme"] == "colorMap"
         # Stops/domain are normalized [0, 1] (JupyterGIS renders normalized bands);
         # raw [vmin, vmax] stops would collapse the data to one colour ("1 pixel").
         assert mapping["scale"]["params"]["domain"] == [0.0, 1.0]
@@ -1220,7 +1220,7 @@ def test_raster_colorramp_value_space_roundtrip():
                             "mappings": [
                                 {
                                     "scale": {
-                                        "scheme": "colorRamp",
+                                        "scheme": "colorMap",
                                         "params": {
                                             "domain": [0.0, 1.0],
                                             "colorStops": [
@@ -1294,7 +1294,7 @@ def test_raster_flat_color_to_grammar_migrates_legacy_ramp():
     assert rule["fields"] == ["$band-1"]
     mapping = rule["mappings"][0]
     assert mapping["encodings"] == ["pixel-color"]
-    assert mapping["scale"]["scheme"] == "colorRamp"
+    assert mapping["scale"]["scheme"] == "colorMap"
     stops = mapping["scale"]["params"]["colorStops"]
     # Stops (already normalized [0, 1]) pass straight through, transparent 0 kept.
     assert [s["stop"] for s in stops] == [0.0, 0.0, 0.5, 1.0]
@@ -1348,7 +1348,7 @@ def _mapping_for_encoding(grammar_layer, encoding):
 
 
 def test_graduated_roundtrip():
-    """ColorRamp fill with materialized stops -> native graduated -> colorRamp.
+    """ColorRamp fill with materialized stops -> native graduated -> colorMap.
 
     Graduated layers export as a native QgsGraduatedSymbolRenderer (not rule-based)
     so the exact class breaks survive the round-trip on all QGIS versions.
@@ -1361,7 +1361,7 @@ def test_graduated_roundtrip():
                 "mappings": [
                     {
                         "scale": {
-                            "scheme": "colorRamp",
+                            "scheme": "colorMap",
                             "params": {
                                 "name": "viridis",
                                 "nShades": 2,
@@ -1383,7 +1383,7 @@ def test_graduated_roundtrip():
     )["layers"][0]
     out, logs = _roundtrip_layer(layer, "fill")
     scheme, params, fields, _ = _mapping_for_encoding(out, "fill-color")
-    assert scheme == "colorRamp"
+    assert scheme == "colorMap"
     assert fields == ["pop"]
     assert [s["stop"] for s in params["colorStops"]] == [0.0, 5.0, 10.0]
     assert logs["warnings"] == []
@@ -1603,7 +1603,7 @@ def test_line_colorramp_mixed_encodings_roundtrip():
                     {
                         "encodings": ["stroke-color", "circle-fill-color"],
                         "scale": {
-                            "scheme": "colorRamp",
+                            "scheme": "colorMap",
                             "params": {
                                 "name": "viridis",
                                 "nShades": 2,
@@ -1623,7 +1623,7 @@ def test_line_colorramp_mixed_encodings_roundtrip():
     )["layers"][0]
     out, logs = _roundtrip_layer(layer, "line")
     scheme, _params, fields, _when = _mapping_for_encoding(out, "stroke-color")
-    assert scheme == "colorRamp"
+    assert scheme == "colorMap"
     assert fields == ["length_km"]
     # The line has no fill, so the ramp must NOT have landed on fill-color.
     assert _mapping_for_encoding(out, "fill-color")[0] is None
@@ -1661,7 +1661,7 @@ def test_roads_when_colorramp_and_constant_roundtrip(tmp_path):
                     {
                         "encodings": ["stroke-color", "circle-fill-color"],
                         "scale": {
-                            "scheme": "colorRamp",
+                            "scheme": "colorMap",
                             "params": {
                                 "name": "viridis",
                                 "domain": [0.0, 1583.0],
@@ -1746,7 +1746,7 @@ def test_roads_when_colorramp_and_constant_roundtrip(tmp_path):
         by_continent["Asia"],
         "stroke-color",
     )
-    assert scheme == "colorRamp"
+    assert scheme == "colorMap"
     assert fields == ["length_km"]
     # Africa: constant green stroke colour preserved.
     a_scheme, a_params, _f, _w = _mapping_for_encoding(
@@ -1905,7 +1905,7 @@ def test_colorramp_name_survives_reopen(tmp_path):
                                         "mappings": [
                                             {
                                                 "scale": {
-                                                    "scheme": "colorRamp",
+                                                    "scheme": "colorMap",
                                                     "params": {
                                                         "name": "plasma",
                                                         "nShades": 3,
@@ -1975,7 +1975,7 @@ def test_colorramp_name_survives_reopen(tmp_path):
     layer = next(iter(reimported["layers"].values()))
     state = layer["parameters"]["symbologyState"]
     scheme, params, fields, _ = _mapping_for_encoding(state["layers"][0], "fill-color")
-    assert scheme == "colorRamp"
+    assert scheme == "colorMap"
     assert fields == ["pop"]
     # The picker's ramp name + direction are restored, not defaulted to viridis.
     assert params["name"] == "plasma"
@@ -2000,7 +2000,7 @@ def test_heatmap_ramp_only_first_stop_transparent():
                     {
                         "encodings": ["pixel-rgb"],
                         "scale": {
-                            "scheme": "colorRamp",
+                            "scheme": "colorMap",
                             "params": {"name": "viridis", "reverse": False},
                         },
                     },
@@ -2017,7 +2017,7 @@ def test_heatmap_ramp_only_first_stop_transparent():
 
 
 def _vector_tile_ramp_jgis(lid, sid, line_stroke_rgba, stroke_width):
-    """A vector tile with a Polygon colorRamp + width and a LineString stroke."""
+    """A vector tile with a Polygon colorMap + width and a LineString stroke."""
     state = {
         "layers": [
             {
@@ -2031,7 +2031,7 @@ def _vector_tile_ramp_jgis(lid, sid, line_stroke_rgba, stroke_width):
                             {
                                 "encodings": ["fill-color", "stroke-color"],
                                 "scale": {
-                                    "scheme": "colorRamp",
+                                    "scheme": "colorMap",
                                     "params": {
                                         "name": "viridis",
                                         "colorStops": [
@@ -2141,7 +2141,7 @@ def test_vector_tile_colorramp_width_alpha_roundtrip():
         if gl.get("when", [{}])[0].get("value") == "Polygon"
     )
     scheme, params, fields, _ = _mapping_for_encoding(polygon, "fill-color")
-    assert scheme == "colorRamp"
+    assert scheme == "colorMap"
     assert fields == ["best_age_top"]
     stops = params["colorStops"]
     # The first stop (value == 1) survives and is not collapsed into the next.


### PR DESCRIPTION
## Description

Rename *colorRamp* acheme name to *colorMap* for Frontend.

- Closes #1723 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1727.org.readthedocs.build/en/1727/
💡 JupyterLite preview: https://jupytergis--1727.org.readthedocs.build/en/1727/lite
💡 Specta preview: https://jupytergis--1727.org.readthedocs.build/en/1727/lite/specta

<!-- readthedocs-preview jupytergis end -->