### PR TITLE
Fix undo/redo in markdown editor

### DIFF
--- a/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
+++ b/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
@@ -83,6 +83,45 @@ export function SegmentMarkdownEditor({
 
     host.addEventListener('paste', onPaste);
 
+    // Route undo/redo through Yjs (browser historyUndo only covers typing).
+    host.dataset.jpUndoer = 'true';
+
+    const onKeyDownCapture = (event: KeyboardEvent): void => {
+      const mod = event.ctrlKey || event.metaKey;
+      if (!mod || event.altKey) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+      const isUndo = key === 'z' && !event.shiftKey;
+      const isRedo = (key === 'z' && event.shiftKey) || key === 'y';
+
+      if (!isUndo && !isRedo) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (isUndo) {
+        editor.undo();
+      } else {
+        editor.redo();
+      }
+    };
+
+    const onBeforeInputCapture = (event: InputEvent): void => {
+      if (
+        event.inputType === 'historyUndo' ||
+        event.inputType === 'historyRedo'
+      ) {
+        event.preventDefault();
+      }
+    };
+
+    host.addEventListener('keydown', onKeyDownCapture, true);
+    host.addEventListener('beforeinput', onBeforeInputCapture, true);
+
     const refreshPreview = (): void => {
       setPreviewMarkdown(sharedModel.getSource());
     };
@@ -92,6 +131,8 @@ export function SegmentMarkdownEditor({
 
     return () => {
       host.removeEventListener('paste', onPaste);
+      host.removeEventListener('keydown', onKeyDownCapture, true);
+      host.removeEventListener('beforeinput', onBeforeInputCapture, true);
       sharedModel.changed.disconnect(refreshPreview);
       editor.dispose();
       editorRef.current = null;

--- a/packages/base/src/features/story/utils/storySegmentMarkdownSharedModel.ts
+++ b/packages/base/src/features/story/utils/storySegmentMarkdownSharedModel.ts
@@ -174,9 +174,12 @@ function ensureParameterSync(
   synced.add(segmentId);
 
   const debouncedSync = debounce(() => {
-    updateSegmentContent(model, segmentId, {
-      markdown: shared.getSource(),
-    });
+    // Mirror Y.Text into layer parameters without polluting the undo stack.
+    model.sharedModel.transact(() => {
+      updateSegmentContent(model, segmentId, {
+        markdown: shared.getSource(),
+      });
+    }, false);
   }, PARAMETER_SYNC_DEBOUNCE_MS);
 
   shared.changed.connect(() => {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Close #1736 

Allow undo/redo to work in markdown editor. 

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1742.org.readthedocs.build/en/1742/
💡 JupyterLite preview: https://jupytergis--1742.org.readthedocs.build/en/1742/lite
💡 Specta preview: https://jupytergis--1742.org.readthedocs.build/en/1742/lite/specta

<!-- readthedocs-preview jupytergis end -->