### PR TITLE
Add default extent when creating new jgis

### DIFF
--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -34,6 +34,12 @@ import { migrateDocument } from './migrations';
 
 export const DEFAULT_PROJECTION = 'EPSG:3857';
 
+/** Whole-world extent in EPSG:3857 (Default projection). */
+export const DEFAULT_WORLD_EXTENT_3857: [number, number, number, number] = [
+  -20037508.342789244, -20037508.342789244, 20037508.342789244,
+  20037508.342789244,
+];
+
 /** Default JSON content for a new JupyterGIS document. */
 export const DEFAULT_JGIS_DOCUMENT_CONTENT = `{
 	"schemaVersion": "${SCHEMA_VERSION}",
@@ -41,7 +47,7 @@ export const DEFAULT_JGIS_DOCUMENT_CONTENT = `{
 	"sources": {},
   "stories": {},
   "viewState": {},
-	"options": {"latitude": 0, "longitude": 0, "zoom": 0, "bearing": 0, "pitch": 0, "projection": "${DEFAULT_PROJECTION}"},
+	"options": {"latitude": 0, "longitude": 0, "zoom": 0, "bearing": 0, "pitch": 0, "projection": "${DEFAULT_PROJECTION}", "extent": [${DEFAULT_WORLD_EXTENT_3857.join(', ')}]},
 	"layerTree": [],
 	"annotations": {},
 	"presets": {},

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -21,7 +21,11 @@ import {
   IJGISStoryMap,
 } from './_interface/project/jgis';
 import { IStorySegmentLayer } from './_interface/project/layers/storySegmentLayer';
-import { DEFAULT_PROJECTION, JupyterGISDoc } from './doc';
+import {
+  DEFAULT_PROJECTION,
+  DEFAULT_WORLD_EXTENT_3857,
+  JupyterGISDoc,
+} from './doc';
 import {
   AWARENESS_FIELD_KEYS,
   AWARENESS_STATE_FIELDS,
@@ -428,6 +432,7 @@ export class JupyterGISModel implements IJupyterGISModel {
         bearing: 0,
         pitch: 0,
         projection: DEFAULT_PROJECTION,
+        extent: [...DEFAULT_WORLD_EXTENT_3857],
       };
       this.sharedModel.annotations = jsonData.annotations ?? {};
       this.sharedModel.presets = jsonData.presets ?? {};
@@ -947,7 +952,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     const zoom = state?.zoom;
     const { storyId } = this.getSelectedStory();
 
-    if (!zoom || !extent) {
+    if (zoom === undefined || !extent) {
       console.warn('No extent or zoom found');
       return null;
     }


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Close #1738 

The issue was that new files didn't have an extent so `addStorySegment` would bail early, but any type of resizing would set the extent which is why adding a segment would work after resizing. 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1743.org.readthedocs.build/en/1743/
💡 JupyterLite preview: https://jupytergis--1743.org.readthedocs.build/en/1743/lite
💡 Specta preview: https://jupytergis--1743.org.readthedocs.build/en/1743/lite/specta

<!-- readthedocs-preview jupytergis end -->