### PR TITLE
Remove legacy code from when we had titles in segments

### DIFF
--- a/packages/base/src/features/story/StoryViewerPanel.tsx
+++ b/packages/base/src/features/story/StoryViewerPanel.tsx
@@ -155,7 +155,7 @@ function StoryViewerPanel({
           <h1 className="jgis-story-viewer-title">
             {layerName ?? `Slide ${currentIndex + 1}`}
           </h1>
-          {activeSlide?.content?.image && imageLoaded ? (
+          {(activeSlide?.content?.image && imageLoaded) ?? (
             <StoryImageSection
               imageUrl={activeSlide.content.image}
               imageLoaded={imageLoaded}
@@ -163,16 +163,7 @@ function StoryViewerPanel({
               slideNumber={currentIndex}
               navSlot={navPlacement === 'over-image' ? navSlot : null}
             />
-          ) : (
-            <StoryTitleSection
-              title={storyData.title ?? ''}
-              navSlot={navPlacement === 'below-title' ? navSlot : null}
-            />
           )}
-          <StorySubtitleSection
-            title={activeSlide?.content?.title ?? ''}
-            navSlot={navPlacement === 'subtitle-specta' ? navSlot : null}
-          />
         </div>
         <div id="jgis-story-segment-content">
           <RenderedStoryMarkdown

--- a/packages/base/src/features/story/StoryViewerPanel.tsx
+++ b/packages/base/src/features/story/StoryViewerPanel.tsx
@@ -155,7 +155,7 @@ function StoryViewerPanel({
           <h1 className="jgis-story-viewer-title">
             {layerName ?? `Slide ${currentIndex + 1}`}
           </h1>
-          {(activeSlide?.content?.image && imageLoaded) ?? (
+          {(activeSlide?.content?.image && imageLoaded) ? (
             <StoryImageSection
               imageUrl={activeSlide.content.image}
               imageLoaded={imageLoaded}
@@ -163,7 +163,7 @@ function StoryViewerPanel({
               slideNumber={currentIndex}
               navSlot={navPlacement === 'over-image' ? navSlot : null}
             />
-          )}
+          ) : null}
         </div>
         <div id="jgis-story-segment-content">
           <RenderedStoryMarkdown

--- a/packages/schema/src/schema/project/layers/storySegmentLayer.json
+++ b/packages/schema/src/schema/project/layers/storySegmentLayer.json
@@ -26,11 +26,6 @@
           "enum": ["map", "markdown"],
           "default": "map"
         },
-        "title": {
-          "title": "Segment Title",
-          "type": "string",
-          "default": ""
-        },
         "image": {
           "type": "string",
           "description": "Link to image for the story",


### PR DESCRIPTION
## Description

Also remove the story title from the map segments, this seems like it was unintended?

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1745.org.readthedocs.build/en/1745/
💡 JupyterLite preview: https://jupytergis--1745.org.readthedocs.build/en/1745/lite
💡 Specta preview: https://jupytergis--1745.org.readthedocs.build/en/1745/lite/specta

<!-- readthedocs-preview jupytergis end -->