### PR TITLE
Fix symbology stops so classification does not require "Classify"

### DIFF
--- a/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
+++ b/packages/base/src/features/layers/symbology/__tests__/grammarToOLStyle.spec.ts
@@ -20,6 +20,7 @@ import { IGrammarSymbologyState } from '@jupytergis/schema';
 
 import {
   extractEncodingFieldValues,
+  extractFieldColumns,
   grammarToOLStyle,
 } from '../grammarToOLStyle';
 
@@ -814,5 +815,79 @@ describe('extractEncodingFieldValues', () => {
       ],
     });
     expect(extractEncodingFieldValues(fieldlessState, rows)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-field feature values
+// ---------------------------------------------------------------------------
+
+describe('grammarToOLStyle — per-field feature values', () => {
+  const rows = [
+    { kind: 'road', surface: 'gravel' },
+    { kind: 'river', surface: 'gravel' },
+    { kind: 'lake', surface: 'tarmac' },
+  ];
+
+  /** Two rules classifying on two different fields. */
+  const twoFieldState: IGrammarSymbologyState = {
+    layers: [
+      {
+        id: 'test-layer',
+        rules: [
+          {
+            id: '1',
+            fields: ['kind'],
+            mappings: [
+              {
+                scale: {
+                  scheme: 'categorical',
+                  params: { colorRamp: 'viridis', fallback: [0, 0, 0, 0] },
+                },
+                encodings: ['fill-color'],
+              },
+            ],
+          },
+          {
+            id: '2',
+            fields: ['surface'],
+            mappings: [
+              {
+                scale: {
+                  scheme: 'categorical',
+                  params: { colorRamp: 'viridis', fallback: [0, 0, 0, 0] },
+                },
+                encodings: ['stroke-color'],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('extracts one column per classified field', () => {
+    expect(extractFieldColumns(twoFieldState, rows)).toEqual({
+      kind: ['road', 'river', 'lake'],
+      surface: ['gravel', 'gravel', 'tarmac'],
+    });
+  });
+
+  it('classifies each rule against its own field', () => {
+    const style = grammarToOLStyle(
+      twoFieldState,
+      extractFieldColumns(twoFieldState, rows),
+    ) as any;
+
+    // kind has 3 unique values, surface has 2 — a shared column would give
+    // both the same branch count.
+    expect(style['fill-color'].length).toBe(1 + 2 * 3 + 1);
+    expect(style['stroke-color'].length).toBe(1 + 2 * 2 + 1);
+  });
+
+  it('still accepts a flat column, applying it to every field', () => {
+    const style = grammarToOLStyle(twoFieldState, ['a', 'b']) as any;
+    expect(style['fill-color'].length).toBe(1 + 2 * 2 + 1);
+    expect(style['stroke-color'].length).toBe(1 + 2 * 2 + 1);
   });
 });

--- a/packages/base/src/features/layers/symbology/__tests__/resolveStops.spec.ts
+++ b/packages/base/src/features/layers/symbology/__tests__/resolveStops.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the shared stop resolvers.
+ *
+ * These cover the contract the style compiler, the editor preview and the
+ * legend all depend on: stops are derived from the data unless the user pinned
+ * them by hand, and the derivation is identical for all three callers.
+ */
+
+jest.mock('ol/expr/expression', () => ({}));
+jest.mock('ol/style/flat', () => ({}));
+jest.mock('@jupytergis/schema', () => ({}));
+jest.mock('geotiff', () => ({ Pool: class {}, fromUrl: jest.fn() }));
+jest.mock('@/src/tools', () => ({ objectEntries: Object.entries }));
+
+import {
+  ICategoricalScaleParams,
+  IColorMapScaleParams,
+  IGrammarSymbologyState,
+  IScalarScaleParams,
+} from '@jupytergis/schema';
+
+import {
+  colorMapClassCount,
+  deriveColorMapStops,
+  grammarNeedsFeatureValues,
+  resolveCategoricalStops,
+  resolveColorMapStops,
+  resolveScalarStops,
+} from '../resolveStops';
+
+const colorMapParams = (
+  overrides: Partial<IColorMapScaleParams> = {},
+): IColorMapScaleParams => ({
+  name: 'viridis',
+  nShades: 5,
+  mode: 'equal interval',
+  reverse: false,
+  fallback: [0, 0, 0, 0],
+  ...overrides,
+});
+
+const categoricalParams = (
+  overrides: Partial<ICategoricalScaleParams> = {},
+): ICategoricalScaleParams => ({
+  colorRamp: 'viridis',
+  fallback: [0, 0, 0, 0],
+  ...overrides,
+});
+
+const scalarParams = (
+  overrides: Partial<IScalarScaleParams> = {},
+): IScalarScaleParams => ({
+  domain: [0, 100],
+  range: [1, 10],
+  fallback: 1,
+  ...overrides,
+});
+
+describe('resolveColorMapStops', () => {
+  it('classifies from feature values when no stops are persisted', () => {
+    const stops = resolveColorMapStops(colorMapParams(), [0, 25, 50, 75, 100]);
+
+    expect(stops.length).toBeGreaterThanOrEqual(2);
+    expect(stops[0].stop).toBe(0);
+    expect(stops[stops.length - 1].stop).toBe(100);
+  });
+
+  it('classifies from the domain alone when no feature values are available', () => {
+    // The vector-tile case: the full feature population is never loaded, so an
+    // explicit domain is the only stable way to classify.
+    const stops = resolveColorMapStops(
+      colorMapParams({ domain: [30, 110] }),
+      [],
+    );
+
+    expect(stops.length).toBeGreaterThanOrEqual(2);
+    expect(stops[0].stop).toBe(30);
+    expect(stops[stops.length - 1].stop).toBe(110);
+  });
+
+  it('returns nothing when there is neither data nor a domain', () => {
+    expect(resolveColorMapStops(colorMapParams(), [])).toEqual([]);
+  });
+
+  it('prefers persisted stops over the data', () => {
+    const colorStops = [
+      { stop: 1, color: [1, 2, 3, 1] as [number, number, number, number] },
+      { stop: 2, color: [4, 5, 6, 1] as [number, number, number, number] },
+    ];
+    expect(
+      resolveColorMapStops(colorMapParams({ colorStops }), [0, 50, 100]),
+    ).toBe(colorStops);
+  });
+
+  it('ignores a single persisted stop, which cannot drive an interpolation', () => {
+    const stops = resolveColorMapStops(
+      colorMapParams({
+        domain: [0, 10],
+        colorStops: [{ stop: 1, color: [1, 2, 3, 1] }],
+      }),
+      [],
+    );
+    expect(stops.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('colorMapClassCount', () => {
+  it('passes nShades through for ramps with no minimum', () => {
+    expect(colorMapClassCount(colorMapParams({ nShades: 3 }))).toBe(3);
+  });
+
+  it('clamps to the ramp minimum so the preview and the map agree', () => {
+    // The Classes input is unclamped, so a ramp with a documented minimum has
+    // to be clamped wherever stops are derived — not just in the editor.
+    const params = colorMapParams({ name: 'hsv', nShades: 3 });
+    expect(colorMapClassCount(params)).toBeGreaterThan(3);
+    expect(deriveColorMapStops(params, [0, 100]).length).toBe(
+      colorMapClassCount(params) + 1,
+    );
+  });
+});
+
+describe('resolveCategoricalStops', () => {
+  it('enumerates categories from the data when no stops are persisted', () => {
+    const stops = resolveCategoricalStops(categoricalParams(), [
+      'a',
+      'b',
+      'a',
+      'c',
+    ]);
+    expect(stops.map(s => s.stop)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns nothing without data — categories are unknowable', () => {
+    expect(resolveCategoricalStops(categoricalParams(), [])).toEqual([]);
+  });
+
+  it('prefers persisted stops over the data', () => {
+    const colorStops = [
+      { stop: 'x', color: [1, 2, 3, 1] as [number, number, number, number] },
+    ];
+    expect(
+      resolveCategoricalStops(categoricalParams({ colorStops }), ['a', 'b']),
+    ).toBe(colorStops);
+  });
+});
+
+describe('resolveScalarStops', () => {
+  it('uses the domain and range endpoints when no stops are persisted', () => {
+    expect(resolveScalarStops(scalarParams())).toEqual([
+      { stop: 0, output: 1 },
+      { stop: 100, output: 10 },
+    ]);
+  });
+
+  it('prefers persisted stops', () => {
+    const scalarStops = [
+      { stop: 0, output: 5 },
+      { stop: 1, output: 6 },
+    ];
+    expect(resolveScalarStops(scalarParams({ scalarStops }))).toBe(scalarStops);
+  });
+});
+
+describe('grammarNeedsFeatureValues', () => {
+  const stateWith = (scale: any): IGrammarSymbologyState => ({
+    layers: [
+      {
+        id: 'l',
+        rules: [
+          { id: 'r', fields: ['speed'], mappings: [{ scale, encodings: [] }] },
+        ],
+      },
+    ],
+  });
+
+  it('is true for a colorMap with no persisted stops', () => {
+    expect(
+      grammarNeedsFeatureValues(
+        stateWith({ scheme: 'colorMap', params: colorMapParams() }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false once the colorMap stops are pinned', () => {
+    expect(
+      grammarNeedsFeatureValues(
+        stateWith({
+          scheme: 'colorMap',
+          params: colorMapParams({
+            colorStops: [
+              { stop: 0, color: [0, 0, 0, 1] },
+              { stop: 1, color: [1, 1, 1, 1] },
+            ],
+          }),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false for scales with no data dependency', () => {
+    expect(
+      grammarNeedsFeatureValues(
+        stateWith({ scheme: 'scalar', params: scalarParams() }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false for an absent state', () => {
+    expect(grammarNeedsFeatureValues(undefined)).toBe(false);
+  });
+});

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -49,10 +49,10 @@ import RgbaColorPicker, {
 } from '@/src/features/layers/symbology/components/color_ramp/RgbaColorPicker';
 import StopContainer from '@/src/features/layers/symbology/components/color_stops/StopContainer';
 import {
-  computeCategorizedColorStops,
-  computeGraduatedColorStops,
-  IComputedStop,
-} from '@/src/features/layers/symbology/styleBuilder';
+  deriveCategoricalStops,
+  deriveColorMapStops,
+  deriveScalarStops,
+} from '@/src/features/layers/symbology/resolveStops';
 import { IStopRow } from '@/src/features/layers/symbology/symbologyDialog';
 import { ErrorTip } from '@/src/shared/components/ErrorTip';
 import { InfoTip } from '@/src/shared/components/InfoTip';
@@ -185,33 +185,14 @@ export const ColorMapEditor: React.FC<IColorMapEditorProps> = ({
     if (!field) {
       return [];
     }
-    const values = Array.from(featureValues[field] ?? []).filter(
-      (v): v is number => Number.isFinite(v),
-    );
-    if (values.length === 0) {
-      return [];
-    }
-
-    const minRequired = COLOR_RAMP_DEFAULTS[params.name as ColorRampName];
-    const nClasses = minRequired
-      ? Math.max(params.nShades ?? minRequired, minRequired)
-      : params.nShades;
-
-    const computed: IComputedStop[] = computeGraduatedColorStops(
-      {
-        renderType: 'Graduated',
-        nClasses,
-        mode: params.mode as any,
-        colorRamp: params.name,
-        reverseRamp: params.reverse,
-        vmin: params.domain?.[0],
-        vmax: params.domain?.[1],
-      } as any,
-      values,
-    );
-    return computed.map(s => ({
+    const values = Array.from(featureValues[field] ?? []);
+    // Not short-circuiting on an empty column: with a fully specified domain
+    // the classification is derivable without any data, which is how a vector
+    // tile layer classifies. Bailing here would show an empty table over a
+    // classified map.
+    return deriveColorMapStops(params, values).map(s => ({
       id: UUID.uuid4(),
-      stop: s.value as number,
+      stop: s.stop,
       output: s.color as RgbaColor,
     }));
   }, [
@@ -380,20 +361,9 @@ export const CategoricalEditor: React.FC<ICategoricalEditorProps> = ({
       return [];
     }
     const values = Array.from(featureValues[field] ?? []);
-    if (values.length === 0) {
-      return [];
-    }
-    const computed: IComputedStop[] = computeCategorizedColorStops(
-      {
-        renderType: 'Categorized',
-        colorRamp: params.colorRamp,
-        reverseRamp: params.reverse ?? false,
-      } as any,
-      values,
-    );
-    return computed.map(s => ({
+    return deriveCategoricalStops(params, values).map(s => ({
       id: UUID.uuid4(),
-      stop: s.value as string | number,
+      stop: s.stop,
       output: s.color as RgbaColor,
     }));
   }, [field, featureValues, params.colorRamp, params.reverse]);
@@ -840,10 +810,12 @@ export const ScalarEditor: React.FC<IScalarEditorProps> = ({
   }, [params, onChange]);
 
   const derivedRows = useMemo<IStopRow[]>(
-    () => [
-      { id: UUID.uuid4(), stop: params.domain[0], output: params.range[0] },
-      { id: UUID.uuid4(), stop: params.domain[1], output: params.range[1] },
-    ],
+    () =>
+      deriveScalarStops(params).map(s => ({
+        id: UUID.uuid4(),
+        stop: s.stop,
+        output: s.output,
+      })),
     [params.domain, params.range],
   );
 

--- a/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
+++ b/packages/base/src/features/layers/symbology/components/ScaleEditor.tsx
@@ -29,7 +29,13 @@ import {
 import { jupyterTheme } from '@jupyterlab/codemirror';
 import { UUID } from '@lumino/coreutils';
 import { py2vega } from 'py2vega-ts';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { vega2ol, FUNCTION_MAPPING, CONSTANTS_MAPPING } from 'vega2ol';
 
 import {
@@ -136,8 +142,10 @@ export const ColorMapEditor: React.FC<IColorMapEditorProps> = ({
   onChange,
 }) => {
   const { params } = scale;
-  const [stopRows, setStopRows] = useState<IStopRow[]>(
-    params.colorStops ? stopsToRows(params.colorStops) : [],
+  // Manually edited stops, which are persisted to the document. `null` means the
+  // user has not overridden anything, so the classification stays data-driven.
+  const [overrideRows, setOverrideRows] = useState<IStopRow[] | null>(
+    params.colorStops ? stopsToRows(params.colorStops) : null,
   );
 
   const update = useCallback(
@@ -145,6 +153,12 @@ export const ColorMapEditor: React.FC<IColorMapEditorProps> = ({
       onChange({ scheme: 'colorMap', params: { ...params, ...patch } }),
     [params, onChange],
   );
+
+  // Drop persisted stops so the layer falls back to the data-driven path.
+  const clearStops = useCallback(() => {
+    const { colorStops: _, ...rest } = params;
+    onChange({ scheme: 'colorMap', params: rest });
+  }, [params, onChange]);
 
   // Auto-populate domain from data when the field is known and domain is unset.
   useEffect(() => {
@@ -164,13 +178,19 @@ export const ColorMapEditor: React.FC<IColorMapEditorProps> = ({
     }
   }, [field, featureValues]); // intentionally omits `update` to avoid loop
 
-  const classify = () => {
+  // Preview of the classification the renderer derives from the data currently
+  // available. Recomputed as features load, so the editor stays in sync with the
+  // map without the user having to press Classify.
+  const derivedRows = useMemo<IStopRow[]>(() => {
     if (!field) {
-      return;
+      return [];
     }
     const values = Array.from(featureValues[field] ?? []).filter(
       (v): v is number => Number.isFinite(v),
     );
+    if (values.length === 0) {
+      return [];
+    }
 
     const minRequired = COLOR_RAMP_DEFAULTS[params.name as ColorRampName];
     const nClasses = minRequired
@@ -189,22 +209,37 @@ export const ColorMapEditor: React.FC<IColorMapEditorProps> = ({
       } as any,
       values,
     );
-    const rows = computed.map(s => ({
+    return computed.map(s => ({
       id: UUID.uuid4(),
       stop: s.value as number,
       output: s.color as RgbaColor,
     }));
-    setStopRows(rows);
-    update({
-      colorStops: computed.map(s => ({
-        stop: s.value as number,
-        color: s.color as RGBA,
-      })),
-    });
+  }, [
+    field,
+    featureValues,
+    params.name,
+    params.nShades,
+    params.mode,
+    params.reverse,
+    params.domain,
+  ]);
+
+  const stopRows = overrideRows ?? derivedRows;
+
+  // Classify only refreshes the preview: it discards any manual override so the
+  // classification goes back to being computed from the data at render time.
+  const classify = () => {
+    if (!field) {
+      return;
+    }
+    setOverrideRows(null);
+    if (params.colorStops) {
+      clearStops();
+    }
   };
 
   const handleStopRowsChange = (rows: IStopRow[]) => {
-    setStopRows(rows);
+    setOverrideRows(rows);
     update({
       colorStops: rowsToColorStops(rows) as Array<{
         stop: number;
@@ -294,6 +329,7 @@ export const ColorMapEditor: React.FC<IColorMapEditorProps> = ({
           selectedMethod="color"
           stopRows={stopRows}
           setStopRows={handleStopRowsChange}
+          numericStops
         />
       )}
     </div>
@@ -319,10 +355,11 @@ export const CategoricalEditor: React.FC<ICategoricalEditorProps> = ({
 }) => {
   const { params } = scale;
 
-  const initialRows: IStopRow[] = params.colorStops
-    ? stopsToRows(params.colorStops)
-    : [];
-  const [stopRows, setStopRows] = useState<IStopRow[]>(initialRows);
+  // Manually edited stops, which are persisted to the document. `null` means the
+  // user has not overridden anything, so the categories stay data-driven.
+  const [overrideRows, setOverrideRows] = useState<IStopRow[] | null>(
+    params.colorStops ? stopsToRows(params.colorStops) : null,
+  );
 
   const update = useCallback(
     (patch: Partial<ICategoricalScale['params']>) =>
@@ -330,11 +367,22 @@ export const CategoricalEditor: React.FC<ICategoricalEditorProps> = ({
     [params, onChange],
   );
 
-  const classify = () => {
+  // Drop persisted stops so the layer falls back to the data-driven path.
+  const clearStops = useCallback(() => {
+    const { colorStops: _, ...rest } = params;
+    onChange({ scheme: 'categorical', params: rest });
+  }, [params, onChange]);
+
+  // Preview of the categories the renderer enumerates from the data currently
+  // available. Recomputed as features load.
+  const derivedRows = useMemo<IStopRow[]>(() => {
     if (!field) {
-      return;
+      return [];
     }
     const values = Array.from(featureValues[field] ?? []);
+    if (values.length === 0) {
+      return [];
+    }
     const computed: IComputedStop[] = computeCategorizedColorStops(
       {
         renderType: 'Categorized',
@@ -343,22 +391,29 @@ export const CategoricalEditor: React.FC<ICategoricalEditorProps> = ({
       } as any,
       values,
     );
-    const rows = computed.map(s => ({
+    return computed.map(s => ({
       id: UUID.uuid4(),
       stop: s.value as string | number,
       output: s.color as RgbaColor,
     }));
-    setStopRows(rows);
-    update({
-      colorStops: computed.map(s => ({
-        stop: s.value as string | number,
-        color: s.color as RGBA,
-      })),
-    });
+  }, [field, featureValues, params.colorRamp, params.reverse]);
+
+  const stopRows = overrideRows ?? derivedRows;
+
+  // Classify only refreshes the preview: it discards any manual override so the
+  // categories go back to being enumerated from the data at render time.
+  const classify = () => {
+    if (!field) {
+      return;
+    }
+    setOverrideRows(null);
+    if (params.colorStops) {
+      clearStops();
+    }
   };
 
   const handleStopRowsChange = (rows: IStopRow[]) => {
-    setStopRows(rows);
+    setOverrideRows(rows);
     update({ colorStops: rowsToColorStops(rows) });
   };
 
@@ -765,36 +820,46 @@ export const ScalarEditor: React.FC<IScalarEditorProps> = ({
     [params, onChange],
   );
 
-  const [stopRows, setStopRows] = useState<IStopRow[]>(
+  // Manually edited stops, which are persisted to the document. `null` means the
+  // user has not overridden anything, so the endpoints stay derived from
+  // domain/range — which is exactly what the renderer falls back to.
+  const [overrideRows, setOverrideRows] = useState<IStopRow[] | null>(
     params.scalarStops
       ? params.scalarStops.map(s => ({
           id: UUID.uuid4(),
           stop: s.stop,
           output: s.output,
         }))
-      : [],
+      : null,
   );
 
+  // Drop persisted stops so the layer falls back to plain domain/range interpolation.
+  const clearStops = useCallback(() => {
+    const { scalarStops: _, ...rest } = params;
+    onChange({ scheme: 'scalar', params: rest });
+  }, [params, onChange]);
+
+  const derivedRows = useMemo<IStopRow[]>(
+    () => [
+      { id: UUID.uuid4(), stop: params.domain[0], output: params.range[0] },
+      { id: UUID.uuid4(), stop: params.domain[1], output: params.range[1] },
+    ],
+    [params.domain, params.range],
+  );
+
+  const stopRows = overrideRows ?? derivedRows;
+
+  // "Set stops" only refreshes the preview: it discards any manual override so
+  // the mapping goes back to interpolating between domain and range.
   const classify = () => {
-    const inMin = params.domain[0];
-    const inMax = params.domain[1];
-    const outMin = params.range[0];
-    const outMax = params.range[1];
-    const rows: IStopRow[] = [
-      { id: UUID.uuid4(), stop: inMin, output: outMin },
-      { id: UUID.uuid4(), stop: inMax, output: outMax },
-    ];
-    setStopRows(rows);
-    update({
-      scalarStops: [
-        { stop: inMin, output: outMin },
-        { stop: inMax, output: outMax },
-      ],
-    });
+    setOverrideRows(null);
+    if (params.scalarStops) {
+      clearStops();
+    }
   };
 
   const handleStopRowsChange = (rows: IStopRow[]) => {
-    setStopRows(rows);
+    setOverrideRows(rows);
     update({
       scalarStops: rows.map(r => ({
         stop: r.stop as number,

--- a/packages/base/src/features/layers/symbology/components/color_stops/StopContainer.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_stops/StopContainer.tsx
@@ -9,12 +9,15 @@ interface IStopContainerProps {
   selectedMethod: string;
   stopRows: IStopRow[];
   setStopRows: (stops: IStopRow[]) => void;
+  /** Stop (input) values are numeric — see StopRow's `numericStops`. */
+  numericStops?: boolean;
 }
 
 const StopContainer: React.FC<IStopContainerProps> = ({
   selectedMethod,
   stopRows,
   setStopRows,
+  numericStops,
 }) => {
   const addStopRow = () => {
     setStopRows([
@@ -51,6 +54,7 @@ const StopContainer: React.FC<IStopContainerProps> = ({
             setStopRows={setStopRows}
             deleteRow={() => deleteStopRow(index)}
             useNumber={selectedMethod === 'radius' ? true : false}
+            numericStops={numericStops}
           />
         ))}
       </div>

--- a/packages/base/src/features/layers/symbology/components/color_stops/StopRow.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_stops/StopRow.tsx
@@ -25,6 +25,13 @@ const StopRow: React.FC<{
   setStopRows: (stopRows: IStopRow[]) => void;
   deleteRow: () => void;
   useNumber?: boolean;
+  /**
+   * Whether the *stop* (input) value is numeric. Independent of `useNumber`,
+   * which describes the output. Categorical stops are strings; colorMap and
+   * scalar stops must stay numbers or the compiled interpolate expression is
+   * rejected by OpenLayers.
+   */
+  numericStops?: boolean;
 }> = ({
   index,
   dataValue,
@@ -33,6 +40,7 @@ const StopRow: React.FC<{
   setStopRows,
   deleteRow,
   useNumber,
+  numericStops,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -45,7 +53,10 @@ const StopRow: React.FC<{
   const handleStopChange = (event: { target: { value: string } }) => {
     const newRows = [...stopRows];
     const value = event.target.value;
-    newRows[index].stop = useNumber ? +value : value;
+    const numeric = useNumber || numericStops;
+    // Keep an in-progress edit ('' or '-') as typed; coerce once it parses.
+    newRows[index].stop =
+      numeric && value !== '' && !isNaN(Number(value)) ? +value : value;
     setStopRows(newRows);
   };
 

--- a/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLLayer.ts
@@ -28,7 +28,7 @@ import { Vector as VectorSource } from 'ol/source';
 import { Rule } from 'ol/style/flat';
 
 import { getColorMap } from './colorRampUtils';
-import { grammarToOLStyle } from './grammarToOLStyle';
+import { FeatureValues, grammarToOLStyle } from './grammarToOLStyle';
 import { DEFAULT_FLAT_STYLE } from './styleBuilder';
 
 // Default OL heatmap gradient (cool → warm).
@@ -53,7 +53,7 @@ export function grammarToOLLayer(
   source: VectorSource | any,
   opacity: number,
   visible: boolean,
-  featureValues: unknown[] = [],
+  featureValues: FeatureValues = [],
   isRaster = false,
 ): Layer | LayerGroup {
   const grammarLayers = state.layers ?? [];
@@ -95,7 +95,7 @@ function compileGrammarLayer(
   source: VectorSource,
   opacity: number,
   visible: boolean,
-  featureValues: unknown[],
+  featureValues: FeatureValues,
 ): VectorImageLayer | HeatmapLayer {
   const kdeTransform = grammarLayer.preprocess?.find(
     (t): t is IKDETransform => t.type === 'kde',
@@ -136,14 +136,18 @@ function compileRasterLayer(
   source: any,
   opacity: number,
   visible: boolean,
-  featureValues: unknown[],
+  featureValues: FeatureValues,
 ): WebGLTileLayer {
   const singleLayerState: IGrammarSymbologyState = {
     layers: [grammarLayer],
   };
   // Use [0, 1] as fallback values so colorRamp stops span the normalized
-  // band range when no explicit featureValues are provided.
-  const values = featureValues.length > 0 ? featureValues : [0, 1];
+  // band range when no explicit featureValues are provided. Raster rules
+  // classify on $band-N pseudo-fields, which have no per-field column.
+  const hasValues = Array.isArray(featureValues)
+    ? featureValues.length > 0
+    : Object.keys(featureValues).length > 0;
+  const values = hasValues ? featureValues : [0, 1];
   const flatStyle = grammarToOLStyle(singleLayerState, values);
   const colorExpr = flatStyle['pixel-color'];
   const bandCount = source.bandCount;
@@ -264,7 +268,7 @@ function compileVectorLayer(
   source: VectorSource,
   opacity: number,
   visible: boolean,
-  featureValues: unknown[],
+  featureValues: FeatureValues,
 ): VectorImageLayer {
   const singleLayerState: IGrammarSymbologyState = {
     layers: [grammarLayer],

--- a/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
+++ b/packages/base/src/features/layers/symbology/grammarToOLStyle.ts
@@ -20,7 +20,6 @@ import {
   IGrammarSymbologyState,
   IPredicate,
   Encoding,
-  RGBA,
   UInt8Encoding,
   UNormEncoding,
 } from '@jupytergis/schema';
@@ -29,12 +28,11 @@ import { py2vega } from 'py2vega-ts';
 import { vega2ol } from 'vega2ol';
 
 import {
-  computeCategorizedColorStops,
-  computeGraduatedColorStops,
-  STOP_NULL,
-  STOP_UNDEFINED,
-  SymbologyState,
-} from './styleBuilder';
+  resolveCategoricalStops,
+  resolveColorMapStops,
+  resolveScalarStops,
+} from './resolveStops';
+import { STOP_NULL, STOP_UNDEFINED } from './styleBuilder';
 
 // '$density' is the pseudo-field produced by a kde transform (KDE density raster).
 // Encoding rules referencing it are compiled only when a kde transform is present;
@@ -77,6 +75,24 @@ interface IEncodingEntry {
 // ---------------------------------------------------------------------------
 
 /**
+ * Values available to classify a rule against, either as one column per field
+ * or as a single column applied to every field.
+ *
+ * The flat form is a convenience for states that classify on one field; a state
+ * with rules on different fields must pass the keyed form, or every rule is
+ * classified against the same column.
+ */
+export type FeatureValues = unknown[] | Record<string, unknown[]>;
+
+/** Pick the column a rule classifies against. */
+function columnFor(featureValues: FeatureValues, field?: string): unknown[] {
+  if (Array.isArray(featureValues)) {
+    return featureValues;
+  }
+  return (field && featureValues[field]) || [];
+}
+
+/**
  * Compile a Grammar symbology state to an OL FlatStyle object.
  * Sub-encodings (fill-red/green/blue/alpha) are assembled into fill-color.
  *
@@ -87,7 +103,7 @@ interface IEncodingEntry {
  */
 export function grammarToOLStyle(
   state: IGrammarSymbologyState,
-  featureValues: unknown[] = [],
+  featureValues: FeatureValues = [],
 ): Record<string, ExpressionValue> {
   // Accumulate per-encoding entries from all layers and their rules.
   // Layers with a kde/cluster preprocess are handled at the renderer level;
@@ -113,6 +129,8 @@ export function grammarToOLStyle(
       // For now use the first field; multi-field assembly is handled via
       // sub-encoding mappings (pixel-red/green/blue) or expression scales.
       const field = rule.fields?.[0];
+      // Each rule classifies against its own field's column.
+      const ruleValues = columnFor(featureValues, field);
       const ruleGuard =
         rule.when && rule.when.length > 0
           ? compileGuard(rule.when, rule.whenOp ?? 'all')
@@ -132,7 +150,7 @@ export function grammarToOLStyle(
               'pixel-green',
               'pixel-blue',
             ] as Encoding[]) {
-              const expr = compileMapping(field, mapping, featureValues, sub);
+              const expr = compileMapping(field, mapping, ruleValues, sub);
               const entries = accumulator.get(sub) ?? [];
               entries.push({ guard, expr });
               accumulator.set(sub, entries);
@@ -140,12 +158,7 @@ export function grammarToOLStyle(
           } else {
             // Compile per-encoding so sub-encodings (pixel-red/green/blue) can each
             // extract the correct component from a colorRamp or other color scale.
-            const expr = compileMapping(
-              field,
-              mapping,
-              featureValues,
-              encoding,
-            );
+            const expr = compileMapping(field, mapping, ruleValues, encoding);
             const entries = accumulator.get(encoding) ?? [];
             entries.push({ guard, expr });
             accumulator.set(encoding, entries);
@@ -199,6 +212,37 @@ export function extractEncodingFieldValues(
     return [];
   }
   return rows.map(r => r[field]).filter(v => v !== null && v !== undefined);
+}
+
+/**
+ * Extract one column per field the state classifies on.
+ *
+ * Prefer this over `extractEncodingFieldValues`: a state with rules on
+ * different fields needs each rule classified against its own column, and a
+ * single flat array silently classifies them all against the first field's.
+ */
+export function extractFieldColumns(
+  state: IGrammarSymbologyState,
+  rows: Record<string, unknown>[],
+): Record<string, unknown[]> {
+  const fields = new Set<string>();
+  for (const gl of state.layers ?? []) {
+    for (const rule of gl.rules ?? []) {
+      const f = rule.fields?.[0];
+      // $-prefixed fields are raster/transform pseudo-fields with no column.
+      if (f && !f.startsWith('$')) {
+        fields.add(f);
+      }
+    }
+  }
+
+  const columns: Record<string, unknown[]> = {};
+  for (const field of fields) {
+    columns[field] = rows
+      .map(r => r[field])
+      .filter(v => v !== null && v !== undefined);
+  }
+  return columns;
 }
 
 // ---------------------------------------------------------------------------
@@ -462,7 +506,7 @@ function compileColorMap(
   featureValues: unknown[],
   encoding?: Encoding,
 ): ExpressionValue {
-  const stops = resolveColorStops(scale, featureValues);
+  const stops = resolveColorMapStops(scale.params, featureValues);
 
   // Guard: interpolate requires at least 2 stop pairs. Return fallback when
   // the source is not yet loaded and no explicit domain/colorStops are set.
@@ -506,36 +550,6 @@ function compileColorMap(
 }
 
 /**
- * Resolve color stops for a colorRamp scale.
- * Explicit colorStops (user overrides) take precedence; otherwise classification
- * breaks are computed from featureValues using computeGraduatedColorStops.
- */
-function resolveColorStops(
-  scale: IColorMapScale,
-  featureValues: unknown[],
-): Array<{ stop: number; color: RGBA }> {
-  if (scale.params.colorStops && scale.params.colorStops.length >= 2) {
-    return scale.params.colorStops;
-  }
-
-  const numericValues = featureValues.filter(Number.isFinite) as number[];
-  const syntheticState = {
-    nClasses: scale.params.nShades,
-    mode: scale.params.mode,
-    colorRamp: scale.params.name,
-    reverseRamp: scale.params.reverse,
-    vmin: scale.params.domain?.[0],
-    vmax: scale.params.domain?.[1],
-  } as unknown as SymbologyState;
-
-  const computed = computeGraduatedColorStops(syntheticState, numericValues);
-  return computed.map(s => ({
-    stop: s.value as number,
-    color: s.color as RGBA,
-  }));
-}
-
-/**
  * categorical: nominal field → RGBA color via a named palette.
  * Unique field values are enumerated from featureValues at render time,
  * mirroring buildCategorized.
@@ -551,20 +565,7 @@ function compileCategorical(
   scale: ICategoricalScale,
   featureValues: unknown[],
 ): ExpressionValue {
-  let stops: Array<{ value: unknown; color: unknown }>;
-
-  if (scale.params.colorStops && scale.params.colorStops.length > 0) {
-    stops = scale.params.colorStops.map(s => ({
-      value: s.stop,
-      color: s.color,
-    }));
-  } else {
-    const syntheticState = {
-      colorRamp: scale.params.colorRamp,
-      reverseRamp: scale.params.reverse ?? false,
-    } as unknown as SymbologyState;
-    stops = computeCategorizedColorStops(syntheticState, featureValues);
-  }
+  const stops = resolveCategoricalStops(scale.params, featureValues);
 
   // Guard: a OL case expression requires at least one condition+value pair
   // before the else branch. Return fallback directly when stops is empty.
@@ -575,10 +576,10 @@ function compileCategorical(
   const caseExpr: ExpressionValue[] = ['case'];
   for (const stop of stops) {
     let condition: ExpressionValue;
-    if (stop.value === STOP_UNDEFINED) {
+    if (stop.stop === STOP_UNDEFINED) {
       // Property missing entirely
       condition = ['!', ['has', field]] as ExpressionValue;
-    } else if (stop.value === STOP_NULL) {
+    } else if (stop.stop === STOP_NULL) {
       // Property exists but value is null
       condition = [
         'all',
@@ -589,7 +590,7 @@ function compileCategorical(
       condition = [
         '==',
         fieldExpr(field),
-        stop.value as ExpressionValue,
+        stop.stop as ExpressionValue,
       ] as ExpressionValue;
     }
     caseExpr.push(condition, stop.color as ExpressionValue);
@@ -613,17 +614,8 @@ function compileScalar(field: string, scale: IScalarScale): ExpressionValue {
     fieldExpr(field),
   ];
 
-  if (scale.params.scalarStops && scale.params.scalarStops.length >= 2) {
-    for (const { stop, output } of scale.params.scalarStops) {
-      interpolateExpr.push(stop, output);
-    }
-  } else {
-    interpolateExpr.push(
-      scale.params.domain[0],
-      scale.params.range[0],
-      scale.params.domain[1],
-      scale.params.range[1],
-    );
+  for (const { stop, output } of resolveScalarStops(scale.params)) {
+    interpolateExpr.push(stop, output);
   }
 
   if (fieldAlwaysPresent(field)) {

--- a/packages/base/src/features/layers/symbology/resolveStops.ts
+++ b/packages/base/src/features/layers/symbology/resolveStops.ts
@@ -1,0 +1,184 @@
+/**
+ * Shared classification resolvers.
+ *
+ * A scale's stops come from one of two places: persisted overrides, written to
+ * the document only when the user edits a stop by hand, or a derivation from
+ * whatever feature values are available at the time of use.
+ *
+ * Three consumers need that derivation — the OL style compiler, the symbology
+ * editor preview and the legend — and they must agree, or the map, the stop
+ * table and the legend show three different classifications. So the derivation
+ * lives here once; each caller supplies the feature values it has.
+ *
+ * `derive*` ignores overrides and always classifies from the data (what the
+ * editor previews). `resolve*` prefers overrides and falls back to `derive*`
+ * (what the renderer and the legend draw).
+ */
+
+import {
+  ICategoricalScaleParams,
+  IColorMapScaleParams,
+  IGrammarSymbologyState,
+  IScalarScaleParams,
+  RGBA,
+} from '@jupytergis/schema';
+
+import { COLOR_RAMP_DEFAULTS, ColorRampName } from './colorRampUtils';
+import {
+  computeCategorizedColorStops,
+  computeGraduatedColorStops,
+  SymbologyState,
+} from './styleBuilder';
+
+export interface IResolvedColorStop {
+  stop: number;
+  color: RGBA;
+}
+
+export interface IResolvedCategoricalStop {
+  stop: string | number;
+  color: RGBA;
+}
+
+export interface IResolvedScalarStop {
+  stop: number;
+  output: number;
+}
+
+/**
+ * Number of classes to classify a colorMap into.
+ *
+ * Some ramps (hsv, picnic, cubehelix, rainbow-soft) only read correctly above a
+ * minimum class count, so `nShades` is clamped to it. The Classes input is not
+ * clamped, so this has to be applied everywhere the stops are derived — not
+ * just in the editor — or the preview and the map disagree on the stop count.
+ */
+export function colorMapClassCount(params: IColorMapScaleParams): number {
+  const minRequired = COLOR_RAMP_DEFAULTS[params.name as ColorRampName];
+  return minRequired
+    ? Math.max(params.nShades ?? minRequired, minRequired)
+    : params.nShades;
+}
+
+/**
+ * Classify a colorMap from the data, ignoring any persisted stops.
+ *
+ * With no values in range this still returns stops when the domain is fully
+ * specified — `computeGraduatedColorStops` falls back to `[vmin, vmax]`. That
+ * is the vector-tile case: the full feature population is never loaded, so an
+ * explicit domain is the only stable way to classify.
+ */
+export function deriveColorMapStops(
+  params: IColorMapScaleParams,
+  featureValues: unknown[],
+): IResolvedColorStop[] {
+  const numericValues = featureValues.filter(v =>
+    Number.isFinite(v),
+  ) as number[];
+
+  const syntheticState = {
+    nClasses: colorMapClassCount(params),
+    mode: params.mode,
+    colorRamp: params.name,
+    reverseRamp: params.reverse,
+    vmin: params.domain?.[0],
+    vmax: params.domain?.[1],
+  } as unknown as SymbologyState;
+
+  return computeGraduatedColorStops(syntheticState, numericValues).map(s => ({
+    stop: s.value as number,
+    color: s.color as RGBA,
+  }));
+}
+
+/** Persisted stops win; otherwise classify from the data. */
+export function resolveColorMapStops(
+  params: IColorMapScaleParams,
+  featureValues: unknown[],
+): IResolvedColorStop[] {
+  if (params.colorStops && params.colorStops.length >= 2) {
+    return params.colorStops;
+  }
+  return deriveColorMapStops(params, featureValues);
+}
+
+/**
+ * Enumerate categories from the data, ignoring any persisted stops.
+ *
+ * Unlike colorMap there is no domain to fall back on: the set of categories is
+ * unknowable without scanning the data, so with no values this returns [].
+ */
+export function deriveCategoricalStops(
+  params: ICategoricalScaleParams,
+  featureValues: unknown[],
+): IResolvedCategoricalStop[] {
+  const syntheticState = {
+    colorRamp: params.colorRamp,
+    reverseRamp: params.reverse ?? false,
+  } as unknown as SymbologyState;
+
+  return computeCategorizedColorStops(syntheticState, featureValues).map(s => ({
+    stop: s.value as string | number,
+    color: s.color as RGBA,
+  }));
+}
+
+/** Persisted stops win; otherwise enumerate categories from the data. */
+export function resolveCategoricalStops(
+  params: ICategoricalScaleParams,
+  featureValues: unknown[],
+): IResolvedCategoricalStop[] {
+  if (params.colorStops && params.colorStops.length > 0) {
+    return params.colorStops;
+  }
+  return deriveCategoricalStops(params, featureValues);
+}
+
+/**
+ * Endpoints of a scalar mapping. No data dependency: domain and range are both
+ * set explicitly by the user, so this is just the two ends of the interpolation.
+ */
+export function deriveScalarStops(
+  params: IScalarScaleParams,
+): IResolvedScalarStop[] {
+  return [
+    { stop: params.domain[0], output: params.range[0] },
+    { stop: params.domain[1], output: params.range[1] },
+  ];
+}
+
+/** Persisted stops win; otherwise interpolate between domain and range. */
+export function resolveScalarStops(
+  params: IScalarScaleParams,
+): IResolvedScalarStop[] {
+  if (params.scalarStops && params.scalarStops.length >= 2) {
+    return params.scalarStops;
+  }
+  return deriveScalarStops(params);
+}
+
+/**
+ * Whether any scale in the state has to look at the data to know its stops.
+ *
+ * Reading feature values costs a source load (or, for tile sources, a restyle
+ * on every tile), so callers use this to skip that work for states that are
+ * fully described by their params — scalar and constant scales always are, and
+ * so are colorMap/categorical scales the user has pinned by editing a stop.
+ */
+export function grammarNeedsFeatureValues(
+  state: IGrammarSymbologyState | undefined,
+): boolean {
+  return (state?.layers ?? []).some(layer =>
+    layer.rules?.some(rule =>
+      rule.mappings?.some(({ scale }) => {
+        if (scale.scheme === 'colorMap') {
+          return (scale.params.colorStops?.length ?? 0) < 2;
+        }
+        if (scale.scheme === 'categorical') {
+          return (scale.params.colorStops?.length ?? 0) === 0;
+        }
+        return false;
+      }),
+    ),
+  );
+}

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -174,9 +174,10 @@ import {
 } from '../features/layers/openeo/OpenEOTileLayer';
 import { grammarToOLLayer } from '../features/layers/symbology/grammarToOLLayer';
 import {
-  extractEncodingFieldValues,
+  extractFieldColumns,
   grammarToOLStyle,
 } from '../features/layers/symbology/grammarToOLStyle';
+import { grammarNeedsFeatureValues } from '../features/layers/symbology/resolveStops';
 import { DEFAULT_FLAT_STYLE } from '../features/layers/symbology/styleBuilder';
 import {
   buildZarrColorStyle,
@@ -503,6 +504,11 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     );
     this._model.modeChanged.disconnect(this._handleModeChanged, this);
     this._stopLocationIndicator();
+
+    if (this._restyleFrame !== null) {
+      cancelAnimationFrame(this._restyleFrame);
+      this._restyleFrame = null;
+    }
 
     this._mainViewModel.dispose();
   }
@@ -1148,6 +1154,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
                 sourceId: id,
                 features,
               });
+              this._scheduleRestyleForSource(id);
             }
           });
 
@@ -1717,7 +1724,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
             olSource instanceof VectorSource
               ? olSource.getFeatures().map(f => (f as Feature).getProperties())
               : [];
-          const featureValues = extractEncodingFieldValues(grammarState, rows);
+          const featureValues = extractFieldColumns(grammarState, rows);
           newMapLayer = grammarToOLLayer(
             layerParameters.symbologyState as IGrammarSymbologyState,
             olSource,
@@ -2023,6 +2030,52 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   }
 
+  /**
+   * Recompile the style of every tile layer bound to `sourceId`.
+   *
+   * A tile source reveals its features a tile at a time, so a data-driven
+   * classification computed when the first tile landed is stale as soon as the
+   * next one does. Tile loads arrive in bursts, and recompiling per tile would
+   * be wasteful, so restyles are coalesced into one per frame.
+   *
+   * Layers whose stops are all persisted don't depend on the data and are left
+   * alone.
+   */
+  private _scheduleRestyleForSource(sourceId: string): void {
+    this._pendingRestyleSources.add(sourceId);
+    if (this._restyleFrame !== null) {
+      return;
+    }
+    this._restyleFrame = requestAnimationFrame(() => {
+      this._restyleFrame = null;
+      const sourceIds = new Set(this._pendingRestyleSources);
+      this._pendingRestyleSources.clear();
+
+      for (const [layerId, layer] of Object.entries(this._model.getLayers())) {
+        const params = layer.parameters as IVectorLayer | undefined;
+        if (!params?.source || !sourceIds.has(params.source)) {
+          continue;
+        }
+        if (!Array.isArray(params.symbologyState?.layers)) {
+          continue;
+        }
+        if (
+          !grammarNeedsFeatureValues(
+            params.symbologyState as IGrammarSymbologyState,
+          )
+        ) {
+          continue;
+        }
+        const mapLayer = this.getLayer(layerId);
+        if (mapLayer && 'setStyle' in mapLayer) {
+          (mapLayer as VectorTileLayer).setStyle(
+            this.vectorLayerStyleRuleBuilder(layer),
+          );
+        }
+      }
+    });
+  }
+
   // Used by VectorTileLayer (which shares a flat-style API with Grammar output).
   vectorLayerStyleRuleBuilder = (layer: IJGISLayer) => {
     const layerParams = layer.parameters as IVectorLayer | undefined;
@@ -2031,9 +2084,20 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return [{ style: DEFAULT_FLAT_STYLE }];
     }
 
+    // Classification is only persisted to the document when the user edits a
+    // stop by hand, so the compiler needs the feature values to derive it. For
+    // a tile source that means whatever tiles have loaded so far, which grows
+    // as the user pans — `_scheduleRestyleForSource` recompiles as it does.
+    const grammarState = layerParams.symbologyState as IGrammarSymbologyState;
+    const sourceId = layerParams.source;
+    const rows = sourceId
+      ? this._model
+          .getFeaturesForCurrentTile({ sourceId })
+          .map(f => f.getProperties?.() ?? {})
+      : [];
     const flatStyle = grammarToOLStyle(
-      layerParams.symbologyState as IGrammarSymbologyState,
-      [],
+      grammarState,
+      extractFieldColumns(grammarState, rows),
     );
 
     const layerStyle: Rule = { style: flatStyle };
@@ -4269,6 +4333,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _documentPath?: string;
   private _contextMenu: ContextMenu;
   private _loadingLayers: Set<string>;
+  private _pendingRestyleSources = new Set<string>();
+  private _restyleFrame: number | null = null;
   private _pendingZoomLayerId: string | null = null;
   private _originalFeatures: IDict<Feature<Geometry>[]> = {};
   private _highlightLayerRef: {

--- a/packages/base/src/workspace/panels/components/legendItem.tsx
+++ b/packages/base/src/workspace/panels/components/legendItem.tsx
@@ -16,7 +16,13 @@ import {
   ColorRampName,
   getColorMap,
 } from '@/src/features/layers/symbology/colorRampUtils';
+import { useGetProperties } from '@/src/features/layers/symbology/hooks/useGetProperties';
 import { useGetSymbology } from '@/src/features/layers/symbology/hooks/useGetSymbology';
+import {
+  grammarNeedsFeatureValues,
+  resolveCategoricalStops,
+  resolveColorMapStops,
+} from '@/src/features/layers/symbology/resolveStops';
 
 // ---------------------------------------------------------------------------
 // Legend entry types
@@ -365,7 +371,19 @@ function kdeToLegendEntries(
   return entries;
 }
 
-function grammarToLegendEntries(state: IGrammarSymbologyState): LegendEntry[] {
+/**
+ * Build the legend for a Grammar state.
+ *
+ * @param featureValues  Feature attribute values keyed by field name, as
+ *   produced by `useGetProperties`. Classification is only persisted to the
+ *   document when the user edits a stop by hand, so without this the legend
+ *   cannot show the breaks the map is actually drawing. Pass `{}` when the
+ *   values are unavailable — scales fall back to a generic ramp preview.
+ */
+function grammarToLegendEntries(
+  state: IGrammarSymbologyState,
+  featureValues: Record<string, Set<any>> = {},
+): LegendEntry[] {
   const entries: LegendEntry[] = [];
 
   for (const grammarLayer of state.layers ?? []) {
@@ -394,6 +412,9 @@ function grammarToLegendEntries(state: IGrammarSymbologyState): LegendEntry[] {
     const layerWhen = grammarLayer.when ?? [];
     for (const rule of grammarLayer.rules) {
       const field = rule.fields?.[0];
+      // The column the rule classifies on, if it has loaded. Empty for raster
+      // pseudo-fields ($band-N) and for sources whose features aren't readable.
+      const fieldValues = field ? Array.from(featureValues[field] ?? []) : [];
       const allWhen = [...layerWhen, ...(rule.when ?? [])];
       const whenLbl = formatWhen(allWhen.length > 0 ? allWhen : undefined);
 
@@ -422,18 +443,21 @@ function grammarToLegendEntries(state: IGrammarSymbologyState): LegendEntry[] {
           switch (scale.scheme) {
             case 'colorMap': {
               const p = scale.params;
-              if (p.colorStops && p.colorStops.length >= 2) {
+              // Persisted stops when the user edited them, otherwise the same
+              // classification the style compiler derives from the data.
+              const resolved = resolveColorMapStops(p, fieldValues);
+              if (resolved.length >= 2) {
                 // When alpha is driven by a companion scalar, clip the displayed
                 // gradient and ticks to the scalar's effective domain — beyond
                 // it alpha is either 0 (invisible) or constant (fully opaque),
                 // so the meaningful field range is [alphaMin, alphaMax].
-                let displayStops = p.colorStops;
+                let displayStops = resolved;
                 if (withAlpha && layerAlphaScalarStops.length >= 2) {
                   const alphaMin = layerAlphaScalarStops[0].stop;
                   const alphaMax =
                     layerAlphaScalarStops[layerAlphaScalarStops.length - 1]
                       .stop;
-                  const clipped = p.colorStops.filter(
+                  const clipped = resolved.filter(
                     s => s.stop >= alphaMin && s.stop <= alphaMax,
                   );
                   if (clipped.length >= 2) {
@@ -460,7 +484,8 @@ function grammarToLegendEntries(state: IGrammarSymbologyState): LegendEntry[] {
                   withAlpha,
                 });
               } else {
-                // No colorStops yet — show a preview gradient from the ramp name.
+                // Nothing to classify from — no persisted stops, no data and no
+                // domain. Show a preview gradient from the ramp name.
                 const colors = rampColors(p.name);
                 const preview: GradientEntry = {
                   type: 'gradient',
@@ -486,19 +511,22 @@ function grammarToLegendEntries(state: IGrammarSymbologyState): LegendEntry[] {
             }
             case 'categorical': {
               const p = scale.params;
-              if (p.colorStops && p.colorStops.length > 0) {
+              // Persisted stops when the user edited them, otherwise the
+              // categories the style compiler enumerates from the data.
+              const resolved = resolveCategoricalStops(p, fieldValues);
+              if (resolved.length > 0) {
                 entries.push({
                   type: 'categorical',
                   field,
                   encoding: encodingLbl,
                   when: whenLbl,
-                  stops: p.colorStops.map(s => ({
+                  stops: resolved.map(s => ({
                     label: String(s.stop),
                     color: rgbaToString(s.color),
                   })),
                 });
               }
-              // No colorStops → skip (categories not yet loaded).
+              // Categories are unknowable without data — skip until it loads.
               break;
             }
             case 'constant_rgba': {
@@ -1026,6 +1054,19 @@ export const LegendItem: React.FC<{
   const [heatmapColors, setHeatmapColors] = useState<string[] | null>(null);
   const [heatmapReversed, setHeatmapReversed] = useState(false);
 
+  // Only read the features when the legend actually needs them: a scale with
+  // persisted stops is self-describing, and reading them means loading the
+  // whole source. Passing no layerId makes the hook a no-op.
+  const needsFeatureValues = grammarNeedsFeatureValues(
+    symbology?.symbologyState,
+  );
+  // Errors are ignored on purpose — unsupported source types just mean the
+  // legend falls back to the stops in the document.
+  const { featureProperties } = useGetProperties({
+    layerId: needsFeatureValues ? layerId : undefined,
+    model,
+  });
+
   useEffect(() => {
     setEntries([]);
     setHeatmapColors(null);
@@ -1050,9 +1091,14 @@ export const LegendItem: React.FC<{
     }
 
     if (Array.isArray(state.layers)) {
-      setEntries(grammarToLegendEntries(state as IGrammarSymbologyState));
+      setEntries(
+        grammarToLegendEntries(
+          state as IGrammarSymbologyState,
+          featureProperties,
+        ),
+      );
     }
-  }, [symbology, isLoading, error]);
+  }, [symbology, isLoading, error, featureProperties]);
 
   if (isLoading) {
     return <p style={{ fontSize: '0.8em', padding: 6 }}>Loading…</p>;

--- a/ui-tests/tests/classify-preview.spec.ts
+++ b/ui-tests/tests/classify-preview.spec.ts
@@ -1,0 +1,108 @@
+import { expect, galata, test } from '@jupyterlab/galata';
+import path from 'path';
+
+const FILENAME = 'colormap-nostops-test.jGIS';
+const FILEPATH = `testDir/${FILENAME}`;
+const LAYER = 'Roads (ColorMap)';
+
+/**
+ * The fixture carries a colorMap scale with NO persisted colorStops, which is
+ * the state a freshly-configured layer is in. The editor must show the
+ * classification derived from the data without the user pressing Classify,
+ * and stops must only reach the document when edited by hand.
+ */
+test.describe('#classifyPreview', () => {
+  test.beforeAll(async ({ request }) => {
+    const content = galata.newContentsHelper(request);
+    await content.deleteDirectory('/testDir');
+    await content.uploadDirectory(
+      path.resolve(__dirname, './gis-files'),
+      '/testDir',
+    );
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.open(FILEPATH);
+    await expect(page.locator('.jGIS-Mainview')).toBeVisible();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.activity.closeAll();
+  });
+
+  /** Open the symbology dialog and expand the colorMap scale editor. */
+  const openScaleEditor = async (page: any) => {
+    await page.getByText(LAYER, { exact: true }).click({ button: 'right' });
+    await page.getByText('Edit Symbology').click();
+    const dialog = page.locator('.jp-Dialog-content');
+    await expect(dialog).toBeAttached();
+    await dialog.getByRole('button', { name: /viridis/ }).click();
+    return dialog;
+  };
+
+  /** Save, then read the layer's symbologyState back off disk. */
+  const readSymbologyState = async (page: any, request: any) => {
+    await page.keyboard.press('Control+s');
+    await page.waitForTimeout(2000);
+    const res = await request.get(`/api/contents/${FILEPATH}?content=1`);
+    const doc = JSON.parse((await res.json()).content);
+    const layer: any = Object.values(doc.layers).find(
+      (l: any) => l.name === LAYER,
+    );
+    return layer.parameters.symbologyState;
+  };
+
+  test('stop table is populated without pressing Classify', async ({
+    page,
+  }) => {
+    const dialog = await openScaleEditor(page);
+
+    const rows = dialog.locator('.jp-gis-color-row');
+    await expect(rows.first()).toBeVisible({ timeout: 15000 });
+
+    // Classification derived from the live feature values, not from the
+    // document — the fixture has no colorStops at all.
+    const values = await dialog
+      .locator('.jp-gis-color-row-value-input')
+      .evaluateAll((els: HTMLInputElement[]) => els.map(e => e.value));
+    expect(values.length).toBeGreaterThan(1);
+    expect(values.every(v => v !== '')).toBe(true);
+
+    await dialog.getByText('Cancel').click();
+  });
+
+  test('Classify does not write colorStops to the document', async ({
+    page,
+    request,
+  }) => {
+    const dialog = await openScaleEditor(page);
+    await expect(dialog.locator('.jp-gis-color-row').first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    await dialog.getByRole('button', { name: 'Classify' }).click();
+    await page.locator('.jp-Dialog-footer button:has-text("Ok")').click();
+    await expect(dialog).not.toBeAttached();
+
+    const state = await readSymbologyState(page, request);
+    const serialized = JSON.stringify(state);
+    expect(serialized).toContain('colorMap');
+    expect(serialized).not.toContain('colorStops');
+  });
+
+  test('editing a stop persists colorStops', async ({ page, request }) => {
+    const dialog = await openScaleEditor(page);
+    const firstValue = dialog.locator('.jp-gis-color-row-value-input').first();
+    await expect(firstValue).toBeVisible({ timeout: 15000 });
+
+    // A manual edit is the one action that should persist stops.
+    await firstValue.fill('42');
+    await firstValue.press('Tab');
+
+    await page.locator('.jp-Dialog-footer button:has-text("Ok")').click();
+    await expect(dialog).not.toBeAttached();
+
+    const state = await readSymbologyState(page, request);
+    expect(JSON.stringify(state)).toContain('colorStops');
+  });
+});

--- a/ui-tests/tests/gis-files/colormap-nostops-test.jGIS
+++ b/ui-tests/tests/gis-files/colormap-nostops-test.jGIS
@@ -1,0 +1,120 @@
+{
+ "layerTree": [
+  "a1b2c3d4-0000-4000-8000-000000000001",
+  "a1b2c3d4-0000-4000-8000-000000000002"
+ ],
+ "layers": {
+  "a1b2c3d4-0000-4000-8000-000000000001": {
+   "name": "OpenStreetMap.Mapnik Layer",
+   "parameters": {
+    "source": "a1b2c3d4-0000-4000-8000-000000000003"
+   },
+   "type": "RasterLayer",
+   "visible": true
+  },
+  "a1b2c3d4-0000-4000-8000-000000000002": {
+   "name": "Roads (ColorMap)",
+   "parameters": {
+    "opacity": 1.0,
+    "source": "a1b2c3d4-0000-4000-8000-000000000004",
+    "type": "line",
+    "symbologyState": {
+     "layers": [
+      {
+       "id": "223e7cec-b975-4f1f-b256-859eaeb5d385",
+       "rules": [
+        {
+         "id": "afaf8f71-9d93-4cfb-a756-cae041eff344",
+         "fields": [
+          "speed_limit"
+         ],
+         "mappings": [
+          {
+           "scale": {
+            "scheme": "colorMap",
+            "params": {
+             "name": "viridis",
+             "domain": [
+              30,
+              110
+             ],
+             "nShades": 5,
+             "mode": "equal interval",
+             "reverse": false,
+             "fallback": [
+              0,
+              0,
+              0,
+              0
+             ]
+            }
+           },
+           "encodings": [
+            "fill-color",
+            "stroke-color",
+            "circle-fill-color",
+            "circle-stroke-color"
+           ]
+          },
+          {
+           "scale": {
+            "scheme": "constant_num",
+            "params": {
+             "value": 3
+            }
+           },
+           "encodings": [
+            "stroke-width",
+            "circle-stroke-width"
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   },
+   "type": "VectorLayer",
+   "visible": true
+  }
+ },
+ "metadata": {},
+ "options": {
+  "bearing": 0.0,
+  "extent": [
+   -225000.0,
+   6125000.0,
+   -208000.0,
+   6136000.0
+  ],
+  "latitude": 48.02,
+  "longitude": -1.95,
+  "pitch": 0.0,
+  "projection": "EPSG:3857",
+  "zoom": 12.0
+ },
+ "schemaVersion": "0.6.0",
+ "sources": {
+  "a1b2c3d4-0000-4000-8000-000000000003": {
+   "name": "OpenStreetMap.Mapnik",
+   "parameters": {
+    "attribution": "(C) OpenStreetMap contributors",
+    "maxZoom": 19.0,
+    "minZoom": 0.0,
+    "provider": "OpenStreetMap",
+    "url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+    "urlParameters": {}
+   },
+   "type": "RasterSource"
+  },
+  "a1b2c3d4-0000-4000-8000-000000000004": {
+   "name": "Roads Test Source",
+   "parameters": {
+    "path": "roads-test.geojson"
+   },
+   "type": "GeoJSONSource"
+  }
+ },
+ "stories": {}
+}


### PR DESCRIPTION
## Description

Shall close #1416 

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1750.org.readthedocs.build/en/1750/
💡 JupyterLite preview: https://jupytergis--1750.org.readthedocs.build/en/1750/lite
💡 Specta preview: https://jupytergis--1750.org.readthedocs.build/en/1750/lite/specta

<!-- readthedocs-preview jupytergis end -->