### PR TITLE
Fix blank color map previews by using refs instead of shared canvas ids

### DIFF
--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelector.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelector.tsx
@@ -38,6 +38,10 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
   colorMaps: propColorMaps,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  // A ref rather than a DOM id: several selectors can be mounted at once (one
+  // per mapping card), and a shared id meant they all drew onto the first
+  // selector's canvas.
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [colorMaps, setColorMaps] = useState<IColorMap[]>([]);
   const canvasWidth = 512;
@@ -78,7 +82,7 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
 
   const updateCanvas = (rampName: string) => {
     // update canvas for displayed color map
-    const canvas = document.getElementById('cv') as HTMLCanvasElement;
+    const canvas = canvasRef.current;
     if (!canvas) {
       return;
     }
@@ -118,7 +122,7 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
         <div className="jp-gis-color-ramp-entry jp-gis-selected-entry">
           <span className="jp-gis-color-label">{selectedRamp}</span>
           <canvas
-            id="cv"
+            ref={canvasRef}
             className="jp-gis-color-canvas-display"
             width={canvasWidth}
             height={canvasHeight}
@@ -128,9 +132,9 @@ const ColorRampSelector: React.FC<IColorRampSelectorProps> = ({
       <div
         className={`jp-gis-color-ramp-dropdown ${isOpen ? 'jp-gis-open' : ''}`}
       >
-        {colorMaps.map((item, index) => (
+        {colorMaps.map(item => (
           <ColorRampSelectorEntry
-            index={index}
+            key={item.name}
             colorMap={item}
             onClick={selectItem}
           />

--- a/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
+++ b/packages/base/src/features/layers/symbology/components/color_ramp/ColorRampSelectorEntry.tsx
@@ -5,12 +5,11 @@
  * Renders a preview ColorRamp on a canvas and triggers `onClick` when selected.
  *
  * Props:
- * - `index`: Unique index for canvas ID.
  * - `colorMap`: Ramp definition including name and colors.
  * - `onClick`: Callback fired with the ramp name when clicked.
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import {
   COLOR_RAMP_WARNINGS,
@@ -21,21 +20,23 @@ import {
 import { InfoTip } from '@/src/shared/components/InfoTip';
 
 interface IColorRampSelectorEntryProps {
-  index: number;
   colorMap: IColorMap;
   onClick: (item: ColorRampName) => void;
 }
 
 const ColorRampSelectorEntry: React.FC<IColorRampSelectorEntryProps> = ({
-  index,
   colorMap,
   onClick,
 }) => {
+  // A ref rather than a DOM id: several selectors can be mounted at once (one
+  // per mapping card), and shared ids made every entry paint onto the first
+  // selector's canvas, leaving the others blank.
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const canvasWidth = 512;
   const canvasHeight = 30;
 
   useEffect(() => {
-    const canvas = document.getElementById(`cv-${index}`) as HTMLCanvasElement;
+    const canvas = canvasRef.current;
     if (!canvas) {
       return;
     }
@@ -43,13 +44,12 @@ const ColorRampSelectorEntry: React.FC<IColorRampSelectorEntryProps> = ({
     canvas.height = canvasHeight;
 
     drawColorRamp(canvas, colorMap);
-  }, [colorMap, index]);
+  }, [colorMap]);
 
   const warning = COLOR_RAMP_WARNINGS[colorMap.name];
 
   return (
     <div
-      key={colorMap.name}
       onClick={() => onClick(colorMap.name)}
       className="jp-gis-color-ramp-entry"
     >
@@ -69,7 +69,7 @@ const ColorRampSelectorEntry: React.FC<IColorRampSelectorEntryProps> = ({
         </span>
       )}
       <canvas
-        id={`cv-${index}`}
+        ref={canvasRef}
         width={canvasWidth}
         height={canvasHeight}
         className="jp-gis-color-canvas"


### PR DESCRIPTION
## Description

Shall close #1751

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1752.org.readthedocs.build/en/1752/
💡 JupyterLite preview: https://jupytergis--1752.org.readthedocs.build/en/1752/lite
💡 Specta preview: https://jupytergis--1752.org.readthedocs.build/en/1752/lite/specta

<!-- readthedocs-preview jupytergis end -->