### PR TITLE
Story Maps: Add option to align segments

### DIFF
--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -37,6 +37,7 @@ import {
   getStoryMarkdownFromSlide,
   getStorySegmentDisplayTitle,
 } from '@/src/features/story/utils/storySegmentViewItems';
+import { isOverlayContentWidthFull } from '@/src/features/story/utils/spectaPresentation';
 import { Button } from '@/src/shared/components/Button';
 import {
   NativeSelect,
@@ -66,6 +67,7 @@ function SegmentEditor({
   onLayerNameChange,
   onTransitionChange,
   onRemoveSegment,
+  showPaneAlignmentPicker,
 }: {
   model: IJupyterGISModel;
   state: IStateDB;
@@ -79,6 +81,7 @@ function SegmentEditor({
   onLayerNameChange: (name: string) => void;
   onTransitionChange: (patch: SegmentTransitionPatch) => void;
   onRemoveSegment: () => void;
+  showPaneAlignmentPicker: boolean;
 }): JSX.Element {
   const [layersOpen, setLayersOpen] = useState(true);
   const [animationOpen, setAnimationOpen] = useState(false);
@@ -126,12 +129,14 @@ function SegmentEditor({
 
       <SegmentModePicker value={segmentMode} onChange={onContentModeChange} />
 
-      <SegmentPaneAlignmentPicker
-        value={paneAlignment}
-        onChange={alignment => {
-          onContentChange({ paneAlignment: alignment });
-        }}
-      />
+      {showPaneAlignmentPicker ? (
+        <SegmentPaneAlignmentPicker
+          value={paneAlignment}
+          onChange={alignment => {
+            onContentChange({ paneAlignment: alignment });
+          }}
+        />
+      ) : null}
 
       {segmentMode === 'map' ? (
         <>
@@ -287,6 +292,10 @@ export function StoryEditorDialogBody({
     updateSegmentTransition,
   } = useStoryEditorSegmentList(model, commands);
 
+  const showPaneAlignmentPicker = !isOverlayContentWidthFull(
+    story?.overlayContentWidth,
+  );
+
   const portalContainerRef = useRef<HTMLDivElement>(null);
   const [isMobile, setIsMobile] = useState(false);
 
@@ -350,6 +359,7 @@ export function StoryEditorDialogBody({
                 updateSegmentTransition(selectedSegment.id, patch);
               }}
               onRemoveSegment={removeSegment}
+              showPaneAlignmentPicker={showPaneAlignmentPicker}
             />
           ) : (
             <SegmentEditorEmptyState />

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -9,6 +9,7 @@ import { SegmentImageUrlField } from '@/src/features/story/components/SegmentIma
 import { SegmentLayerOverrides } from '@/src/features/story/components/SegmentLayerOverrides';
 import { SegmentMarkdownEditor } from '@/src/features/story/components/SegmentMarkdownEditor';
 import { SegmentModePicker } from '@/src/features/story/components/SegmentModePicker';
+import { SegmentPaneAlignmentPicker } from '@/src/features/story/components/SegmentPaneAlignmentPicker';
 import { StoryEditorHeaderBar } from '@/src/features/story/components/StoryEditorHeaderBar';
 import { StoryEditorSection } from '@/src/features/story/components/StoryEditorSection';
 import { StoryEditorSegmentList } from '@/src/features/story/components/StoryEditorSegmentList';
@@ -20,7 +21,10 @@ import type {
   StorySegmentDisplayMode,
 } from '@/src/features/story/types/types';
 import { getSegmentDisplayMode } from '@/src/features/story/utils/listStoryScrollTrack';
-import type { SegmentContentPatch } from '@/src/features/story/utils/storySegmentContent';
+import {
+  getSegmentPaneAlignment,
+  type SegmentContentPatch,
+} from '@/src/features/story/utils/storySegmentContent';
 import {
   formatSegmentTransitionTime,
   getSegmentTransitionTime,
@@ -82,6 +86,10 @@ function SegmentEditor({
   const imageUrl = segment.activeSlide?.content?.image ?? '';
   const markdown = getStoryMarkdownFromSlide(segment.activeSlide);
   const segmentMode = getSegmentDisplayMode(segment.activeSlide);
+  const paneAlignment = getSegmentPaneAlignment(
+    segment.activeSlide?.content,
+    segmentMode,
+  );
   const transitionType = segment.activeSlide?.transition?.type ?? 'linear';
   const transitionTime = getSegmentTransitionTime(
     segment.activeSlide?.transition,
@@ -117,6 +125,13 @@ function SegmentEditor({
       </div>
 
       <SegmentModePicker value={segmentMode} onChange={onContentModeChange} />
+
+      <SegmentPaneAlignmentPicker
+        value={paneAlignment}
+        onChange={alignment => {
+          onContentChange({ paneAlignment: alignment });
+        }}
+      />
 
       {segmentMode === 'map' ? (
         <>

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -21,6 +21,7 @@ import type {
   StorySegmentDisplayMode,
 } from '@/src/features/story/types/types';
 import { getSegmentDisplayMode } from '@/src/features/story/utils/listStoryScrollTrack';
+import { isOverlayContentWidthFull } from '@/src/features/story/utils/spectaPresentation';
 import {
   getSegmentPaneAlignment,
   type SegmentContentPatch,
@@ -37,7 +38,6 @@ import {
   getStoryMarkdownFromSlide,
   getStorySegmentDisplayTitle,
 } from '@/src/features/story/utils/storySegmentViewItems';
-import { isOverlayContentWidthFull } from '@/src/features/story/utils/spectaPresentation';
 import { Button } from '@/src/shared/components/Button';
 import {
   NativeSelect,

--- a/packages/base/src/features/story/__tests__/storySegmentContent.spec.ts
+++ b/packages/base/src/features/story/__tests__/storySegmentContent.spec.ts
@@ -1,7 +1,38 @@
 import {
+  getSegmentPaneAlignment,
+  mapPaneAlignmentToAlignSelf,
   normalizeSegmentContentForMode,
   updateSegmentContent,
 } from '@/src/features/story/utils/storySegmentContent';
+
+describe('getSegmentPaneAlignment', () => {
+  it('uses stored alignment when set', () => {
+    expect(
+      getSegmentPaneAlignment(
+        { contentMode: 'map', paneAlignment: 'start' },
+        'map',
+      ),
+    ).toBe('start');
+  });
+
+  it('falls back to end for map segments without alignment', () => {
+    expect(getSegmentPaneAlignment({ contentMode: 'map' }, 'map')).toBe('end');
+  });
+
+  it('falls back to center for markdown segments without alignment', () => {
+    expect(
+      getSegmentPaneAlignment({ contentMode: 'markdown' }, 'markdown'),
+    ).toBe('center');
+  });
+});
+
+describe('mapPaneAlignmentToAlignSelf', () => {
+  it('maps schema values to flex align-self keywords', () => {
+    expect(mapPaneAlignmentToAlignSelf('start')).toBe('flex-start');
+    expect(mapPaneAlignmentToAlignSelf('center')).toBe('center');
+    expect(mapPaneAlignmentToAlignSelf('end')).toBe('flex-end');
+  });
+});
 
 describe('normalizeSegmentContentForMode', () => {
   it('keeps map fields when switching to map', () => {
@@ -11,6 +42,7 @@ describe('normalizeSegmentContentForMode', () => {
           contentMode: 'markdown',
           markdown: '# Hello',
           title: 'ignored',
+          paneAlignment: 'start',
         },
         'map',
       ),
@@ -19,6 +51,7 @@ describe('normalizeSegmentContentForMode', () => {
       title: 'ignored',
       image: '',
       markdown: '# Hello',
+      paneAlignment: 'start',
     });
   });
 
@@ -30,12 +63,14 @@ describe('normalizeSegmentContentForMode', () => {
           title: 'Flood stage',
           image: 'hero.png',
           markdown: 'Caption text',
+          paneAlignment: 'end',
         },
         'markdown',
       ),
     ).toEqual({
       contentMode: 'markdown',
       markdown: 'Caption text',
+      paneAlignment: 'end',
     });
   });
 });

--- a/packages/base/src/features/story/__tests__/storySegmentContent.spec.ts
+++ b/packages/base/src/features/story/__tests__/storySegmentContent.spec.ts
@@ -1,6 +1,6 @@
 import {
   getSegmentPaneAlignment,
-  mapPaneAlignmentToAlignSelf,
+  segmentPaneAlignment,
   normalizeSegmentContentForMode,
   updateSegmentContent,
 } from '@/src/features/story/utils/storySegmentContent';
@@ -26,11 +26,11 @@ describe('getSegmentPaneAlignment', () => {
   });
 });
 
-describe('mapPaneAlignmentToAlignSelf', () => {
+describe('segmentPaneAlignment', () => {
   it('maps schema values to flex align-self keywords', () => {
-    expect(mapPaneAlignmentToAlignSelf('start')).toBe('flex-start');
-    expect(mapPaneAlignmentToAlignSelf('center')).toBe('center');
-    expect(mapPaneAlignmentToAlignSelf('end')).toBe('flex-end');
+    expect(segmentPaneAlignment('start')).toBe('flex-start');
+    expect(segmentPaneAlignment('center')).toBe('center');
+    expect(segmentPaneAlignment('end')).toBe('flex-end');
   });
 });
 

--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -14,6 +14,7 @@ import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSeg
 import type {
   IListStorySegmentTransition,
   StorySegmentDisplayMode,
+  StorySegmentPaneAlignment,
   IStorySegmentViewItem,
 } from '@/src/features/story/types/types';
 import { isIntraSegmentScroll } from '@/src/features/story/utils/computeListStoryScrollState';
@@ -23,6 +24,10 @@ import {
   getTransitionTranslatePx,
 } from '@/src/features/story/utils/listStoryScrollTrack';
 import { getSpectaPresentationCssVars } from '@/src/features/story/utils/spectaPresentation';
+import {
+  getSegmentPaneAlignment,
+  segmentPaneAlignment,
+} from '@/src/features/story/utils/storySegmentContent';
 import {
   buildStorySegmentViewItems,
   getStoryMarkdownFromSlide,
@@ -35,8 +40,17 @@ interface IListStoryStageOverlayProps {
 }
 
 type SegmentOverlayPaneConfig =
-  | { type: 'markdown'; markdown: string; segmentId: string }
-  | { type: 'map'; segmentIndex: number };
+  | {
+      type: 'markdown';
+      markdown: string;
+      segmentId: string;
+      paneAlignment: StorySegmentPaneAlignment;
+    }
+  | {
+      type: 'map';
+      segmentIndex: number;
+      paneAlignment: StorySegmentPaneAlignment;
+    };
 
 type OverlayPaneRole = 'from' | 'to' | 'lookahead';
 
@@ -44,6 +58,7 @@ const EMPTY_MARKDOWN_PANE: SegmentOverlayPaneConfig = {
   type: 'markdown',
   markdown: '',
   segmentId: '',
+  paneAlignment: 'center',
 };
 
 interface IOverlayStackPane {
@@ -65,13 +80,21 @@ function buildPaneConfig(
   if (!item) {
     return EMPTY_MARKDOWN_PANE;
   }
+
+  const paneAlignment = getSegmentPaneAlignment(
+    item.activeSlide?.content,
+    mode,
+  );
+
   if (mode === 'map') {
-    return { type: 'map', segmentIndex: item.index };
+    return { type: 'map', segmentIndex: item.index, paneAlignment };
   }
+
   return {
     type: 'markdown',
     markdown: getStoryMarkdownFromSlide(item.activeSlide),
     segmentId: item.id,
+    paneAlignment,
   };
 }
 
@@ -193,11 +216,18 @@ function segmentConfigsEqual(
   }
 
   if (prev.type === 'map' && next.type === 'map') {
-    return prev.segmentIndex === next.segmentIndex;
+    return (
+      prev.segmentIndex === next.segmentIndex &&
+      prev.paneAlignment === next.paneAlignment
+    );
   }
 
   if (prev.type === 'markdown' && next.type === 'markdown') {
-    return prev.segmentId === next.segmentId && prev.markdown === next.markdown;
+    return (
+      prev.segmentId === next.segmentId &&
+      prev.markdown === next.markdown &&
+      prev.paneAlignment === next.paneAlignment
+    );
   }
 
   return false;
@@ -229,6 +259,7 @@ const SegmentOverlayPane = React.memo(
     onPaneUnmount,
   }: ISegmentOverlayPaneProps): React.ReactElement => {
     const isMap = config.type === 'map';
+    const alignSelf = segmentPaneAlignment(config.paneAlignment);
 
     useLayoutEffect(() => {
       return () => {
@@ -243,6 +274,10 @@ const SegmentOverlayPane = React.memo(
         className={`jgis-story-segment-overlay-pane jgis-story-${
           isMap ? 'map' : 'markdown'
         }-scroll-pane`}
+        style={{
+          alignSelf,
+          ...(isMap ? { alignItems: alignSelf } : undefined),
+        }}
       >
         {isMap ? (
           <ListStoryMapOverlayPanel

--- a/packages/base/src/features/story/components/SegmentPaneAlignmentPicker.tsx
+++ b/packages/base/src/features/story/components/SegmentPaneAlignmentPicker.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import type { StorySegmentPaneAlignment } from '@/src/features/story/types/types';
+import { Button } from '@/src/shared/components/Button';
+import { ButtonGroup } from '@/src/shared/components/ButtonGroup';
+
+const PANE_ALIGNMENT_OPTIONS: {
+  value: StorySegmentPaneAlignment;
+  label: string;
+}[] = [
+  { value: 'start', label: 'Left' },
+  { value: 'center', label: 'Center' },
+  { value: 'end', label: 'Right' },
+];
+
+export interface ISegmentPaneAlignmentPickerProps {
+  value: StorySegmentPaneAlignment;
+  onChange: (alignment: StorySegmentPaneAlignment) => void;
+}
+
+export function SegmentPaneAlignmentPicker({
+  value,
+  onChange,
+}: ISegmentPaneAlignmentPickerProps): JSX.Element {
+  return (
+    <section className="jgis-story-editor-block">
+      <div className="jgis-story-editor-label">Pane alignment</div>
+      <ButtonGroup
+        className="jgis-story-editor-pane-alignment-picker"
+        aria-label="Pane alignment"
+      >
+        {PANE_ALIGNMENT_OPTIONS.map(option => (
+          <Button
+            key={option.value}
+            type="button"
+            variant="outline"
+            className={
+              value === option.value
+                ? 'jgis-story-editor-pane-alignment-button--selected'
+                : undefined
+            }
+            aria-pressed={value === option.value}
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </ButtonGroup>
+    </section>
+  );
+}

--- a/packages/base/src/features/story/components/SegmentPaneAlignmentPicker.tsx
+++ b/packages/base/src/features/story/components/SegmentPaneAlignmentPicker.tsx
@@ -25,20 +25,12 @@ export function SegmentPaneAlignmentPicker({
   return (
     <section className="jgis-story-editor-block">
       <div className="jgis-story-editor-label">Pane alignment</div>
-      <ButtonGroup
-        className="jgis-story-editor-pane-alignment-picker"
-        aria-label="Pane alignment"
-      >
+      <ButtonGroup aria-label="Pane alignment">
         {PANE_ALIGNMENT_OPTIONS.map(option => (
           <Button
             key={option.value}
             type="button"
-            variant="outline"
-            className={
-              value === option.value
-                ? 'jgis-story-editor-pane-alignment-button--selected'
-                : undefined
-            }
+            variant={value === option.value ? 'secondary' : 'outline'}
             aria-pressed={value === option.value}
             onClick={() => onChange(option.value)}
           >

--- a/packages/base/src/features/story/types/types.ts
+++ b/packages/base/src/features/story/types/types.ts
@@ -2,6 +2,8 @@ import type { IStorySegmentLayer } from '@jupytergis/schema';
 
 export type StorySegmentDisplayMode = 'map' | 'markdown';
 
+export type StorySegmentPaneAlignment = 'start' | 'center' | 'end';
+
 export const SegmentInteractionMode = {
   mapView: 'map-view',
   previewingSegment: 'previewing-segment',

--- a/packages/base/src/features/story/utils/spectaPresentation.ts
+++ b/packages/base/src/features/story/utils/spectaPresentation.ts
@@ -67,6 +67,10 @@ export function matchOverlayContentWidthPreset(
   return preset?.id ?? null;
 }
 
+export function isOverlayContentWidthFull(width: string | undefined): boolean {
+  return resolveOverlayContentWidthValue(width) === '100%';
+}
+
 export function parseOverlayContentWidth(width: string | undefined): {
   amount: string;
   unit: OverlayContentWidthUnit;

--- a/packages/base/src/features/story/utils/storySegmentContent.ts
+++ b/packages/base/src/features/story/utils/storySegmentContent.ts
@@ -1,14 +1,46 @@
 import type { IJupyterGISModel, IStorySegmentLayer } from '@jupytergis/schema';
 
-import type { StorySegmentDisplayMode } from '@/src/features/story/types/types';
+import type {
+  StorySegmentDisplayMode,
+  StorySegmentPaneAlignment,
+} from '@/src/features/story/types/types';
 
 type SegmentContent = NonNullable<IStorySegmentLayer['content']>;
 
 export type SegmentContentPatch = Partial<
-  Pick<SegmentContent, 'title' | 'markdown' | 'image' | 'attachments'>
+  Pick<
+    SegmentContent,
+    'title' | 'markdown' | 'image' | 'attachments' | 'paneAlignment'
+  >
 >;
 
 const EMPTY_SEGMENT_CONTENT: SegmentContent = { contentMode: 'map' };
+
+/** Legacy default when paneAlignment is unset so we dont need to migrate
+ * map -> end, markdown -> center. */
+export function getSegmentPaneAlignment(
+  content: SegmentContent | undefined,
+  mode: StorySegmentDisplayMode,
+): StorySegmentPaneAlignment {
+  if (content?.paneAlignment) {
+    return content.paneAlignment;
+  }
+
+  return mode === 'map' ? 'end' : 'center';
+}
+
+export function segmentPaneAlignment(
+  alignment: StorySegmentPaneAlignment,
+): 'flex-start' | 'center' | 'flex-end' {
+  switch (alignment) {
+    case 'start':
+      return 'flex-start';
+    case 'end':
+      return 'flex-end';
+    default:
+      return 'center';
+  }
+}
 
 export function normalizeSegmentContentForMode(
   content: SegmentContent | undefined,
@@ -21,6 +53,7 @@ export function normalizeSegmentContentForMode(
       contentMode: 'markdown',
       markdown: value.markdown ?? '',
       attachments: value.attachments,
+      paneAlignment: value.paneAlignment,
     };
   }
 
@@ -30,6 +63,7 @@ export function normalizeSegmentContentForMode(
     image: value.image ?? '',
     markdown: value.markdown ?? '',
     attachments: value.attachments,
+    paneAlignment: value.paneAlignment,
   };
 }
 

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -549,6 +549,17 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   );
 }
 
+.jgis-story-editor-pane-alignment-picker
+  .jgis-button.jgis-story-editor-pane-alignment-button--selected {
+  border-color: var(--jp-brand-color1);
+  background: color-mix(
+    in srgb,
+    var(--jp-brand-color1) 8%,
+    var(--jp-layout-color1)
+  );
+  z-index: 1;
+}
+
 .jgis-story-map-interaction-bar-root {
   pointer-events: auto;
 }

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -549,17 +549,6 @@ button.jgis-story-editor-segment-item.jp-mod-styled.jgis-story-editor-segment-it
   );
 }
 
-.jgis-story-editor-pane-alignment-picker
-  .jgis-button.jgis-story-editor-pane-alignment-button--selected {
-  border-color: var(--jp-brand-color1);
-  background: color-mix(
-    in srgb,
-    var(--jp-brand-color1) 8%,
-    var(--jp-layout-color1)
-  );
-  z-index: 1;
-}
-
 .jgis-story-map-interaction-bar-root {
   pointer-events: auto;
 }

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -382,7 +382,6 @@
       calc(var(--jgis-story-markdown-segment-opacity, 1) * 100%),
     transparent
   );
-  margin: 0 auto;
   padding: 1rem;
 }
 
@@ -398,7 +397,6 @@
   height: auto;
   box-sizing: border-box;
   width: var(--jgis-story-overlay-content-width, 100%);
-  margin: 0 auto;
 }
 
 .jgis-story-segment-transition-stack .jgis-story-map-scroll-pane {
@@ -415,8 +413,7 @@
   justify-content: space-evenly;
   box-sizing: border-box;
   background-color: transparent;
-  align-items: flex-end;
-  padding-right: 1rem;
+  padding-inline: 1rem;
 }
 
 .jgis-story-map-overlay-content {

--- a/packages/schema/src/schema/project/layers/storySegmentLayer.json
+++ b/packages/schema/src/schema/project/layers/storySegmentLayer.json
@@ -26,6 +26,13 @@
           "enum": ["map", "markdown"],
           "default": "map"
         },
+        "paneAlignment": {
+          "type": "string",
+          "title": "Pane Alignment",
+          "description": "Horizontal alignment of the segment overlay pane",
+          "enum": ["start", "center", "end"],
+          "default": "center"
+        },
         "title": {
           "title": "Segment Title",
           "type": "string",


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->

## Checklist
Adds the option to set the alignment of story segments when the width is not set to full.


<img width="1163" height="803" alt="image" src="https://github.com/user-attachments/assets/e8a18320-1333-4131-9c03-1a0556a4d621" />

<img width="1063" height="931" alt="image" src="https://github.com/user-attachments/assets/e42b2798-3b0a-4cd5-a943-2f399bbd0cd6" />

<img width="1063" height="931" alt="image" src="https://github.com/user-attachments/assets/cdfa99cf-f63d-496d-a6c9-b9fcadd19906" />

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1756.org.readthedocs.build/en/1756/
💡 JupyterLite preview: https://jupytergis--1756.org.readthedocs.build/en/1756/lite
💡 Specta preview: https://jupytergis--1756.org.readthedocs.build/en/1756/lite/specta

<!-- readthedocs-preview jupytergis end -->