### PR TITLE
Remove replaceLayer method

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2113,6 +2113,60 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     return scaled;
   };
 
+  private _syncGrammarSubLayers(
+    id: string,
+    layer: IJGISLayer,
+    mapLayer: Layer | LayerGroup,
+  ): void {
+    const layerParams = layer.parameters as
+      | IVectorLayer
+      | IGeoTiffLayer
+      | IGeoZarrLayer
+      | undefined;
+    const grammarState = layerParams?.symbologyState as
+      | IGrammarSymbologyState
+      | undefined;
+
+    if (!grammarState || !Array.isArray(grammarState.layers)) {
+      return;
+    }
+
+    const sourceId = layerParams?.source;
+    const source = sourceId ? this._sources[sourceId] : undefined;
+    const rows =
+      source instanceof VectorSource
+        ? source.getFeatures().map(f => (f as Feature).getProperties())
+        : [];
+    const featureValues = extractEncodingFieldValues(grammarState, rows);
+    const nextLayer = grammarToOLLayer(
+      grammarState,
+      source,
+      layerParams?.opacity ?? layer.parameters?.opacity ?? 1,
+      layer.visible,
+      featureValues,
+      layer.type === 'GeoTiffLayer' || layer.type === 'GeoZarrLayer',
+    );
+
+    if (mapLayer instanceof LayerGroup) {
+      const replacementLayers =
+        nextLayer instanceof LayerGroup
+          ? nextLayer.getLayers().getArray()
+          : [nextLayer];
+      mapLayer.setOpacity(
+        layerParams?.opacity ?? layer.parameters?.opacity ?? 1,
+      );
+      mapLayer.setVisible(layer.visible);
+      mapLayer.setLayers(new Collection(replacementLayers));
+      return;
+    }
+
+    nextLayer.set('id', id);
+    const index = this.getLayerIndex(id);
+    if (index !== -1) {
+      this._Map.getLayers().setAt(index, nextLayer);
+    }
+  }
+
   /**
    * Update a layer of the map.
    *
@@ -2139,8 +2193,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         const layerParams = layer.parameters as IVectorLayer;
 
         if (Array.isArray(layerParams.symbologyState?.layers)) {
-          // Grammar layers may change structure (e.g. KDE added/removed) — rebuild.
-          this.replaceLayer(id, layer);
+          this._syncGrammarSubLayers(id, layer, mapLayer as Layer | LayerGroup);
           break;
         }
 
@@ -2174,7 +2227,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       }
       case 'GeoTiffLayer': {
         if (Array.isArray(layer?.parameters?.symbologyState?.layers)) {
-          this.replaceLayer(id, layer);
+          this._syncGrammarSubLayers(id, layer, mapLayer as Layer | LayerGroup);
         } else {
           mapLayer.setOpacity(layer.parameters?.opacity);
           if (layer?.parameters?.color) {
@@ -2187,7 +2240,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       }
       case 'GeoZarrLayer': {
         if (Array.isArray(layer?.parameters?.symbologyState?.layers)) {
-          this.replaceLayer(id, layer);
+          this._syncGrammarSubLayers(id, layer, mapLayer as Layer | LayerGroup);
           break;
         }
 
@@ -2866,17 +2919,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this._Map.getLayers().insertAt(safeIndex, layer);
   }
 
-  /**
-   * Remove and recreate layer
-   * @param id ID of layer being replaced
-   * @param layer New layer to replace with
-   */
-  replaceLayer(id: string, layer: IJGISLayer) {
-    const layerIndex = this.getLayerIndex(id);
-    this.removeLayer(id);
-    this.addLayer(id, layer, layerIndex);
-  }
-
   private _onLayersChanged(
     _: IJupyterGISDoc,
     change: IJGISLayerDocChange,
@@ -2899,11 +2941,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           this._model.currentMode = 'panning';
           this._notifyInteractionModeCommands();
         }
-        return;
-      }
-
-      if (oldLayer && oldLayer.type !== newLayer.type) {
-        this.replaceLayer(id, newLayer);
         return;
       }
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2148,15 +2148,23 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     );
 
     if (mapLayer instanceof LayerGroup) {
-      const replacementLayers =
-        nextLayer instanceof LayerGroup
-          ? nextLayer.getLayers().getArray()
-          : [nextLayer];
-      mapLayer.setOpacity(
-        layerParams?.opacity ?? layer.parameters?.opacity ?? 1,
-      );
-      mapLayer.setVisible(layer.visible);
-      mapLayer.setLayers(new Collection(replacementLayers));
+      if (nextLayer instanceof LayerGroup) {
+        const replacementLayers = nextLayer.getLayers().getArray();
+        mapLayer.setOpacity(
+          layerParams?.opacity ?? layer.parameters?.opacity ?? 1,
+        );
+        mapLayer.setVisible(layer.visible);
+        mapLayer.setLayers(new Collection(replacementLayers));
+        return;
+      }
+
+      // Collapse back to a single top-level layer so tools that expect a
+      // concrete OL Layer (fly-to/identify) keep working.
+      nextLayer.set('id', id);
+      const index = this.getLayerIndex(id);
+      if (index !== -1) {
+        this._Map.getLayers().setAt(index, nextLayer);
+      }
       return;
     }
 


### PR DESCRIPTION
## Description

Fix https://github.com/geojupyter/jupytergis/issues/1748

I don't really like that code though. I think we could make a pass at cleaning the `_buildMapLayer` and `updateLayer` to have them share more code. Also we may benefit from only handling `LayerGroup`s.

<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1758.org.readthedocs.build/en/1758/
💡 JupyterLite preview: https://jupytergis--1758.org.readthedocs.build/en/1758/lite
💡 Specta preview: https://jupytergis--1758.org.readthedocs.build/en/1758/lite/specta

<!-- readthedocs-preview jupytergis end -->