### PR TITLE
Story mode: Fix code blocks color

### DIFF
--- a/packages/base/style/storySpectaArticleOverlay.css
+++ b/packages/base/style/storySpectaArticleOverlay.css
@@ -136,14 +136,12 @@
 }
 
 .jgis-story-rendered-markdown .specta-article-host-widget pre code {
-  color: #222;
   background-color: transparent !important;
   padding: 0;
   font-size: 0.875rem !important;
 }
 
 .jgis-story-rendered-markdown .specta-article-host-widget code {
-  background-color: #e9ecef;
   padding: 0.2em 0.4em;
   border-radius: 4px;
   font-size: 0.875rem !important;


### PR DESCRIPTION
## Description

Fix code color in code blocks, let the theme handle the color.

I am not sure about whether we should upstream this to specta? I dislike that we ship the specta CSS this way. Maybe we could try to find a way to improve this, I wonder if tools like https://sass-lang.com/ or equivalent can allow us to scope the CSS easily.

<img width="2817" height="1908" alt="Screenshot 2026-08-19 at 15 05 47" src="https://github.com/user-attachments/assets/8b44202d-5b32-4c54-9266-4e4941dcfb99" />


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1771.org.readthedocs.build/en/1771/
💡 JupyterLite preview: https://jupytergis--1771.org.readthedocs.build/en/1771/lite
💡 Specta preview: https://jupytergis--1771.org.readthedocs.build/en/1771/lite/specta

<!-- readthedocs-preview jupytergis end -->