### PR TITLE
Fix icon alignment

### DIFF
--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -287,7 +287,7 @@ button.jp-mod-styled.jp-mod-reject {
 }
 
 .jgis-icon-adjust {
-  padding-top: 5px;
+  padding-top: 2.4px;
 }
 
 .jgis-inline-icon {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix story editor icon alignment.

Before:
<img width="446" height="118" alt="image" src="https://github.com/user-attachments/assets/990ba1b4-cf10-482b-8bcd-eea65f6c49e0" />

After:
<img width="446" height="118" alt="image" src="https://github.com/user-attachments/assets/d7db8cc2-4799-4136-a497-6a1fa697646d" />

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1773.org.readthedocs.build/en/1773/
💡 JupyterLite preview: https://jupytergis--1773.org.readthedocs.build/en/1773/lite
💡 Specta preview: https://jupytergis--1773.org.readthedocs.build/en/1773/lite/specta

<!-- readthedocs-preview jupytergis end -->