### PR TITLE
Replace CFF license array with string to fixup Zenodo integration

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ abstract: >-
   environment in JupyterLab.
 
 type: "software"
-license: ["BSD-3-Clause"]
+license: "BSD-3-Clause"
 keywords:
   - "Jupyter"
   - "GIS"


### PR DESCRIPTION
## Description

See: <https://github.com/zenodo/zenodo/issues/2515> -- still not fixed!

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1779.org.readthedocs.build/en/1779/
💡 JupyterLite preview: https://jupytergis--1779.org.readthedocs.build/en/1779/lite
💡 Specta preview: https://jupytergis--1779.org.readthedocs.build/en/1779/lite/specta

<!-- readthedocs-preview jupytergis end -->