### PR TITLE
Remove hardcoded colors in specta presentation css

### DIFF
--- a/packages/base/style/storySpectaArticleOverlay.css
+++ b/packages/base/style/storySpectaArticleOverlay.css
@@ -115,7 +115,6 @@
 }
 
 .jgis-story-rendered-markdown .specta-article-host-widget a {
-  color: #007bff;
   text-decoration: none;
 }
 
@@ -160,7 +159,7 @@
 }
 
 .jgis-story-rendered-markdown .specta-article-host-widget blockquote {
-  border-left: 3px solid #ffffff00;
+  border-left: 3px solid;
   padding-left: 1rem;
   margin: 1.2em 0;
   font-style: italic;
@@ -187,7 +186,6 @@
 .jgis-story-rendered-markdown .specta-article-host-widget hr {
   border: 0;
   height: 1px;
-  background-color: #ddd;
   margin: 2em 0;
 }
 
@@ -200,13 +198,12 @@
 
 .jgis-story-rendered-markdown .specta-article-host-widget th,
 .jgis-story-rendered-markdown .specta-article-host-widget td {
-  border: 1px solid #ddd;
+  border: 1px solid;
   padding: 0.375rem 0.625rem;
   text-align: left;
 }
 
 .jgis-story-rendered-markdown .specta-article-host-widget th {
-  background-color: #f7f7f7;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
This remove some hardcoded color values so the theme colors are not overridden in a story presentation.
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1784.org.readthedocs.build/en/1784/
💡 JupyterLite preview: https://jupytergis--1784.org.readthedocs.build/en/1784/lite
💡 Specta preview: https://jupytergis--1784.org.readthedocs.build/en/1784/lite/specta

<!-- readthedocs-preview jupytergis end -->