### PR TITLE
ignore zero-width resizes for mobile mode

### DIFF
--- a/packages/base/src/shared/hooks/useIsMobile.ts
+++ b/packages/base/src/shared/hooks/useIsMobile.ts
@@ -32,6 +32,9 @@ export function useIsMobile(
     }
 
     const update = (width: number): void => {
+      if (width === 0) {
+        return;
+      }
       setIsMobile(width < breakpoint);
     };
 


### PR DESCRIPTION
## Description

`useIsMobile` now ignores `width === 0` readings instead of just treating them as "narrow" and flipping into mobile layout.

I found this while debugging an issue on another branch. Ended up not being related, so I split it out here.

ResizeObserver can report a width of 0 for a container that's momentarily unmeasured. Since 0 < breakpoint is always true, that reading would flip the layout into mobile mode even though the container isn't actually narrow. This likely doesn't currently happen in practice, but it's not guaranteed, so it's worth guarding against.

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1787.org.readthedocs.build/en/1787/
💡 JupyterLite preview: https://jupytergis--1787.org.readthedocs.build/en/1787/lite
💡 Specta preview: https://jupytergis--1787.org.readthedocs.build/en/1787/lite/specta

<!-- readthedocs-preview jupytergis end -->