### PR TITLE
Fix missing signal disconnects in MainView.componentWillUnmount

### DIFF
--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -467,6 +467,29 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       this._onSharedOptionsChanged,
       this,
     );
+    this._model.sharedLayersChanged.disconnect(this._onLayersChanged, this);
+    this._model.sharedLayerTreeChanged.disconnect(
+      this._onLayerTreeChange,
+      this,
+    );
+    this._model.sharedSourcesChanged.disconnect(this._onSourcesChange, this);
+    this._model.sharedModel.changed.disconnect(this._onSharedModelStateChange);
+    this._model.sharedAnnotationsChanged.disconnect(
+      this._onAnnotationsChanged,
+      this,
+    );
+    this._model.zoomToPositionSignal.disconnect(this._onZoomToPosition, this);
+    this._model.updateLayerSignal.disconnect(this._triggerLayerUpdate, this);
+    this._model.addFeatureAsMsSignal.disconnect(this._convertFeatureToMs, this);
+    this._model.geolocationChanged.disconnect(
+      this._handleGeolocationChanged,
+      this,
+    );
+    this._model.flyToGeometrySignal.disconnect(this.flyToGeometry, this);
+    this._model.highlightFeatureSignal.disconnect(
+      this.highlightFeatureOnMap,
+      this,
+    );
 
     this._model.temporalControllerActiveChanged.disconnect(
       this._handleTemporalControllerActiveChanged,


### PR DESCRIPTION
## Description
componentWillUnmount connected 11 signals in componentDidMount but never disconnected them. This adds the missing disconnects so the component cleans up fully on unmount.

I added this while debugging a separate pr, but it ended up not being relevant, so I'm splitting it out here.

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1788.org.readthedocs.build/en/1788/
💡 JupyterLite preview: https://jupytergis--1788.org.readthedocs.build/en/1788/lite
💡 Specta preview: https://jupytergis--1788.org.readthedocs.build/en/1788/lite/specta

<!-- readthedocs-preview jupytergis end -->