### PR TITLE
Story markdown fixes

### DIFF
--- a/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
+++ b/packages/base/src/features/story/components/ListStoryStageOverlay.tsx
@@ -12,6 +12,7 @@ import { ListStoryOverlayMarkdown } from '@/src/features/story/components/ListSt
 import { useListStoryScrollTrackContext } from '@/src/features/story/context/ListStoryScrollTrackContext';
 import { useCurrentSegmentIndex } from '@/src/features/story/hooks/useCurrentSegmentIndex';
 import type {
+  IListStoryScrollTrackLayout,
   IListStorySegmentTransition,
   StorySegmentDisplayMode,
   StorySegmentPaneAlignment,
@@ -24,6 +25,7 @@ import {
 } from '@/src/features/story/utils/cssWidth';
 import { getHandoffGapHeight } from '@/src/features/story/utils/getHandoffGapHeight';
 import {
+  estimateMarkdownHeight,
   getSegmentDisplayMode,
   getTransitionTranslatePx,
 } from '@/src/features/story/utils/listStoryScrollTrack';
@@ -109,29 +111,101 @@ function buildPaneConfig(
   };
 }
 
-function getMarkdownLookaheadIndex(
+/** Extra px past the viewport so the next short markdown is already painted. */
+const MARKDOWN_LOOKAHEAD_OVERSCAN_PX = 64;
+
+function overlayPaneHeight(
+  mode: StorySegmentDisplayMode,
+  segmentIndex: number,
+  layout: IListStoryScrollTrackLayout | null,
+  viewportHeight: number,
   items: IStorySegmentViewItem[],
-  afterIndex: number,
-  markdownSegmentGap: boolean,
-): number | null {
+): number {
+  if (mode === 'map') {
+    return Math.max(viewportHeight, 0);
+  }
+
+  const layoutHeight =
+    layout?.segments.find(segment => segment.index === segmentIndex)?.height ??
+    0;
+  if (layoutHeight > 0) {
+    return layoutHeight;
+  }
+
+  const item = items.find(entry => entry.index === segmentIndex);
+  const markdown = getStoryMarkdownFromSlide(item?.activeSlide);
+  return estimateMarkdownHeight(markdown, Math.max(viewportHeight, 1));
+}
+
+function appendMarkdownLookaheadPanes({
+  panes,
+  items,
+  afterIndex,
+  markdownSegmentGap,
+  viewportHeight,
+  layout,
+}: {
+  panes: IOverlayStackPane[];
+  items: IStorySegmentViewItem[];
+  afterIndex: number;
+  markdownSegmentGap: boolean;
+  viewportHeight: number;
+  layout: IListStoryScrollTrackLayout | null;
+}): void {
   if (markdownSegmentGap) {
-    return null;
+    return;
   }
 
   const current = items.find(item => item.index === afterIndex);
-  const next = items.find(item => item.index === afterIndex + 1);
-  if (!current || !next) {
-    return null;
+  if (!current || getSegmentDisplayMode(current.activeSlide) !== 'markdown') {
+    return;
   }
 
-  if (
-    getSegmentDisplayMode(current.activeSlide) === 'markdown' &&
-    getSegmentDisplayMode(next.activeSlide) === 'markdown'
-  ) {
-    return next.index;
-  }
+  // Only panes at/after the anchor count toward filling the viewport.
+  // Outgoing `from` + handoff gap sit above the translate and must not
+  // suppress lookahead into a short markdown run.
+  let mountedHeight = panes
+    .filter(pane => pane.segmentIndex >= afterIndex)
+    .reduce(
+      (sum, pane) =>
+        sum +
+        overlayPaneHeight(
+          pane.mode,
+          pane.segmentIndex,
+          layout,
+          viewportHeight,
+          items,
+        ),
+      0,
+    );
 
-  return null;
+  const fillUntil =
+    Math.max(viewportHeight, 0) + MARKDOWN_LOOKAHEAD_OVERSCAN_PX;
+  let prevIndex = afterIndex;
+
+  while (mountedHeight < fillUntil) {
+    const next = items.find(item => item.index === prevIndex + 1);
+    if (!next || getSegmentDisplayMode(next.activeSlide) !== 'markdown') {
+      break;
+    }
+
+    panes.push({
+      role: 'lookahead',
+      segmentIndex: next.index,
+      mode: 'markdown',
+      config: buildPaneConfig(next, 'markdown'),
+    });
+
+    mountedHeight += overlayPaneHeight(
+      'markdown',
+      next.index,
+      layout,
+      viewportHeight,
+      items,
+    );
+
+    prevIndex = next.index;
+  }
 }
 
 function buildOverlayStack({
@@ -140,12 +214,16 @@ function buildOverlayStack({
   items,
   handoffGapHeight,
   markdownSegmentGap,
+  viewportHeight,
+  layout,
 }: {
   transition: IListStorySegmentTransition;
   intraSegmentScroll: boolean;
   items: IStorySegmentViewItem[];
   handoffGapHeight: number;
   markdownSegmentGap: boolean;
+  viewportHeight: number;
+  layout: IListStoryScrollTrackLayout | null;
 }): IOverlayStack {
   const fromItem = items.find(item => item.index === transition.fromIndex);
 
@@ -158,21 +236,14 @@ function buildOverlayStack({
 
   if (intraSegmentScroll) {
     const panes = [fromPane];
-    const lookaheadIndex = getMarkdownLookaheadIndex(
+    appendMarkdownLookaheadPanes({
+      panes,
       items,
-      transition.fromIndex,
+      afterIndex: transition.fromIndex,
       markdownSegmentGap,
-    );
-
-    if (lookaheadIndex !== null) {
-      const lookaheadItem = items.find(item => item.index === lookaheadIndex);
-      panes.push({
-        role: 'lookahead',
-        segmentIndex: lookaheadIndex,
-        mode: 'markdown',
-        config: buildPaneConfig(lookaheadItem, 'markdown'),
-      });
-    }
+      viewportHeight,
+      layout,
+    });
 
     return { panes, includeGap: false };
   }
@@ -188,21 +259,14 @@ function buildOverlayStack({
     },
   ];
 
-  const lookaheadIndex = getMarkdownLookaheadIndex(
+  appendMarkdownLookaheadPanes({
+    panes,
     items,
-    transition.toIndex,
+    afterIndex: transition.toIndex,
     markdownSegmentGap,
-  );
-
-  if (lookaheadIndex !== null) {
-    const lookaheadItem = items.find(item => item.index === lookaheadIndex);
-    panes.push({
-      role: 'lookahead',
-      segmentIndex: lookaheadIndex,
-      mode: 'markdown',
-      config: buildPaneConfig(lookaheadItem, 'markdown'),
-    });
-  }
+    viewportHeight,
+    layout,
+  });
 
   return { panes, includeGap: handoffGapHeight > 0 };
 }
@@ -460,6 +524,8 @@ export function ListStoryStageOverlay({
       items,
       handoffGapHeight,
       markdownSegmentGap,
+      viewportHeight: stageHeight,
+      layout: scrollTrackLayout,
     });
   }, [
     transition,
@@ -467,6 +533,8 @@ export function ListStoryStageOverlay({
     items,
     handoffGapHeight,
     markdownSegmentGap,
+    stageHeight,
+    scrollTrackLayout,
   ]);
 
   const fromStackPane = overlayStack.panes.find(pane => pane.role === 'from');

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -107,9 +107,9 @@ export const RenderedStoryMarkdown = memo(
         try {
           await renderer.renderModel(mimeModel);
         } catch (error) {
-          console.error('Failed to render story markdown', error);
-          disposeRenderer(renderer);
-          return;
+          // URL resolve can throw on missing local images (Specta contents
+          // manager). Jupyter already painted the markdown so don't dispose.
+          console.warn('Story markdown rendered with errors', error);
         }
 
         if (cancelled || renderer.isDisposed) {

--- a/packages/base/src/features/story/components/StoryRenderMime.tsx
+++ b/packages/base/src/features/story/components/StoryRenderMime.tsx
@@ -2,6 +2,7 @@ import type { IJupyterGISModel } from '@jupytergis/schema';
 import { AttachmentsModel, AttachmentsResolver } from '@jupyterlab/attachments';
 import {
   RenderMimeRegistry,
+  type IRenderMime,
   type IRenderMimeRegistry,
   type IUrlResolverFactory,
 } from '@jupyterlab/rendermime';
@@ -22,6 +23,29 @@ function getUrlResolverFactory(
   );
 }
 
+function wrapResolverSoftFail(
+  resolver: IRenderMime.IResolver,
+): IRenderMime.IResolver {
+  return {
+    resolveUrl: async (url, context) => {
+      try {
+        return await resolver.resolveUrl(url, context);
+      } catch {
+        return url;
+      }
+    },
+    getDownloadUrl: async urlPath => {
+      try {
+        return await resolver.getDownloadUrl(urlPath);
+      } catch {
+        return urlPath;
+      }
+    },
+    isLocal: resolver.isLocal?.bind(resolver),
+    resolvePath: resolver.resolvePath?.bind(resolver),
+  };
+}
+
 function createStoryRenderMimeRegistry(
   rendermime: IRenderMimeRegistry,
   model: IJupyterGISModel,
@@ -35,10 +59,12 @@ function createStoryRenderMimeRegistry(
     );
   }
 
-  const resolver = getUrlResolverFactory(urlResolverFactory).createResolver({
-    path: filePath,
-    contents: contentsManager,
-  });
+  const resolver = wrapResolverSoftFail(
+    getUrlResolverFactory(urlResolverFactory).createResolver({
+      path: filePath,
+      contents: contentsManager,
+    }),
+  );
 
   return rendermime.clone({ resolver });
 }


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix some issues with vertical stories. Adjusts the lookahead strategy to render more than 3 segments if needed to fill the viewport. Also makes a change the to markdown resolver so broken image links don't kill the entire segment. 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1790.org.readthedocs.build/en/1790/
💡 JupyterLite preview: https://jupytergis--1790.org.readthedocs.build/en/1790/lite
💡 Specta preview: https://jupytergis--1790.org.readthedocs.build/en/1790/lite/specta

<!-- readthedocs-preview jupytergis end -->