### PR TITLE
Don't apply overrides for markdown segments

### DIFF
--- a/packages/base/src/features/story/utils/storySegmentOverrides.ts
+++ b/packages/base/src/features/story/utils/storySegmentOverrides.ts
@@ -1,6 +1,7 @@
 import type { IJupyterGISModel, IStorySegmentLayer } from '@jupytergis/schema';
 
 import type { IOverrideLayerEntry } from '@/src/features/story/types/types';
+import { getSegmentDisplayMode } from '@/src/features/story/utils/listStoryScrollTrack';
 
 export function applySegmentLayerOverrides(
   model: IJupyterGISModel,
@@ -8,9 +9,15 @@ export function applySegmentLayerOverrides(
   entries: IOverrideLayerEntry[],
 ): void {
   const segment = model.getLayer(segmentId);
-  const layerOverrides = (
-    segment?.parameters as IStorySegmentLayer['parameters'] | undefined
-  )?.layerOverride;
+  const parameters = segment?.parameters as
+    | IStorySegmentLayer['parameters']
+    | undefined;
+
+  if (getSegmentDisplayMode(parameters) === 'markdown') {
+    return;
+  }
+
+  const layerOverrides = parameters?.layerOverride;
 
   if (!Array.isArray(layerOverrides)) {
     return;


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix #1769 Don't apply overrides for markdown segments. 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1791.org.readthedocs.build/en/1791/
💡 JupyterLite preview: https://jupytergis--1791.org.readthedocs.build/en/1791/lite
💡 Specta preview: https://jupytergis--1791.org.readthedocs.build/en/1791/lite/specta

<!-- readthedocs-preview jupytergis end -->