### PR TITLE
add type defintion for self._options

### DIFF
--- a/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
+++ b/python/jupytergis_lab/jupytergis_lab/notebook/gis_document.py
@@ -208,6 +208,7 @@ class GISDocument(CommWidget):
         self._presets: Map = Map()
         self.ydoc["presets"] = self._presets
 
+        self._options: Map[str | float | bool | list[float]]
         # For untitled docs, initialize options right away
         if path is None:
             self.ydoc["options"] = self._options = Map(


### PR DESCRIPTION
## Description
resolves #1794

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1795.org.readthedocs.build/en/1795/
💡 JupyterLite preview: https://jupytergis--1795.org.readthedocs.build/en/1795/lite
💡 Specta preview: https://jupytergis--1795.org.readthedocs.build/en/1795/lite/specta

<!-- readthedocs-preview jupytergis end -->