### PR TITLE
Refactor `_onZoomToPosition` to work with `LayerGroups`

### DIFF
--- a/packages/base/src/mainview/__tests__/olLayerZoomExtent.spec.ts
+++ b/packages/base/src/mainview/__tests__/olLayerZoomExtent.spec.ts
@@ -1,0 +1,121 @@
+import type { Layer } from 'ol/layer';
+import type LayerGroup from 'ol/layer/Group';
+import type Projection from 'ol/proj/Projection';
+import { get as getProjection } from 'ol/proj';
+import type { Source } from 'ol/source';
+
+import {
+  getZoomExtentForOlLayer,
+  isValidExtent,
+  transformExtentToViewProjection,
+} from '@/src/mainview/utils/olLayerZoomExtent';
+
+const EPSG3857 = getProjection('EPSG:3857')!;
+const EPSG4326 = getProjection('EPSG:4326')!;
+
+function mockLayer(
+  extent: number[] | undefined,
+  projection: Projection = EPSG3857,
+): Layer {
+  return {
+    getSource: () =>
+      ({
+        getProjection: () => projection,
+        extent,
+      }) as Source & { extent?: number[] },
+  } as Layer;
+}
+
+function mockGroup(layers: Array<Layer | LayerGroup>): LayerGroup {
+  return {
+    getLayers: () => ({
+      getArray: () => layers,
+    }),
+  } as LayerGroup;
+}
+
+function computeFromMockSource(
+  _layer: Layer,
+  source: Source | null,
+): number[] | undefined {
+  return (source as { extent?: number[] } | null)?.extent;
+}
+
+describe('isValidExtent', () => {
+  it('accepts finite four-number extents', () => {
+    expect(isValidExtent([0, 1, 2, 3])).toBe(true);
+  });
+
+  it('rejects non-finite values', () => {
+    expect(isValidExtent([0, 1, Number.NaN, 3])).toBe(false);
+    expect(isValidExtent(undefined)).toBe(false);
+  });
+});
+
+describe('transformExtentToViewProjection', () => {
+  it('returns the same array when projection codes match', () => {
+    const extent = [0, 1, 2, 3];
+    expect(
+      transformExtentToViewProjection(extent, EPSG3857, EPSG3857),
+    ).toBe(extent);
+  });
+
+  it('transforms when projection codes differ', () => {
+    const wgs84Box = [-1, 51, 1, 52];
+    const transformed = transformExtentToViewProjection(
+      wgs84Box,
+      EPSG3857,
+      EPSG4326,
+    );
+    expect(transformed).not.toEqual(wgs84Box);
+    expect(isValidExtent(transformed)).toBe(true);
+  });
+});
+
+describe('getZoomExtentForOlLayer', () => {
+  it('returns extent for a single layer', () => {
+    expect(
+      getZoomExtentForOlLayer(
+        mockLayer([0, 0, 10, 10]),
+        EPSG3857,
+        computeFromMockSource,
+      ),
+    ).toEqual([0, 0, 10, 10]);
+  });
+
+  it('unions extents from sibling layers in a group', () => {
+    expect(
+      getZoomExtentForOlLayer(
+        mockGroup([
+          mockLayer([0, 0, 5, 5]),
+          mockLayer([10, 10, 20, 20]),
+        ]),
+        EPSG3857,
+        computeFromMockSource,
+      ),
+    ).toEqual([0, 0, 20, 20]);
+  });
+
+  it('walks nested layer groups', () => {
+    expect(
+      getZoomExtentForOlLayer(
+        mockGroup([
+          mockGroup([mockLayer([100, 100, 110, 110])]),
+          mockLayer([0, 0, 5, 5]),
+        ]),
+        EPSG3857,
+        computeFromMockSource,
+      ),
+    ).toEqual([0, 0, 110, 110]);
+  });
+
+  it('returns undefined when no child has an extent', () => {
+    expect(
+      getZoomExtentForOlLayer(
+        mockLayer(undefined),
+        EPSG3857,
+        computeFromMockSource,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/base/src/mainview/__tests__/olLayerZoomExtent.spec.ts
+++ b/packages/base/src/mainview/__tests__/olLayerZoomExtent.spec.ts
@@ -1,7 +1,7 @@
 import type { Layer } from 'ol/layer';
 import type LayerGroup from 'ol/layer/Group';
-import type Projection from 'ol/proj/Projection';
 import { get as getProjection } from 'ol/proj';
+import type Projection from 'ol/proj/Projection';
 import type { Source } from 'ol/source';
 
 import {
@@ -55,9 +55,9 @@ describe('isValidExtent', () => {
 describe('transformExtentToViewProjection', () => {
   it('returns the same array when projection codes match', () => {
     const extent = [0, 1, 2, 3];
-    expect(
-      transformExtentToViewProjection(extent, EPSG3857, EPSG3857),
-    ).toBe(extent);
+    expect(transformExtentToViewProjection(extent, EPSG3857, EPSG3857)).toBe(
+      extent,
+    );
   });
 
   it('transforms when projection codes differ', () => {
@@ -86,10 +86,7 @@ describe('getZoomExtentForOlLayer', () => {
   it('unions extents from sibling layers in a group', () => {
     expect(
       getZoomExtentForOlLayer(
-        mockGroup([
-          mockLayer([0, 0, 5, 5]),
-          mockLayer([10, 10, 20, 20]),
-        ]),
+        mockGroup([mockLayer([0, 0, 5, 5]), mockLayer([10, 10, 20, 20])]),
         EPSG3857,
         computeFromMockSource,
       ),

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2424,7 +2424,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   ): number[] {
     const viewProjection = this._Map.getView().getProjection();
 
-    if (sourceProjection && sourceProjection !== viewProjection) {
+    if (
+      sourceProjection &&
+      sourceProjection.getCode() !== viewProjection.getCode()
+    ) {
       return transformExtent(extent, sourceProjection, viewProjection);
     }
 
@@ -2453,10 +2456,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       }
 
       const source = current.getSource();
-      const extent = this._computeExtent(
-        current as Layer | StacLayer,
-        source,
-      );
+      const extent = this._computeExtent(current as Layer | StacLayer, source);
       if (!this._isValidExtent(extent)) {
         continue;
       }

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -71,7 +71,7 @@ import TileState from 'ol/TileState';
 import { FullScreen, ScaleLine, Zoom, Control, Rotate } from 'ol/control';
 import { Coordinate } from 'ol/coordinate';
 import { singleClick } from 'ol/events/condition';
-import { extend, getCenter, getSize } from 'ol/extent';
+import { getCenter, getSize } from 'ol/extent';
 import { GeoJSON, MVT } from 'ol/format';
 import { Geometry, Point } from 'ol/geom';
 import { Type } from 'ol/geom/Geometry';
@@ -165,6 +165,11 @@ import {
   type PatchGeoJSONFeatureAttributes,
 } from './geoJsonFeaturePatch';
 import { MainViewModel } from './mainviewmodel';
+import {
+  getZoomExtentForOlLayer,
+  isValidExtent,
+  transformExtentToViewProjection,
+} from './utils/olLayerZoomExtent';
 import { ensureHighlightLayer } from '../features/identify/utils/highlightLayer';
 import { buildHighlightStyle } from '../features/identify/utils/highlightStyle';
 import {
@@ -2414,77 +2419,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     return undefined;
   }
 
-  private _isValidExtent(extent: number[] | undefined): extent is number[] {
-    return !!extent && extent.every(value => Number.isFinite(value));
-  }
-
-  private _transformExtentToViewProjection(
-    extent: number[],
-    sourceProjection?: ReturnType<Source['getProjection']>,
-  ): number[] {
-    const viewProjection = this._Map.getView().getProjection();
-
-    if (
-      sourceProjection &&
-      sourceProjection.getCode() !== viewProjection.getCode()
-    ) {
-      return transformExtent(extent, sourceProjection, viewProjection);
-    }
-
-    return extent;
-  }
-
-  private _getZoomExtentForOlLayer(
-    olLayer: Layer | LayerGroup,
-  ): number[] | undefined {
-    const stack: Array<Layer | LayerGroup> = [olLayer];
-    let combined: number[] | undefined;
-
-    while (stack.length > 0) {
-      const current = stack.pop();
-      if (!current) {
-        continue;
-      }
-
-      if (current instanceof LayerGroup) {
-        for (const child of current.getLayers().getArray()) {
-          if (child instanceof LayerGroup || child instanceof Layer) {
-            stack.push(child as Layer | LayerGroup);
-          }
-        }
-        continue;
-      }
-
-      const source = current.getSource();
-      const extent = this._computeExtent(current as Layer | StacLayer, source);
-      if (!this._isValidExtent(extent)) {
-        continue;
-      }
-
-      const transformed = this._transformExtentToViewProjection(
-        extent,
-        source?.getProjection(),
-      );
-      if (!this._isValidExtent(transformed)) {
-        continue;
-      }
-
-      if (!combined) {
-        combined = [...transformed];
-      } else {
-        extend(combined, transformed);
-      }
-    }
-
-    return combined;
-  }
-
   private _fitViewToExtent(
     extent: number[] | undefined,
     layerId: string,
     options: { duration?: number; padding?: number[] } = {},
   ): void {
-    if (!this._isValidExtent(extent)) {
+    if (!isValidExtent(extent)) {
       this._log('warning', `Layer ${layerId} extent is not valid.`);
       return;
     }
@@ -2507,8 +2447,9 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     if (jgisLayer.type === 'StacLayer') {
       const stacBbox = (jgisLayer.parameters as IStacLayer).data?.bbox;
       if (stacBbox?.length === 4) {
-        const extent = this._transformExtentToViewProjection(
+        const extent = transformExtentToViewProjection(
           [...stacBbox],
+          this._Map.getView().getProjection(),
           getProjection('EPSG:4326'),
         );
 
@@ -2565,8 +2506,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     layerId: string,
     olLayer: Layer | LayerGroup,
   ): void {
-    const extent = this._getZoomExtentForOlLayer(olLayer);
-    if (!this._isValidExtent(extent)) {
+    const extent = getZoomExtentForOlLayer(
+      olLayer,
+      this._Map.getView().getProjection(),
+      (layer, source) => this._computeExtent(layer, source),
+    );
+    if (!isValidExtent(extent)) {
       return;
     }
 
@@ -3585,13 +3530,20 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return;
     }
 
-    const olLayer = this.getLayer(id) as Layer | LayerGroup | undefined;
+    const olLayer = this.getLayer(id);
     if (!olLayer) {
       this._zoomToJgisLayerWithoutOlLayer(id, this._model.getLayer(id));
       return;
     }
 
-    this._fitViewToExtent(this._getZoomExtentForOlLayer(olLayer), id);
+    this._fitViewToExtent(
+      getZoomExtentForOlLayer(
+        olLayer,
+        this._Map.getView().getProjection(),
+        (layer, source) => this._computeExtent(layer, source),
+      ),
+      id,
+    );
   }
 
   private _moveToPosition(

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2485,7 +2485,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     options: { duration?: number; padding?: number[] } = {},
   ): void {
     if (!this._isValidExtent(extent)) {
-      this._log('warning', `Layer ${layerId} has no extent.`);
+      this._log('warning', `Layer ${layerId} extent is not valid.`);
       return;
     }
 

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -71,7 +71,7 @@ import TileState from 'ol/TileState';
 import { FullScreen, ScaleLine, Zoom, Control, Rotate } from 'ol/control';
 import { Coordinate } from 'ol/coordinate';
 import { singleClick } from 'ol/events/condition';
-import { getCenter, getSize } from 'ol/extent';
+import { extend, getCenter, getSize } from 'ol/extent';
 import { GeoJSON, MVT } from 'ol/format';
 import { Geometry, Point } from 'ol/geom';
 import { Type } from 'ol/geom/Geometry';
@@ -2414,6 +2414,140 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     return undefined;
   }
 
+  private _isValidExtent(extent: number[] | undefined): extent is number[] {
+    return !!extent && extent.every(value => Number.isFinite(value));
+  }
+
+  private _transformExtentToViewProjection(
+    extent: number[],
+    sourceProjection?: ReturnType<Source['getProjection']>,
+  ): number[] {
+    const viewProjection = this._Map.getView().getProjection();
+
+    if (sourceProjection && sourceProjection !== viewProjection) {
+      return transformExtent(extent, sourceProjection, viewProjection);
+    }
+
+    return extent;
+  }
+
+  private _getZoomExtentForOlLayer(
+    olLayer: Layer | LayerGroup,
+  ): number[] | undefined {
+    if (olLayer instanceof LayerGroup) {
+      let combined: number[] | undefined;
+      for (const child of olLayer.getLayers().getArray()) {
+        if (!(child instanceof Layer)) {
+          continue;
+        }
+
+        const childSource = child.getSource();
+        const childExtent = this._computeExtent(
+          child as Layer | StacLayer,
+          childSource,
+        );
+
+        if (!this._isValidExtent(childExtent)) {
+          continue;
+        }
+
+        const transformed = this._transformExtentToViewProjection(
+          childExtent,
+          childSource?.getProjection(),
+        );
+
+        if (!this._isValidExtent(transformed)) {
+          continue;
+        }
+
+        if (!combined) {
+          combined = [...transformed];
+        } else {
+          extend(combined, transformed);
+        }
+      }
+
+      return combined;
+    }
+
+    const source = olLayer.getSource();
+    const extent = this._computeExtent(olLayer as Layer | StacLayer, source);
+
+    if (!this._isValidExtent(extent)) {
+      return undefined;
+    }
+
+    return this._transformExtentToViewProjection(
+      extent,
+      source?.getProjection(),
+    );
+  }
+
+  private _fitViewToExtent(
+    extent: number[] | undefined,
+    layerId: string,
+    options: { duration?: number; padding?: number[] } = {},
+  ): void {
+    if (!this._isValidExtent(extent)) {
+      this._log('warning', `Layer ${layerId} has no extent.`);
+      return;
+    }
+
+    this._Map.getView().fit(extent, {
+      size: this._Map.getSize(),
+      duration: options.duration ?? 500,
+      ...(options.padding ? { padding: options.padding } : {}),
+    });
+  }
+
+  private _zoomToJgisLayerWithoutOlLayer(
+    id: string,
+    jgisLayer: IJGISLayer | undefined,
+  ): void {
+    if (!jgisLayer) {
+      return;
+    }
+
+    if (jgisLayer.type === 'StacLayer') {
+      const stacBbox = (jgisLayer.parameters as IStacLayer).data?.bbox;
+      if (stacBbox?.length === 4) {
+        const extent = this._transformExtentToViewProjection(
+          [...stacBbox],
+          getProjection('EPSG:4326'),
+        );
+
+        this._fitViewToExtent(extent, id, {
+          padding: [250, 250, 250, 250],
+        });
+
+        return;
+      }
+    }
+
+    if (jgisLayer.type === 'StorySegmentLayer') {
+      const params = jgisLayer.parameters as IStorySegmentLayer;
+      const coords = getCenter(params.extent);
+      const viewCenter = this._Map.getView().getCenter();
+      const alreadyCentered =
+        viewCenter !== undefined &&
+        Math.abs(viewCenter[0] - coords[0]) < 1e-9 &&
+        Math.abs(viewCenter[1] - coords[1]) < 1e-9;
+
+      if (!alreadyCentered) {
+        this._flyToPosition(
+          { x: coords[0], y: coords[1] },
+          params.zoom,
+          (params.transition.time ?? 1) * 1000,
+          params.transition.type,
+        );
+      }
+
+      return;
+    }
+
+    this._pendingZoomLayerId = id;
+  }
+
   private _computeZoomFromExtent(extent: number[]): number | null {
     if (!this._Map) {
       return null;
@@ -3458,122 +3592,20 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     );
   }
 
-  // TODO this and flyToPosition need a rework
   private _onZoomToPosition(_: IJupyterGISModel, id: string) {
-    // Check if the id is an annotation
     const annotation = this._model.annotationModel?.getAnnotation(id);
     if (annotation) {
       this._flyToPosition(annotation.position, annotation.zoom);
       return;
     }
 
-    // The id is a layer
-    const layer = this.getLayer(id);
-    const source = layer?.getSource();
-    const jgisLayer = this._model.getLayer(id);
-
-    /**
-     * Layer may be undefined in two cases:
-     * 1. StorySegmentLayer: These layers don't have an associated OpenLayers layer
-     * 2. StacLayer: When centerOnPosition is called immediately after adding the layer,
-     *    the OpenLayers layer hasn't been created yet, so we use the bbox from the
-     *    layer model's STAC data directly.
-     */
-    if (!layer) {
-      // Handle StacLayer that hasn't been added to the map yet
-      if (jgisLayer?.type === 'StacLayer') {
-        const layerParams = jgisLayer.parameters as IStacLayer;
-        const stacBbox = layerParams.data?.bbox;
-
-        if (stacBbox && stacBbox.length === 4) {
-          // STAC bbox format: [west, south, east, north] in EPSG:4326
-          const [west, south, east, north] = stacBbox;
-          const bboxExtent = [west, south, east, north];
-
-          // Convert from EPSG:4326 to view projection
-          const viewProjection = this._Map.getView().getProjection();
-          const transformedExtent =
-            viewProjection.getCode() !== 'EPSG:4326'
-              ? transformExtent(bboxExtent, 'EPSG:4326', viewProjection)
-              : bboxExtent;
-
-          this._Map.getView().fit(transformedExtent, {
-            size: this._Map.getSize(),
-            duration: 500,
-            padding: [250, 250, 250, 250],
-          });
-          return;
-        }
-      }
-
-      // Handle StorySegmentLayer
-      if (jgisLayer?.type === 'StorySegmentLayer') {
-        const layerParams = jgisLayer.parameters as IStorySegmentLayer;
-        const coords = getCenter(layerParams.extent);
-
-        // Don't move map if we're already centered on the segment
-        const viewCenter = this._Map.getView().getCenter();
-        const centersEqual =
-          viewCenter !== undefined &&
-          Math.abs(viewCenter[0] - coords[0]) < 1e-9 &&
-          Math.abs(viewCenter[1] - coords[1]) < 1e-9;
-        if (centersEqual) {
-          return;
-        }
-
-        this._flyToPosition(
-          { x: coords[0], y: coords[1] },
-          layerParams.zoom,
-          (layerParams.transition.time ?? 1) * 1000, // seconds -> ms
-          layerParams.transition.type,
-        );
-
-        return;
-      }
-
-      // Generic layer whose OpenLayers layer hasn't been created yet (e.g. a
-      // layer just added via the Python API with zoom_to=True). Remember the
-      // request and retry once the layer has been added to the map.
-      if (jgisLayer) {
-        this._pendingZoomLayerId = id;
-        return;
-      }
-    }
-
-    const extent = this._computeExtent(layer, source);
-    if (!extent) {
-      this._log('warning', 'Layer ${id} has no extent.');
+    const olLayer = this.getLayer(id) as Layer | LayerGroup | undefined;
+    if (!olLayer) {
+      this._zoomToJgisLayerWithoutOlLayer(id, this._model.getLayer(id));
       return;
     }
 
-    if (!extent.every(value => Number.isFinite(value))) {
-      this._log(
-        'warning',
-        `Layer ${id} has an invalid extent: ${extent.join(', ')}`,
-      );
-      return;
-    }
-
-    // Convert layer extent value to view projection if needed
-    const sourceProjection = source?.getProjection();
-    const viewProjection = this._Map.getView().getProjection();
-
-    const transformedExtent =
-      sourceProjection && sourceProjection !== viewProjection
-        ? transformExtent(extent, sourceProjection, viewProjection)
-        : extent;
-    if (!transformedExtent.every(value => Number.isFinite(value))) {
-      this._log(
-        'warning',
-        `Layer ${id} has an invalid transformed extent: ${transformedExtent.join(', ')}`,
-      );
-      return;
-    }
-
-    this._Map.getView().fit(transformedExtent, {
-      size: this._Map.getSize(),
-      duration: 500,
-    });
+    this._fitViewToExtent(this._getZoomExtentForOlLayer(olLayer), id);
   }
 
   private _moveToPosition(

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2565,32 +2565,22 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     layerId: string,
     olLayer: Layer | LayerGroup,
   ): void {
-    const effectiveLayer =
-      olLayer instanceof LayerGroup
-        ? (olLayer.getLayers().getArray()[0] as Layer | undefined)
-        : olLayer;
-    if (!effectiveLayer) {
+    const extent = this._getZoomExtentForOlLayer(olLayer);
+    if (!this._isValidExtent(extent)) {
       return;
     }
-    const source = effectiveLayer.getSource();
-    const sourceId = source?.get?.('id');
 
-    let extent = sourceId ? this._model.getExtent(sourceId) : undefined;
-
-    if (!extent) {
-      extent = this._computeExtent(effectiveLayer, source);
+    const zoom = this._computeZoomFromExtent(extent);
+    if (zoom === null) {
+      return;
     }
 
-    if (extent) {
-      const zoom = this._computeZoomFromExtent(extent);
+    const view: IViewState[string] = {
+      extent,
+      zoom,
+    };
 
-      if (zoom === null) {
-        return;
-      }
-
-      const view: IViewState[string] = { extent, zoom };
-      this._model.updateLayerViewState(layerId, view);
-    }
+    this._model.updateLayerViewState(layerId, view);
   }
 
   /**

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2434,53 +2434,49 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _getZoomExtentForOlLayer(
     olLayer: Layer | LayerGroup,
   ): number[] | undefined {
-    if (olLayer instanceof LayerGroup) {
-      let combined: number[] | undefined;
-      for (const child of olLayer.getLayers().getArray()) {
-        if (!(child instanceof Layer)) {
-          continue;
-        }
+    const stack: Array<Layer | LayerGroup> = [olLayer];
+    let combined: number[] | undefined;
 
-        const childSource = child.getSource();
-        const childExtent = this._computeExtent(
-          child as Layer | StacLayer,
-          childSource,
-        );
-
-        if (!this._isValidExtent(childExtent)) {
-          continue;
-        }
-
-        const transformed = this._transformExtentToViewProjection(
-          childExtent,
-          childSource?.getProjection(),
-        );
-
-        if (!this._isValidExtent(transformed)) {
-          continue;
-        }
-
-        if (!combined) {
-          combined = [...transformed];
-        } else {
-          extend(combined, transformed);
-        }
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) {
+        continue;
       }
 
-      return combined;
+      if (current instanceof LayerGroup) {
+        for (const child of current.getLayers().getArray()) {
+          if (child instanceof LayerGroup || child instanceof Layer) {
+            stack.push(child as Layer | LayerGroup);
+          }
+        }
+        continue;
+      }
+
+      const source = current.getSource();
+      const extent = this._computeExtent(
+        current as Layer | StacLayer,
+        source,
+      );
+      if (!this._isValidExtent(extent)) {
+        continue;
+      }
+
+      const transformed = this._transformExtentToViewProjection(
+        extent,
+        source?.getProjection(),
+      );
+      if (!this._isValidExtent(transformed)) {
+        continue;
+      }
+
+      if (!combined) {
+        combined = [...transformed];
+      } else {
+        extend(combined, transformed);
+      }
     }
 
-    const source = olLayer.getSource();
-    const extent = this._computeExtent(olLayer as Layer | StacLayer, source);
-
-    if (!this._isValidExtent(extent)) {
-      return undefined;
-    }
-
-    return this._transformExtentToViewProjection(
-      extent,
-      source?.getProjection(),
-    );
+    return combined;
   }
 
   private _fitViewToExtent(

--- a/packages/base/src/mainview/utils/olLayerZoomExtent.ts
+++ b/packages/base/src/mainview/utils/olLayerZoomExtent.ts
@@ -1,9 +1,9 @@
 import { extend } from 'ol/extent';
-import type BaseLayer from 'ol/layer/Base';
 import type { Layer } from 'ol/layer';
+import type BaseLayer from 'ol/layer/Base';
 import type LayerGroup from 'ol/layer/Group';
-import type Projection from 'ol/proj/Projection';
 import { transformExtent } from 'ol/proj';
+import type Projection from 'ol/proj/Projection';
 import type { Source } from 'ol/source';
 
 export function isValidExtent(
@@ -39,10 +39,7 @@ function isLayer(layer: BaseLayer): layer is Layer {
 export function getZoomExtentForOlLayer(
   olLayer: Layer | LayerGroup,
   viewProjection: Projection,
-  computeExtent: (
-    layer: Layer,
-    source: Source | null,
-  ) => number[] | undefined,
+  computeExtent: (layer: Layer, source: Source | null) => number[] | undefined,
 ): number[] | undefined {
   const stack: BaseLayer[] = [olLayer];
   let combined: number[] | undefined;

--- a/packages/base/src/mainview/utils/olLayerZoomExtent.ts
+++ b/packages/base/src/mainview/utils/olLayerZoomExtent.ts
@@ -1,0 +1,88 @@
+import { extend } from 'ol/extent';
+import type BaseLayer from 'ol/layer/Base';
+import type { Layer } from 'ol/layer';
+import type LayerGroup from 'ol/layer/Group';
+import type Projection from 'ol/proj/Projection';
+import { transformExtent } from 'ol/proj';
+import type { Source } from 'ol/source';
+
+export function isValidExtent(
+  extent: number[] | undefined,
+): extent is number[] {
+  return !!extent && extent.every(value => Number.isFinite(value));
+}
+
+export function transformExtentToViewProjection(
+  extent: number[],
+  viewProjection: Projection,
+  sourceProjection?: Projection | null,
+): number[] {
+  if (
+    sourceProjection &&
+    sourceProjection.getCode() !== viewProjection.getCode()
+  ) {
+    return transformExtent(extent, sourceProjection, viewProjection);
+  }
+
+  return extent;
+}
+
+function isLayerGroup(layer: BaseLayer): layer is LayerGroup {
+  return 'getLayers' in layer;
+}
+
+function isLayer(layer: BaseLayer): layer is Layer {
+  return 'getSource' in layer && !('getLayers' in layer);
+}
+
+/** Union extent of an OL layer or nested layer group in view projection. */
+export function getZoomExtentForOlLayer(
+  olLayer: Layer | LayerGroup,
+  viewProjection: Projection,
+  computeExtent: (
+    layer: Layer,
+    source: Source | null,
+  ) => number[] | undefined,
+): number[] | undefined {
+  const stack: BaseLayer[] = [olLayer];
+  let combined: number[] | undefined;
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    if (isLayerGroup(current)) {
+      stack.push(...current.getLayers().getArray());
+      continue;
+    }
+
+    if (!isLayer(current)) {
+      continue;
+    }
+
+    const source = current.getSource();
+    const extent = computeExtent(current, source);
+    if (!isValidExtent(extent)) {
+      continue;
+    }
+
+    const transformed = transformExtentToViewProjection(
+      extent,
+      viewProjection,
+      source?.getProjection(),
+    );
+    if (!isValidExtent(transformed)) {
+      continue;
+    }
+
+    if (!combined) {
+      combined = [...transformed];
+    } else {
+      extend(combined, transformed);
+    }
+  }
+
+  return combined;
+}


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Refactor `_onZoomToPosition`  to work with `LayerGroups`
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1797.org.readthedocs.build/en/1797/
💡 JupyterLite preview: https://jupytergis--1797.org.readthedocs.build/en/1797/lite
💡 Specta preview: https://jupytergis--1797.org.readthedocs.build/en/1797/lite/specta

<!-- readthedocs-preview jupytergis end -->