### PR TITLE
Fix broken JupyterLite example links in README

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ bibtex_bibfiles = [
 ]
 
 jupyterlite_contents = [
-    "../examples",
+    "../examples/*",
 ]
 jupyterlite_ignore_contents = [
     r"\.\./examples/tiler-.*",


### PR DESCRIPTION
## Description

Shall close #1799

## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1800.org.readthedocs.build/en/1800/
💡 JupyterLite preview: https://jupytergis--1800.org.readthedocs.build/en/1800/lite
💡 Specta preview: https://jupytergis--1800.org.readthedocs.build/en/1800/lite/specta

<!-- readthedocs-preview jupytergis end -->