### PR TITLE
Draw tool: Modify interaction

### DIFF
--- a/packages/base/src/commands/BaseCommandIDs.ts
+++ b/packages/base/src/commands/BaseCommandIDs.ts
@@ -33,6 +33,7 @@ export const newGeoPackageRasterEntry = 'jupytergis:newGeoPackageRasterEntry';
 export const newGeoPackageVectorEntry = 'jupytergis:newGeoPackageVectorEntry';
 export const openNewOpenEODialog = 'jupytergis:openNewOpenEODialog';
 export const toggleDrawFeatures = 'jupytergis:toggleDrawFeatures';
+export const deleteSelectedFeatures = 'jupytergis:deleteSelectedFeatures';
 
 // Layer and group actions
 export const showLayerPropertiesDialog = 'jupytergis:showLayerPropertiesDialog';

--- a/packages/base/src/features/draw-tool/drawInteractionStyle.ts
+++ b/packages/base/src/features/draw-tool/drawInteractionStyle.ts
@@ -1,0 +1,18 @@
+import { Fill, Stroke, Style } from 'ol/style';
+import CircleStyle from 'ol/style/Circle';
+
+export const drawInteractionStyle = new Style({
+  fill: new Fill({
+    color: 'rgba(255, 255, 255, 0.2)',
+  }),
+  stroke: new Stroke({
+    color: '#ffcc33',
+    width: 2,
+  }),
+  image: new CircleStyle({
+    radius: 7,
+    fill: new Fill({
+      color: '#ffcc33',
+    }),
+  }),
+});

--- a/packages/base/src/features/draw-tool/drawToolController.ts
+++ b/packages/base/src/features/draw-tool/drawToolController.ts
@@ -1,0 +1,340 @@
+import type { IJupyterGISModel, IJGISSource } from '@jupytergis/schema';
+import { UUID } from '@lumino/coreutils';
+import type { Map as OlMap } from 'ol';
+import Feature from 'ol/Feature';
+import { Coordinate } from 'ol/coordinate';
+import { GeoJSON } from 'ol/format';
+import { Type } from 'ol/geom/Geometry';
+import Draw, { DrawEvent } from 'ol/interaction/Draw';
+import Modify from 'ol/interaction/Modify';
+import Snap from 'ol/interaction/Snap';
+import { Layer } from 'ol/layer';
+import { Vector as VectorSource } from 'ol/source';
+
+import { applyDrawCustomAttributesToFeature } from '@/src/features/labels/drawCustomAttributes';
+import { drawInteractionStyle } from './drawInteractionStyle';
+import { getVectorSourceFromLayer, isDrawLayer } from './drawToolUtils';
+
+export interface IDrawToolHost {
+  getMap(): OlMap | undefined;
+  getLayer(layerId: string): Layer | undefined;
+  getModel(): IJupyterGISModel;
+  onDrawLayerIdChange(layerId: string | undefined): void;
+  onDrawGeometryLabelChange(label: string): void;
+}
+
+export class DrawToolController {
+  private _draw: Draw | undefined;
+  private _snap: Snap | undefined;
+  private _modify: Modify | undefined;
+  private _currentDrawLayerId: string | undefined;
+  private _currentDrawSource: IJGISSource | undefined;
+  private _currentVectorSource: VectorSource | undefined;
+  private _currentDrawSourceId: string | undefined;
+  private _currentDrawGeometry: Type | undefined;
+
+  constructor(private readonly _host: IDrawToolHost) {}
+
+  get currentDrawLayerId(): string | undefined {
+    return this._currentDrawLayerId;
+  }
+
+  get currentDrawSourceId(): string | undefined {
+    return this._currentDrawSourceId;
+  }
+
+  handleGeometryTypeChange(drawGeometryLabel: string): void {
+    if (!drawGeometryLabel || this._currentDrawGeometry === drawGeometryLabel) {
+      this._currentDrawGeometry = undefined;
+      this._updateInteractions();
+      this._host.onDrawGeometryLabelChange('');
+      return;
+    }
+
+    this._currentDrawGeometry = drawGeometryLabel as Type;
+    this._updateInteractions();
+    this._host.onDrawGeometryLabelChange(drawGeometryLabel);
+  }
+
+  enterLayer(): void {
+    this._bindFromSelectedLayer();
+    if (!this._currentDrawLayerId) {
+      return;
+    }
+
+    this._updateInteractions();
+  }
+
+  leaveDrawMode(): void {
+    this._removeInteractions();
+    this._currentDrawGeometry = undefined;
+    this._currentDrawLayerId = undefined;
+    this._host.onDrawLayerIdChange(undefined);
+    this._host.onDrawGeometryLabelChange('');
+  }
+
+  removeInteractions(): void {
+    this._removeInteractions();
+  }
+
+  deleteAtCoordinate(coordinate: Coordinate): boolean {
+    const map = this._host.getMap();
+    if (!this._currentDrawLayerId || !map) {
+      return false;
+    }
+
+    const source = this._resolveVectorSource(this._currentDrawLayerId);
+    if (!source) {
+      return false;
+    }
+
+    const pixel = map.getPixelFromCoordinate(coordinate);
+    if (!pixel) {
+      return false;
+    }
+
+    const hits = map.getFeaturesAtPixel(pixel, {
+      hitTolerance: 10,
+      layerFilter: layer => this._isDrawLayerFilter(layer),
+    });
+
+    if (hits.length === 0) {
+      return false;
+    }
+
+    for (const hit of hits) {
+      if (!(hit instanceof Feature)) {
+        continue;
+      }
+
+      const featureId = hit.get('_id');
+      const onSource =
+        featureId !== undefined
+          ? source.getFeatures().find(f => f.get('_id') === featureId)
+          : hit;
+
+      if (onSource) {
+        source.removeFeature(onSource);
+      } else {
+        source.removeFeature(hit);
+      }
+    }
+
+    this._currentVectorSource = source;
+    this._persist(source);
+
+    return true;
+  }
+
+  hasFeatureAtCoordinate(coordinate: Coordinate): boolean {
+    const map = this._host.getMap();
+    if (!this._currentVectorSource || !map) {
+      return false;
+    }
+
+    const pixel = map.getPixelFromCoordinate(coordinate);
+    if (!pixel) {
+      return false;
+    }
+
+    return map.hasFeatureAtPixel(pixel, {
+      hitTolerance: 10,
+      layerFilter: layer => this._isDrawLayerFilter(layer),
+    });
+  }
+
+  setDrawLayerId(layerId: string): void {
+    this._currentDrawLayerId = layerId;
+    this._host.onDrawLayerIdChange(layerId);
+  }
+
+  private _bindFromSelectedLayer(): void {
+    const model = this._host.getModel();
+    const selectedLayers =
+      model.sharedModel.awareness.getLocalState()?.selected?.value;
+
+    if (!selectedLayers) {
+      return;
+    }
+
+    const selectedLayerId = Object.keys(selectedLayers)[0];
+    this._currentDrawLayerId = selectedLayerId;
+    this._host.onDrawLayerIdChange(selectedLayerId);
+
+    const jgisLayer = model.getLayer(selectedLayerId);
+    this._currentDrawSourceId = (
+      jgisLayer as { parameters?: { source?: string } }
+    )?.parameters?.source;
+
+    if (this._currentDrawSourceId) {
+      this._currentDrawSource = model.getSource(this._currentDrawSourceId);
+    }
+  }
+
+  private _resolveVectorSource(layerId: string): VectorSource | undefined {
+    this._currentVectorSource = getVectorSourceFromLayer(
+      id => this._host.getLayer(id),
+      layerId,
+    );
+
+    return this._currentVectorSource;
+  }
+
+  private _isDrawLayerFilter(layer: Layer): boolean {
+    return isDrawLayer(
+      id => this._host.getLayer(id),
+      this._currentDrawLayerId,
+      layer,
+    );
+  }
+
+  private _persist(source?: VectorSource, pendingFeature?: Feature): void {
+    const map = this._host.getMap();
+    const model = this._host.getModel();
+    const vectorSource =
+      source ??
+      (this._currentDrawLayerId
+        ? this._resolveVectorSource(this._currentDrawLayerId)
+        : this._currentVectorSource);
+
+    if (!this._currentDrawSourceId && this._currentDrawLayerId) {
+      this._bindFromSelectedLayer();
+    }
+
+    if (
+      !vectorSource ||
+      !this._currentDrawSource ||
+      !this._currentDrawSourceId ||
+      !map
+    ) {
+      return;
+    }
+
+    const geojsonWriter = new GeoJSON({
+      featureProjection: map.getView().getProjection(),
+    });
+
+    const liveFeatures = vectorSource.getFeatures();
+    const featuresToSerialize =
+      pendingFeature && !liveFeatures.includes(pendingFeature)
+        ? [...liveFeatures, pendingFeature]
+        : liveFeatures;
+
+    const features = featuresToSerialize.map(feature =>
+      geojsonWriter.writeFeatureObject(feature),
+    );
+
+    const updatedJgisSource: IJGISSource = {
+      name: this._currentDrawSource.name,
+      type: this._currentDrawSource.type,
+      parameters: {
+        data: {
+          type: 'FeatureCollection',
+          features,
+        },
+      },
+    };
+
+    this._currentDrawSource = updatedJgisSource;
+    model.sharedModel.updateSource(
+      this._currentDrawSourceId,
+      updatedJgisSource,
+    );
+  }
+
+  private _removeInteractions(): void {
+    const map = this._host.getMap();
+    if (!map) {
+      return;
+    }
+
+    if (this._draw) {
+      this._draw.setActive(false);
+      map.removeInteraction(this._draw);
+      this._draw = undefined;
+    }
+
+    if (this._modify) {
+      this._modify.setActive(false);
+      map.removeInteraction(this._modify);
+      this._modify = undefined;
+    }
+
+    if (this._snap) {
+      this._snap.setActive(false);
+      map.removeInteraction(this._snap);
+      this._snap = undefined;
+    }
+  }
+
+  private _updateInteractions(): void {
+    if (this._currentDrawLayerId) {
+      this._resolveVectorSource(this._currentDrawLayerId);
+    }
+
+    this._removeInteractions();
+
+    const map = this._host.getMap();
+    if (!map || !this._currentVectorSource) {
+      return;
+    }
+
+    const drawSource = this._currentVectorSource;
+
+    this._modify = new Modify({ source: drawSource });
+    this._modify.on('modifystart', () => {
+      if (this._draw) {
+        this._draw.setActive(false);
+      }
+    });
+
+    this._modify.on('modifyend', () => {
+      if (this._draw) {
+        this._draw.setActive(true);
+      }
+      this._persist();
+    });
+
+    this._snap = new Snap({ source: drawSource });
+
+    map.addInteraction(this._modify);
+    map.addInteraction(this._snap);
+
+    if (this._currentDrawGeometry) {
+      this._draw = new Draw({
+        style: drawInteractionStyle,
+        type: this._currentDrawGeometry,
+        source: drawSource,
+      });
+      this._draw.on('drawend', this._handleDrawEnd);
+      map.addInteraction(this._draw);
+      this._draw.setActive(true);
+    }
+
+    this._modify.setActive(true);
+    this._snap.setActive(true);
+  }
+
+  private _handleDrawEnd = (event: DrawEvent): void => {
+    const model = this._host.getModel();
+    const feature = event.feature;
+    feature.set('_id', UUID.uuid4());
+    feature.set('_createdAt', new Date().toISOString());
+    feature.set('_creatorClientId', model.getClientId().toString());
+    feature.set('_fromDrawTool', true);
+
+    const layerId = this._currentDrawLayerId;
+    const customAttributes = layerId
+      ? model.getDrawCustomAttributes(layerId)
+      : [];
+    applyDrawCustomAttributesToFeature(feature, customAttributes);
+
+    const source = layerId
+      ? this._resolveVectorSource(layerId)
+      : this._currentVectorSource;
+    const onSource = source?.getFeatures().includes(feature) ?? false;
+
+    // OL dispatches drawend before adding the feature to the source.
+    this._persist(source, onSource ? undefined : feature);
+  };
+}

--- a/packages/base/src/features/draw-tool/drawToolUtils.ts
+++ b/packages/base/src/features/draw-tool/drawToolUtils.ts
@@ -1,0 +1,48 @@
+import { Layer, Vector as VectorLayer } from 'ol/layer';
+import LayerGroup from 'ol/layer/Group';
+import { Vector as VectorSource } from 'ol/source';
+
+export function getVectorSourceFromLayer(
+  getLayer: (layerId: string) => Layer | undefined,
+  layerId: string,
+): VectorSource | undefined {
+  const matchingLayer = getLayer(layerId);
+  let source: VectorSource | undefined;
+
+  if (matchingLayer instanceof LayerGroup) {
+    for (const sub of matchingLayer.getLayers().getArray()) {
+      if (typeof (sub as VectorLayer).getSource === 'function') {
+        source = (sub as VectorLayer).getSource() as VectorSource;
+        break;
+      }
+    }
+  } else if (
+    matchingLayer &&
+    typeof (matchingLayer as VectorLayer).getSource === 'function'
+  ) {
+    source = (matchingLayer as VectorLayer).getSource() as VectorSource;
+  }
+
+  return source;
+}
+
+export function isDrawLayer(
+  getLayer: (layerId: string) => Layer | undefined,
+  drawLayerId: string | undefined,
+  layer: Layer,
+): boolean {
+  if (!drawLayerId) {
+    return false;
+  }
+
+  if (layer.get('id') === drawLayerId) {
+    return true;
+  }
+
+  const expected = getLayer(drawLayerId);
+  if (expected instanceof LayerGroup) {
+    return expected.getLayers().getArray().includes(layer);
+  }
+
+  return false;
+}

--- a/packages/base/src/features/draw-tool/index.ts
+++ b/packages/base/src/features/draw-tool/index.ts
@@ -1,0 +1,4 @@
+export { drawInteractionStyle } from './drawInteractionStyle';
+export { DrawToolController } from './drawToolController';
+export type { IDrawToolHost } from './drawToolController';
+export { getVectorSourceFromLayer, isDrawLayer } from './drawToolUtils';

--- a/packages/base/src/features/labels/components/VectorDrawControls.tsx
+++ b/packages/base/src/features/labels/components/VectorDrawControls.tsx
@@ -11,6 +11,9 @@ const DRAW_GEOMETRIES = [
   { value: 'Polygon', label: 'Polygon' },
 ] as const;
 
+/** Empty string = select/edit mode (no draw tool armed). */
+export const DRAW_SELECT_TOOL = '';
+
 export interface IVectorDrawControlsProps {
   drawGeometryLabel: string | undefined;
   onDrawGeometryTypeChange: (geometryType: string) => void;
@@ -24,15 +27,27 @@ export function VectorDrawControls({
   model,
   drawLayerId,
 }: IVectorDrawControlsProps): JSX.Element {
+  const isSelectMode = !drawGeometryLabel;
+
   return (
     <div className="jgis-vector-draw-controls">
-      <ButtonGroup aria-label="Geometry type">
+      <ButtonGroup aria-label="Draw tools">
+        <Button
+          type="button"
+          size="sm"
+          variant={isSelectMode ? 'secondary' : 'outline'}
+          aria-pressed={isSelectMode}
+          onClick={() => onDrawGeometryTypeChange(DRAW_SELECT_TOOL)}
+        >
+          Select
+        </Button>
         {DRAW_GEOMETRIES.map(({ value, label }) => (
           <Button
             key={value}
             type="button"
             size="sm"
             variant={drawGeometryLabel === value ? 'secondary' : 'outline'}
+            aria-pressed={drawGeometryLabel === value}
             onClick={() => onDrawGeometryTypeChange(value)}
           >
             {label}

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -942,6 +942,21 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   };
 
   addContextMenu = (): void => {
+    this._commands.addCommand(CommandIDs.deleteSelectedFeatures, {
+      label: 'Delete feature',
+      isEnabled: () => {
+        if (!this._clickCoords || this._model.currentMode !== 'drawing') {
+          return false;
+        }
+        return this._mapHasDrawFeatureAtCoordinate(this._clickCoords);
+      },
+      execute: () => {
+        if (this._clickCoords) {
+          this._deleteDrawFeaturesAtCoordinate(this._clickCoords);
+        }
+      },
+    });
+
     this._commands.addCommand(CommandIDs.addAnnotation, {
       label: 'Add annotation',
       describedBy: {
@@ -1012,6 +1027,12 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         const text = `${lonLat[1].toFixed(6)}, ${lonLat[0].toFixed(6)}`;
         await navigator.clipboard.writeText(text);
       },
+    });
+
+    this._contextMenu.addItem({
+      command: CommandIDs.deleteSelectedFeatures,
+      selector: '.ol-viewport',
+      rank: 0,
     });
 
     this._contextMenu.addItem({
@@ -3044,6 +3065,13 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         if (mapLayer) {
           this._trackLayerViewState(id, mapLayer);
         }
+
+        if (
+          this._model.currentMode === 'drawing' &&
+          id === this._currentDrawLayerID
+        ) {
+          this._editVectorLayer();
+        }
       } else {
         this.updateLayers(layerTree);
       }
@@ -3106,14 +3134,21 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return;
     }
 
-    change.sourceChange?.forEach(change => {
-      if (!change.newValue || Object.keys(change.newValue).length === 0) {
-        this.removeSource(change.id);
+    change.sourceChange?.forEach(srcChange => {
+      if (!srcChange.newValue || Object.keys(srcChange.newValue).length === 0) {
+        this.removeSource(srcChange.id);
       } else {
-        const source = this._model.getSource(change.id);
-        if (source) {
-          this.updateSource(change.id, source);
+        const source = this._model.getSource(srcChange.id);
+        if (!source) {
+          return;
         }
+        if (
+          this._model.currentMode === 'drawing' &&
+          srcChange.id === this._currentDrawSourceID
+        ) {
+          return;
+        }
+        void this.updateSource(srcChange.id, source);
       }
     });
 
@@ -3947,13 +3982,15 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this.setState(old => ({ ...old, isDrawing }));
 
     if (isDrawing) {
+      this._setHighlightFeatures([]);
       this._editVectorLayer();
+      return;
     }
 
-    if (!isDrawing && this._draw) {
-      this._removeDrawInteraction();
-      this._setCurrentDrawLayerId(undefined);
-    }
+    this._removeInteractions();
+    this._currentDrawGeometry = undefined;
+    this._setCurrentDrawLayerId(undefined);
+    this.setState(old => ({ ...old, drawGeometryLabel: '' }));
   };
 
   private _notifyInteractionModeCommands(): void {
@@ -3972,15 +4009,11 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     );
   }
 
-  private _handleDrawGeometryTypeChange = (
-    /* handle with the change of geometry and instantiate new draw interaction and other ones accordingly*/
-    drawGeometryLabel: string,
-  ) => {
-    // Clicking the active geometry toggles drawing off.
-    if (this._currentDrawGeometry === drawGeometryLabel) {
+  private _handleDrawGeometryTypeChange = (drawGeometryLabel: string) => {
+    // Empty label (Select) or re-clicking the active tool -> select mode
+    if (!drawGeometryLabel || this._currentDrawGeometry === drawGeometryLabel) {
       this._currentDrawGeometry = undefined;
-      this._removeInteractions();
-
+      this._updateInteractions();
       this.setState(old => ({
         ...old,
         drawGeometryLabel: '',
@@ -3989,15 +4022,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
 
     this._currentDrawGeometry = drawGeometryLabel as Type;
-
-    if (this._currentDrawLayerID) {
-      this._currentVectorSource = this._getVectorSourceFromLayerID(
-        this._currentDrawLayerID,
-      );
-    }
-
     this._updateInteractions();
-    this._updateDrawSource();
 
     this.setState(old => ({
       ...old,
@@ -4008,15 +4033,44 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _getVectorSourceFromLayerID = (
     layerID: string,
   ): VectorSource | undefined => {
-    /* get the OpenLayers VectorSource corresponding to the JGIS currentDrawLayerID */
-    const layers = this._Map.getLayers();
-    const layerArray = layers.getArray();
-    const matchingLayer = layerArray.find(layer => layer.get('id') === layerID);
-    const source = matchingLayer?.get('source');
+    const matchingLayer = this.getLayer(layerID);
+    let source: VectorSource | undefined;
+
+    if (matchingLayer instanceof LayerGroup) {
+      for (const sub of matchingLayer.getLayers().getArray()) {
+        if (typeof (sub as VectorLayer).getSource === 'function') {
+          source = (sub as VectorLayer).getSource() as VectorSource;
+          break;
+        }
+      }
+    } else if (
+      matchingLayer &&
+      typeof (matchingLayer as VectorLayer).getSource === 'function'
+    ) {
+      source = (matchingLayer as VectorLayer).getSource() as VectorSource;
+    }
 
     this._currentVectorSource = source;
 
     return this._currentVectorSource;
+  };
+
+  private _isDrawLayerFilter = (layer: Layer): boolean => {
+    const drawLayerId = this._currentDrawLayerID;
+    if (!drawLayerId) {
+      return false;
+    }
+
+    if (layer.get('id') === drawLayerId) {
+      return true;
+    }
+
+    const expected = this.getLayer(drawLayerId);
+    if (expected instanceof LayerGroup) {
+      return expected.getLayers().getArray().includes(layer);
+    }
+
+    return false;
   };
 
   _getDrawSourceFromSelectedLayer = () => {
@@ -4040,9 +4094,22 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
   };
 
-  _onVectorSourceChange = () => {
+  private _persistDrawVectorSource = (
+    source?: VectorSource,
+    pendingFeature?: Feature,
+  ): void => {
+    const vectorSource =
+      source ??
+      (this._currentDrawLayerID
+        ? this._getVectorSourceFromLayerID(this._currentDrawLayerID)
+        : this._currentVectorSource);
+
+    if (!this._currentDrawSourceID && this._currentDrawLayerID) {
+      this._getDrawSourceFromSelectedLayer();
+    }
+
     if (
-      !this._currentVectorSource ||
+      !vectorSource ||
       !this._currentDrawSource ||
       !this._currentDrawSourceID
     ) {
@@ -4053,9 +4120,15 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       featureProjection: this._Map.getView().getProjection(),
     });
 
-    const features = this._currentVectorSource
-      .getFeatures()
-      .map(feature => geojsonWriter.writeFeatureObject(feature));
+    const liveFeatures = vectorSource.getFeatures();
+    const featuresToSerialize =
+      pendingFeature && !liveFeatures.includes(pendingFeature)
+        ? [...liveFeatures, pendingFeature]
+        : liveFeatures;
+
+    const features = featuresToSerialize.map(feature =>
+      geojsonWriter.writeFeatureObject(feature),
+    );
 
     const updatedData = {
       type: 'FeatureCollection',
@@ -4077,19 +4150,9 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     );
   };
 
-  _updateDrawSource = () => {
-    if (this._currentVectorSource) {
-      this._currentVectorSource.on('change', this._onVectorSourceChange);
-    }
-  };
-
   _removeInteractions = () => {
     if (this._draw) {
       this._removeDrawInteraction();
-    }
-
-    if (this._select) {
-      this._removeSelectInteraction();
     }
 
     if (this._modify) {
@@ -4102,35 +4165,119 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   };
 
   _updateInteractions = () => {
+    if (this._currentDrawLayerID) {
+      this._getVectorSourceFromLayerID(this._currentDrawLayerID);
+    }
+
     this._removeInteractions();
 
-    if (!this._currentDrawGeometry) {
+    if (!this._currentVectorSource) {
       return;
     }
 
-    this._draw = new Draw({
-      style: drawInteractionStyle,
-      type: this._currentDrawGeometry,
-      source: this._currentVectorSource,
-    });
-    this._draw.on('drawend', this._handleDrawEnd);
-    this._select = new Select();
-    this._modify = new Modify({
-      features: this._select.getFeatures(),
-    });
-    this._snap = new Snap({
-      source: this._currentVectorSource,
+    const drawSource = this._currentVectorSource;
+
+    // draw-and-modify, Modify always on source, Draw when a geometry tool is selected.
+    this._modify = new Modify({ source: drawSource });
+    this._modify.on('modifystart', () => {
+      if (this._draw) {
+        this._draw.setActive(false);
+      }
     });
 
-    this._Map.addInteraction(this._draw);
-    this._Map.addInteraction(this._select);
+    this._modify.on('modifyend', () => {
+      if (this._draw) {
+        this._draw.setActive(true);
+      }
+      this._persistDrawVectorSource();
+    });
+
+    this._snap = new Snap({ source: drawSource });
+
     this._Map.addInteraction(this._modify);
     this._Map.addInteraction(this._snap);
 
-    this._draw.setActive(true);
-    this._select.setActive(false);
-    this._modify.setActive(false);
+    if (this._currentDrawGeometry) {
+      this._draw = new Draw({
+        style: drawInteractionStyle,
+        type: this._currentDrawGeometry,
+        source: drawSource,
+      });
+      this._draw.on('drawend', this._handleDrawEnd);
+      this._Map.addInteraction(this._draw);
+      this._draw.setActive(true);
+    }
+
+    this._modify.setActive(true);
     this._snap.setActive(true);
+  };
+
+  private _deleteDrawFeaturesAtCoordinate = (
+    coordinate: Coordinate,
+  ): boolean => {
+    if (!this._currentDrawLayerID) {
+      return false;
+    }
+
+    const source = this._getVectorSourceFromLayerID(this._currentDrawLayerID);
+    if (!source) {
+      return false;
+    }
+
+    const pixel = this._Map.getPixelFromCoordinate(coordinate);
+    if (!pixel) {
+      return false;
+    }
+
+    const hits = this._Map.getFeaturesAtPixel(pixel, {
+      hitTolerance: 10,
+      layerFilter: this._isDrawLayerFilter,
+    });
+
+    if (hits.length === 0) {
+      return false;
+    }
+
+    for (const hit of hits) {
+      if (!(hit instanceof Feature)) {
+        continue;
+      }
+
+      const featureId = hit.get('_id');
+      const onSource =
+        featureId !== undefined
+          ? source.getFeatures().find(f => f.get('_id') === featureId)
+          : hit;
+
+      if (onSource) {
+        source.removeFeature(onSource);
+      } else {
+        source.removeFeature(hit);
+      }
+    }
+
+    this._currentVectorSource = source;
+    this._persistDrawVectorSource(source);
+    this._commands.notifyCommandChanged(CommandIDs.deleteSelectedFeatures);
+    return true;
+  };
+
+  private _mapHasDrawFeatureAtCoordinate = (
+    coordinate: Coordinate,
+  ): boolean => {
+    if (!this._currentVectorSource) {
+      return false;
+    }
+
+    const pixel = this._Map.getPixelFromCoordinate(coordinate);
+    if (!pixel) {
+      return false;
+    }
+
+    return this._Map.hasFeatureAtPixel(pixel, {
+      hitTolerance: 10,
+      layerFilter: this._isDrawLayerFilter,
+    });
   };
 
   private _handleDrawEnd = (event: DrawEvent): void => {
@@ -4145,6 +4292,14 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       ? this._model.getDrawCustomAttributes(layerId)
       : [];
     applyDrawCustomAttributesToFeature(feature, customAttributes);
+
+    const source = layerId
+      ? this._getVectorSourceFromLayerID(layerId)
+      : this._currentVectorSource;
+    const onSource = source?.getFeatures().includes(feature) ?? false;
+
+    // OL dispatches drawend before adding the feature to the source.
+    this._persistDrawVectorSource(source, onSource ? undefined : feature);
   };
 
   _editVectorLayer = () => {
@@ -4153,36 +4308,37 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
       return;
     }
 
-    this._currentVectorSource = this._getVectorSourceFromLayerID(
-      this._currentDrawLayerID,
-    );
-
-    if (!this._currentVectorSource || !this._currentDrawGeometry) {
-      return;
-    }
-
-    this._updateInteractions(); /* remove previous interactions and instantiate new ones */
-    this._updateDrawSource(); /*add new features, update source and get changes reported to the JGIS Document in geoJSON format */
+    this._updateInteractions();
   };
 
   private _removeDrawInteraction = () => {
+    if (!this._draw) {
+      return;
+    }
+
     this._draw.setActive(false);
     this._Map.removeInteraction(this._draw);
-  };
-
-  private _removeSelectInteraction = () => {
-    this._select.setActive(false);
-    this._Map.removeInteraction(this._select);
+    this._draw = undefined;
   };
 
   private _removeSnapInteraction = () => {
+    if (!this._snap) {
+      return;
+    }
+
     this._snap.setActive(false);
     this._Map.removeInteraction(this._snap);
+    this._snap = undefined;
   };
 
   private _removeModifyInteraction = () => {
+    if (!this._modify) {
+      return;
+    }
+
     this._modify.setActive(false);
     this._Map.removeInteraction(this._modify);
+    this._modify = undefined;
   };
 
   /**
@@ -4379,10 +4535,9 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _highlightLayerRef: {
     current: VectorImageLayer<VectorSource> | null;
   } = { current: null };
-  private _draw: Draw;
-  private _snap: Snap;
-  private _modify: Modify;
-  private _select: Select;
+  private _draw: Draw | undefined;
+  private _snap: Snap | undefined;
+  private _modify: Modify | undefined;
   private _currentDrawLayerID: string | undefined;
   private _previousDrawLayerID: string | undefined;
   private _currentDrawSource: IJGISSource | undefined;

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -74,7 +74,6 @@ import { singleClick } from 'ol/events/condition';
 import { getCenter, getSize } from 'ol/extent';
 import { GeoJSON, MVT } from 'ol/format';
 import { Geometry, Point } from 'ol/geom';
-import { Type } from 'ol/geom/Geometry';
 import {
   DragAndDrop,
   DragPan,
@@ -88,10 +87,7 @@ import {
   DoubleClickZoom,
   Select,
 } from 'ol/interaction';
-import Draw, { DrawEvent } from 'ol/interaction/Draw';
 import type Interaction from 'ol/interaction/Interaction';
-import Modify from 'ol/interaction/Modify';
-import Snap from 'ol/interaction/Snap';
 import {
   Image as ImageLayer,
   Layer,
@@ -123,8 +119,7 @@ import {
 import GeoZarr from 'ol/source/GeoZarr';
 import Static from 'ol/source/ImageStatic';
 import { TileSourceEvent } from 'ol/source/Tile';
-import { Fill, Icon, Stroke, Style } from 'ol/style';
-import CircleStyle from 'ol/style/Circle';
+import { Fill, Icon, Style } from 'ol/style';
 import { Rule } from 'ol/style/flat';
 //@ts-expect-error no types for ol-pmtiles
 import { PMTilesRasterSource, PMTilesVectorSource } from 'ol-pmtiles';
@@ -135,9 +130,9 @@ import * as React from 'react';
 
 import { CommandIDs } from '@/src/constants';
 import AnnotationFloater from '@/src/features/annotations/components/AnnotationFloater';
+import { DrawToolController } from '@/src/features/draw-tool';
 import FeatureFloater from '@/src/features/identify/components/FeatureFloater';
 import { getFeatureIdentifier } from '@/src/features/identify/utils/getFeatureIdentifier';
-import { applyDrawCustomAttributesToFeature } from '@/src/features/labels/drawCustomAttributes';
 import {
   getStoryPresentationMode,
   isVerticalScrollPresentation,
@@ -201,22 +196,6 @@ type OlLayerTypes =
   | StacLayer
   | ImageLayer<any>
   | LayerGroup;
-
-const drawInteractionStyle = new Style({
-  fill: new Fill({
-    color: 'rgba(255, 255, 255, 0.2)',
-  }),
-  stroke: new Stroke({
-    color: '#ffcc33',
-    width: 2,
-  }),
-  image: new CircleStyle({
-    radius: 7,
-    fill: new Fill({
-      color: '#ffcc33',
-    }),
-  }),
-});
 
 interface IMainViewProps {
   viewModel: MainViewModel;
@@ -401,6 +380,14 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     this._commands = new CommandRegistry();
     this._contextMenu = new ContextMenu({
       commands: this._commands,
+    });
+    this._drawTool = new DrawToolController({
+      getMap: () => this._Map,
+      getLayer: layerId => this.getLayer(layerId),
+      getModel: () => this._model,
+      onDrawLayerIdChange: layerId => this._setCurrentDrawLayerId(layerId),
+      onDrawGeometryLabelChange: label =>
+        this.setState(old => ({ ...old, drawGeometryLabel: label })),
     });
     this._updateCenter = debounce(this.updateCenter, 100);
   }
@@ -948,11 +935,11 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         if (!this._clickCoords || this._model.currentMode !== 'drawing') {
           return false;
         }
-        return this._mapHasDrawFeatureAtCoordinate(this._clickCoords);
+        return this._drawTool.hasFeatureAtCoordinate(this._clickCoords);
       },
       execute: () => {
         if (this._clickCoords) {
-          this._deleteDrawFeaturesAtCoordinate(this._clickCoords);
+          this._drawTool.deleteAtCoordinate(this._clickCoords);
         }
       },
     });
@@ -2690,8 +2677,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     }
 
     this._previousDrawLayerID = selectedLayerId;
-    this._setCurrentDrawLayerId(selectedLayerId);
-    this._editVectorLayer();
+    this._drawTool.setDrawLayerId(selectedLayerId);
+    this._drawTool.enterLayer();
   };
 
   /**
@@ -3068,9 +3055,9 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
         if (
           this._model.currentMode === 'drawing' &&
-          id === this._currentDrawLayerID
+          id === this._drawTool.currentDrawLayerId
         ) {
-          this._editVectorLayer();
+          this._drawTool.enterLayer();
         }
       } else {
         this.updateLayers(layerTree);
@@ -3144,7 +3131,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
         }
         if (
           this._model.currentMode === 'drawing' &&
-          srcChange.id === this._currentDrawSourceID
+          srcChange.id === this._drawTool.currentDrawSourceId
         ) {
           return;
         }
@@ -3983,14 +3970,11 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
 
     if (isDrawing) {
       this._setHighlightFeatures([]);
-      this._editVectorLayer();
+      this._drawTool.enterLayer();
       return;
     }
 
-    this._removeInteractions();
-    this._currentDrawGeometry = undefined;
-    this._setCurrentDrawLayerId(undefined);
-    this.setState(old => ({ ...old, drawGeometryLabel: '' }));
+    this._drawTool.leaveDrawMode();
   };
 
   private _notifyInteractionModeCommands(): void {
@@ -4001,7 +3985,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   }
 
   private _setCurrentDrawLayerId(layerId: string | undefined): void {
-    this._currentDrawLayerID = layerId;
     this.setState(old =>
       old.currentDrawLayerId === layerId
         ? old
@@ -4009,336 +3992,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
     );
   }
 
-  private _handleDrawGeometryTypeChange = (drawGeometryLabel: string) => {
-    // Empty label (Select) or re-clicking the active tool -> select mode
-    if (!drawGeometryLabel || this._currentDrawGeometry === drawGeometryLabel) {
-      this._currentDrawGeometry = undefined;
-      this._updateInteractions();
-      this.setState(old => ({
-        ...old,
-        drawGeometryLabel: '',
-      }));
-      return;
-    }
-
-    this._currentDrawGeometry = drawGeometryLabel as Type;
-    this._updateInteractions();
-
-    this.setState(old => ({
-      ...old,
-      drawGeometryLabel,
-    }));
-  };
-
-  private _getVectorSourceFromLayerID = (
-    layerID: string,
-  ): VectorSource | undefined => {
-    const matchingLayer = this.getLayer(layerID);
-    let source: VectorSource | undefined;
-
-    if (matchingLayer instanceof LayerGroup) {
-      for (const sub of matchingLayer.getLayers().getArray()) {
-        if (typeof (sub as VectorLayer).getSource === 'function') {
-          source = (sub as VectorLayer).getSource() as VectorSource;
-          break;
-        }
-      }
-    } else if (
-      matchingLayer &&
-      typeof (matchingLayer as VectorLayer).getSource === 'function'
-    ) {
-      source = (matchingLayer as VectorLayer).getSource() as VectorSource;
-    }
-
-    this._currentVectorSource = source;
-
-    return this._currentVectorSource;
-  };
-
-  private _isDrawLayerFilter = (layer: Layer): boolean => {
-    const drawLayerId = this._currentDrawLayerID;
-    if (!drawLayerId) {
-      return false;
-    }
-
-    if (layer.get('id') === drawLayerId) {
-      return true;
-    }
-
-    const expected = this.getLayer(drawLayerId);
-    if (expected instanceof LayerGroup) {
-      return expected.getLayers().getArray().includes(layer);
-    }
-
-    return false;
-  };
-
-  _getDrawSourceFromSelectedLayer = () => {
-    const selectedLayers =
-      this._model?.sharedModel.awareness.getLocalState()?.selected?.value;
-
-    if (!selectedLayers) {
-      return;
-    }
-
-    const selectedLayerID = Object.keys(selectedLayers)[0];
-    this._setCurrentDrawLayerId(selectedLayerID);
-
-    const JGISLayer = this._model.getLayer(selectedLayerID);
-    this._currentDrawSourceID = (JGISLayer as any)?.parameters?.source;
-
-    if (this._currentDrawSourceID) {
-      this._currentDrawSource = this._model.getSource(
-        this._currentDrawSourceID,
-      );
-    }
-  };
-
-  private _persistDrawVectorSource = (
-    source?: VectorSource,
-    pendingFeature?: Feature,
-  ): void => {
-    const vectorSource =
-      source ??
-      (this._currentDrawLayerID
-        ? this._getVectorSourceFromLayerID(this._currentDrawLayerID)
-        : this._currentVectorSource);
-
-    if (!this._currentDrawSourceID && this._currentDrawLayerID) {
-      this._getDrawSourceFromSelectedLayer();
-    }
-
-    if (
-      !vectorSource ||
-      !this._currentDrawSource ||
-      !this._currentDrawSourceID
-    ) {
-      return;
-    }
-
-    const geojsonWriter = new GeoJSON({
-      featureProjection: this._Map.getView().getProjection(),
-    });
-
-    const liveFeatures = vectorSource.getFeatures();
-    const featuresToSerialize =
-      pendingFeature && !liveFeatures.includes(pendingFeature)
-        ? [...liveFeatures, pendingFeature]
-        : liveFeatures;
-
-    const features = featuresToSerialize.map(feature =>
-      geojsonWriter.writeFeatureObject(feature),
-    );
-
-    const updatedData = {
-      type: 'FeatureCollection',
-      features: features,
-    };
-
-    const updatedJGISLayerSource: IJGISSource = {
-      name: this._currentDrawSource.name,
-      type: this._currentDrawSource.type,
-      parameters: {
-        data: updatedData,
-      },
-    };
-
-    this._currentDrawSource = updatedJGISLayerSource;
-    this._model.sharedModel.updateSource(
-      this._currentDrawSourceID,
-      updatedJGISLayerSource,
-    );
-  };
-
-  _removeInteractions = () => {
-    if (this._draw) {
-      this._removeDrawInteraction();
-    }
-
-    if (this._modify) {
-      this._removeModifyInteraction();
-    }
-
-    if (this._snap) {
-      this._removeSnapInteraction();
-    }
-  };
-
-  _updateInteractions = () => {
-    if (this._currentDrawLayerID) {
-      this._getVectorSourceFromLayerID(this._currentDrawLayerID);
-    }
-
-    this._removeInteractions();
-
-    if (!this._currentVectorSource) {
-      return;
-    }
-
-    const drawSource = this._currentVectorSource;
-
-    // draw-and-modify, Modify always on source, Draw when a geometry tool is selected.
-    this._modify = new Modify({ source: drawSource });
-    this._modify.on('modifystart', () => {
-      if (this._draw) {
-        this._draw.setActive(false);
-      }
-    });
-
-    this._modify.on('modifyend', () => {
-      if (this._draw) {
-        this._draw.setActive(true);
-      }
-      this._persistDrawVectorSource();
-    });
-
-    this._snap = new Snap({ source: drawSource });
-
-    this._Map.addInteraction(this._modify);
-    this._Map.addInteraction(this._snap);
-
-    if (this._currentDrawGeometry) {
-      this._draw = new Draw({
-        style: drawInteractionStyle,
-        type: this._currentDrawGeometry,
-        source: drawSource,
-      });
-      this._draw.on('drawend', this._handleDrawEnd);
-      this._Map.addInteraction(this._draw);
-      this._draw.setActive(true);
-    }
-
-    this._modify.setActive(true);
-    this._snap.setActive(true);
-  };
-
-  private _deleteDrawFeaturesAtCoordinate = (
-    coordinate: Coordinate,
-  ): boolean => {
-    if (!this._currentDrawLayerID) {
-      return false;
-    }
-
-    const source = this._getVectorSourceFromLayerID(this._currentDrawLayerID);
-    if (!source) {
-      return false;
-    }
-
-    const pixel = this._Map.getPixelFromCoordinate(coordinate);
-    if (!pixel) {
-      return false;
-    }
-
-    const hits = this._Map.getFeaturesAtPixel(pixel, {
-      hitTolerance: 10,
-      layerFilter: this._isDrawLayerFilter,
-    });
-
-    if (hits.length === 0) {
-      return false;
-    }
-
-    for (const hit of hits) {
-      if (!(hit instanceof Feature)) {
-        continue;
-      }
-
-      const featureId = hit.get('_id');
-      const onSource =
-        featureId !== undefined
-          ? source.getFeatures().find(f => f.get('_id') === featureId)
-          : hit;
-
-      if (onSource) {
-        source.removeFeature(onSource);
-      } else {
-        source.removeFeature(hit);
-      }
-    }
-
-    this._currentVectorSource = source;
-    this._persistDrawVectorSource(source);
-    this._commands.notifyCommandChanged(CommandIDs.deleteSelectedFeatures);
-    return true;
-  };
-
-  private _mapHasDrawFeatureAtCoordinate = (
-    coordinate: Coordinate,
-  ): boolean => {
-    if (!this._currentVectorSource) {
-      return false;
-    }
-
-    const pixel = this._Map.getPixelFromCoordinate(coordinate);
-    if (!pixel) {
-      return false;
-    }
-
-    return this._Map.hasFeatureAtPixel(pixel, {
-      hitTolerance: 10,
-      layerFilter: this._isDrawLayerFilter,
-    });
-  };
-
-  private _handleDrawEnd = (event: DrawEvent): void => {
-    const feature = event.feature;
-    feature.set('_id', UUID.uuid4());
-    feature.set('_createdAt', new Date().toISOString());
-    feature.set('_creatorClientId', this._model.getClientId().toString());
-    feature.set('_fromDrawTool', true);
-
-    const layerId = this._currentDrawLayerID;
-    const customAttributes = layerId
-      ? this._model.getDrawCustomAttributes(layerId)
-      : [];
-    applyDrawCustomAttributesToFeature(feature, customAttributes);
-
-    const source = layerId
-      ? this._getVectorSourceFromLayerID(layerId)
-      : this._currentVectorSource;
-    const onSource = source?.getFeatures().includes(feature) ?? false;
-
-    // OL dispatches drawend before adding the feature to the source.
-    this._persistDrawVectorSource(source, onSource ? undefined : feature);
-  };
-
-  _editVectorLayer = () => {
-    this._getDrawSourceFromSelectedLayer();
-    if (!this._currentDrawLayerID) {
-      return;
-    }
-
-    this._updateInteractions();
-  };
-
-  private _removeDrawInteraction = () => {
-    if (!this._draw) {
-      return;
-    }
-
-    this._draw.setActive(false);
-    this._Map.removeInteraction(this._draw);
-    this._draw = undefined;
-  };
-
-  private _removeSnapInteraction = () => {
-    if (!this._snap) {
-      return;
-    }
-
-    this._snap.setActive(false);
-    this._Map.removeInteraction(this._snap);
-    this._snap = undefined;
-  };
-
-  private _removeModifyInteraction = () => {
-    if (!this._modify) {
-      return;
-    }
-
-    this._modify.setActive(false);
-    this._Map.removeInteraction(this._modify);
-    this._modify = undefined;
+  private _handleDrawGeometryTypeChange = (drawGeometryLabel: string): void => {
+    this._drawTool.handleGeometryTypeChange(drawGeometryLabel);
   };
 
   /**
@@ -4535,15 +4190,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
   private _highlightLayerRef: {
     current: VectorImageLayer<VectorSource> | null;
   } = { current: null };
-  private _draw: Draw | undefined;
-  private _snap: Snap | undefined;
-  private _modify: Modify | undefined;
-  private _currentDrawLayerID: string | undefined;
+  private _drawTool: DrawToolController;
   private _previousDrawLayerID: string | undefined;
-  private _currentDrawSource: IJGISSource | undefined;
-  private _currentVectorSource: VectorSource | undefined;
-  private _currentDrawSourceID: string | undefined;
-  private _currentDrawGeometry: Type | undefined;
   private _updateCenter: CallableFunction;
   private _state?: IStateDB;
   private _formSchemaRegistry?: IJGISFormSchemaRegistry;


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Another update for the draw tool. This fixes the modify interaction so drawn features can be edited, adds a `Select` mode to modify without drawing, and also adds a context menu option to delete features.

I also pulled the draw tool logic out of `MainView` because 
 1. We really need to start shrinking `MainView` and 
 2. In an attempt to minimize conflicts with #1770  
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1803.org.readthedocs.build/en/1803/
💡 JupyterLite preview: https://jupytergis--1803.org.readthedocs.build/en/1803/lite
💡 Specta preview: https://jupytergis--1803.org.readthedocs.build/en/1803/lite/specta

<!-- readthedocs-preview jupytergis end -->