### PR TITLE
Pin pnpm version to fix RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,10 +2,10 @@
 version: 2
 
 build:
-  os: "ubuntu-24.04"
+  os: 'ubuntu-24.04'
   tools:
-    python: "3.12"
-    nodejs: "24"
+    python: '3.12'
+    nodejs: '24'
   jobs:
     # Install micromamba
     pre_create_environment:
@@ -23,7 +23,7 @@ build:
       # Pin micromamba
       - /bin/bash --login -c "micromamba self-update"
       # Create the isolated env for building JupyterGIS
-      - /bin/bash --login -c "micromamba create -n jupytergis-build -c conda-forge nodejs=24 pnpm pip python=3.13.\* proj"
+      - /bin/bash --login -c "micromamba create -n jupytergis-build -c conda-forge nodejs=24 pnpm=11.17.0 pip python=3.13.\* proj"
       - /bin/bash --login -c "micromamba run -n jupytergis-build pip install --group build"
       # Build JupyterGIS Javascript packages; required for building the docs env
       - /bin/bash --login -c "micromamba run -n jupytergis-build pnpm install --frozen-lockfile"


### PR DESCRIPTION
## Description

RTD fails because conda forge installs pnpm v12.0.0 while our required version in v11.17.0.

## Checklist

- [x] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [x] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1804.org.readthedocs.build/en/1804/
💡 JupyterLite preview: https://jupytergis--1804.org.readthedocs.build/en/1804/lite
💡 Specta preview: https://jupytergis--1804.org.readthedocs.build/en/1804/lite/specta

<!-- readthedocs-preview jupytergis end -->