### PR TITLE
Story Editor: Change segments with arrow keys

### DIFF
--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -16,8 +16,8 @@ import { StoryEditorHeaderBar } from '@/src/features/story/components/StoryEdito
 import { StoryEditorInput } from '@/src/features/story/components/StoryEditorInput';
 import { StoryEditorSection } from '@/src/features/story/components/StoryEditorSection';
 import { StoryEditorSegmentList } from '@/src/features/story/components/StoryEditorSegmentList';
-import { useStoryEditorSegmentList } from '@/src/features/story/hooks/useStoryEditorSegmentList';
 import { useStoryEditorSegmentKeyboard } from '@/src/features/story/hooks/useStoryEditorSegmentKeyboard';
+import { useStoryEditorSegmentList } from '@/src/features/story/hooks/useStoryEditorSegmentList';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import type {
   IStorySegmentViewItem,

--- a/packages/base/src/features/story/StoryEditorDialogBody.tsx
+++ b/packages/base/src/features/story/StoryEditorDialogBody.tsx
@@ -17,6 +17,7 @@ import { StoryEditorInput } from '@/src/features/story/components/StoryEditorInp
 import { StoryEditorSection } from '@/src/features/story/components/StoryEditorSection';
 import { StoryEditorSegmentList } from '@/src/features/story/components/StoryEditorSegmentList';
 import { useStoryEditorSegmentList } from '@/src/features/story/hooks/useStoryEditorSegmentList';
+import { useStoryEditorSegmentKeyboard } from '@/src/features/story/hooks/useStoryEditorSegmentKeyboard';
 import { StoryEditorSession } from '@/src/features/story/storyEditorSession';
 import type {
   IStorySegmentViewItem,
@@ -317,6 +318,8 @@ export function StoryEditorDialogBody({
     updateSegmentLayerName,
     updateSegmentTransition,
   } = useStoryEditorSegmentList(model, commands);
+
+  useStoryEditorSegmentKeyboard(model, story);
 
   const isTextSegmentWidthFull = isMarkdownOverlayWidthFull(
     story?.overlayContentWidth,

--- a/packages/base/src/features/story/__tests__/storyEditorSegmentKeyboard.spec.ts
+++ b/packages/base/src/features/story/__tests__/storyEditorSegmentKeyboard.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('@jupyterlab/apputils', () => ({
+  Dialog: class Dialog {},
+}));
+
+import {
+  getAdjacentStorySegmentIndex,
+  shouldIgnoreStoryEditorArrowKeys,
+} from '../hooks/useStoryEditorSegmentKeyboard';
+
+describe('storyEditorSegmentKeyboard', () => {
+  it('blocks arrow keys in text entry targets', () => {
+    const input = document.createElement('input');
+    expect(shouldIgnoreStoryEditorArrowKeys(input)).toBe(true);
+  });
+
+  it('blocks arrow keys in native selects', () => {
+    const select = document.createElement('select');
+    expect(shouldIgnoreStoryEditorArrowKeys(select)).toBe(true);
+  });
+
+  it('returns adjacent segment indexes within bounds', () => {
+    expect(getAdjacentStorySegmentIndex(1, 3, 'ArrowDown')).toBe(2);
+    expect(getAdjacentStorySegmentIndex(1, 3, 'ArrowUp')).toBe(0);
+    expect(getAdjacentStorySegmentIndex(0, 3, 'ArrowUp')).toBeNull();
+    expect(getAdjacentStorySegmentIndex(2, 3, 'ArrowDown')).toBeNull();
+  });
+});

--- a/packages/base/src/features/story/hooks/useStoryEditorSegmentKeyboard.ts
+++ b/packages/base/src/features/story/hooks/useStoryEditorSegmentKeyboard.ts
@@ -1,0 +1,82 @@
+import type { IJGISStoryMap, IJupyterGISModel } from '@jupytergis/schema';
+import { useEffect } from 'react';
+
+import { isTextEntryTarget } from '@/src/shared/editorAwareDialog';
+
+export function shouldIgnoreStoryEditorArrowKeys(
+  target: EventTarget | null,
+): boolean {
+  if (isTextEntryTarget(target)) {
+    return true;
+  }
+
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return (
+    target.closest('select, [role="combobox"], [role="listbox"]') !== null
+  );
+}
+
+export function getAdjacentStorySegmentIndex(
+  currentIndex: number,
+  segmentCount: number,
+  key: 'ArrowUp' | 'ArrowDown',
+): number | null {
+  const delta = key === 'ArrowDown' ? 1 : -1;
+  const nextIndex = currentIndex + delta;
+
+  if (nextIndex < 0 || nextIndex >= segmentCount) {
+    return null;
+  }
+
+  return nextIndex;
+}
+
+export function useStoryEditorSegmentKeyboard(
+  model: IJupyterGISModel,
+  story: IJGISStoryMap | null,
+): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
+        return;
+      }
+
+      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return;
+      }
+
+      if (shouldIgnoreStoryEditorArrowKeys(event.target)) {
+        return;
+      }
+
+      const segmentIds = story?.storySegments;
+      if (!segmentIds?.length) {
+        return;
+      }
+
+      const currentIndex = model.getCurrentSegmentIndex() ?? 0;
+      const nextIndex = getAdjacentStorySegmentIndex(
+        currentIndex,
+        segmentIds.length,
+        event.key,
+      );
+
+      if (nextIndex === null) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      model.setCurrentSegmentIndex(nextIndex);
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [model, story]);
+}

--- a/packages/base/src/features/story/hooks/useStoryEditorSegmentKeyboard.ts
+++ b/packages/base/src/features/story/hooks/useStoryEditorSegmentKeyboard.ts
@@ -14,9 +14,7 @@ export function shouldIgnoreStoryEditorArrowKeys(
     return false;
   }
 
-  return (
-    target.closest('select, [role="combobox"], [role="listbox"]') !== null
-  );
+  return target.closest('select, [role="combobox"], [role="listbox"]') !== null;
 }
 
 export function getAdjacentStorySegmentIndex(

--- a/packages/base/src/shared/editorAwareDialog.ts
+++ b/packages/base/src/shared/editorAwareDialog.ts
@@ -18,7 +18,7 @@ const NON_TEXT_INPUT_TYPES = new Set([
  * rather than submit the dialog (CodeMirror, textarea, contenteditable, or a
  * text-entry input).
  */
-function isTextEntryTarget(target: EventTarget | null): boolean {
+export function isTextEntryTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
     return false;
   }


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Up/down arrow keys change segments when story editor is open 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1810.org.readthedocs.build/en/1810/
💡 JupyterLite preview: https://jupytergis--1810.org.readthedocs.build/en/1810/lite
💡 Specta preview: https://jupytergis--1810.org.readthedocs.build/en/1810/lite/specta

<!-- readthedocs-preview jupytergis end -->