### PR TITLE
Let mobile story taps reach the segment overlay controls

### DIFF
--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -501,11 +501,12 @@
   right: 0.125rem;
 }
 
-/* Full-viewport touch scroll driver; segment UI is on ListStoryStageOverlay. */
+/* Full-viewport touch scroll driver; sits under the segment UI so that taps
+   reach the overlay controls, and above the map so swipes never pan it. */
 .jgis-story-mobile-list-scroll {
   position: fixed;
   inset: 0;
-  z-index: 6;
+  z-index: 4;
   top: var(--jgis-story-title-bar-height);
   width: 100%;
   overflow-y: auto;
@@ -513,6 +514,29 @@
   overscroll-behavior: contain;
   touch-action: pan-y;
   background: transparent;
+}
+
+/* The segment UI covers the scroll driver, so it stays transparent to touch
+   and only its controls take the tap. */
+.jgis-mainview-stage:has(.jgis-story-mobile-list-scroll)
+  .jgis-story-stage-overlay {
+  pointer-events: none;
+}
+
+.jgis-mainview-stage:has(.jgis-story-mobile-list-scroll)
+  .jgis-story-stage-overlay
+  :is(
+    a[href],
+    button,
+    summary,
+    input,
+    select,
+    textarea,
+    label,
+    [role='button'],
+    [role='link']
+  ) {
+  pointer-events: auto;
 }
 
 /* Mobile list only (scroll driver mounted); desktop list keeps 25% map cards. */


### PR DESCRIPTION
## Description

Shall close #1811


https://github.com/user-attachments/assets/178643ad-a46c-45c5-ab1d-28e19d2cc9f6



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself
