### PR TITLE
Disable the WMS layers dropdown until the server is connected

### DIFF
--- a/packages/base/src/features/layers/forms/source/wmsTileSource.tsx
+++ b/packages/base/src/features/layers/forms/source/wmsTileSource.tsx
@@ -103,19 +103,29 @@ export function WmsTileSourceForm(
     const layerNames = wmsAvailableLayers
       .map(layer => layer.name)
       .filter(name => name !== '');
+    const hasAvailableLayers = layerNames.length > 0;
 
     // Populate schema enum dynamically so RJSF renders a select for params.layers
     const params = (schema.properties?.params ?? {}) as IDict;
     const paramsProperties = (params.properties ?? {}) as IDict;
     if (paramsProperties.layers) {
       // Keep select options in sync with the cached/available layers list.
-      if (layerNames.length > 0) {
+      if (hasAvailableLayers) {
         paramsProperties.layers.enum = layerNames;
       } else {
         // Avoid invalid schema (`enum` must be a non-empty array).
         delete (paramsProperties.layers as IDict).enum;
       }
     }
+
+    // A layer can only be picked once the server has been contacted, so don't
+    // report it as missing before then; the disabled dropdown says what to do.
+    const requiredParams = ((params.required ?? []) as string[]).filter(
+      key => key !== 'layers',
+    );
+    params.required = hasAvailableLayers
+      ? [...requiredParams, 'layers']
+      : requiredParams;
 
     builtUiSchema.url = {
       'ui:widget': WmsTileSourceUrlInput,
@@ -127,7 +137,15 @@ export function WmsTileSourceForm(
       layers: {
         ...(builtUiSchema.params as IDict)?.layers,
         'ui:widget': 'select',
-        'ui:placeholder': 'Select a layer',
+        // Without a connection the list is empty, so make it clear that
+        // connecting is the prerequisite rather than offering an empty select.
+        'ui:disabled': !hasAvailableLayers,
+        'ui:placeholder': hasAvailableLayers
+          ? 'Select a layer'
+          : 'Connect to the WMS server first',
+        'ui:description': hasAvailableLayers
+          ? undefined
+          : 'Connect to the WMS server to get the list of available layers.',
         'ui:enumNames': wmsAvailableLayers.map(layer => layer.title),
       },
     };

--- a/packages/base/style/dialog.css
+++ b/packages/base/style/dialog.css
@@ -7,6 +7,13 @@
   background-image: unset;
 }
 
+/* RJSF sets `disabled` on the `<select>` itself, but the form's own colours
+ * override the browser default, so a disabled dropdown still looks clickable. */
+.jGIS-property-panel .rjsf select:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 /* Collapse the form-group row that contains our hidden field marker */
 .jp-root .form-group:has(.jGIS-hidden-field) {
   display: none !important;


### PR DESCRIPTION
## Description

<img width="1650" height="846" alt="86039" src="https://github.com/user-attachments/assets/4550106a-caf9-4cf5-83a9-fe56772311a8" />

<img width="1638" height="838" alt="32906" src="https://github.com/user-attachments/assets/af3786db-395c-436e-bcef-b5ca1e6ffbe6" />


## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1827.org.readthedocs.build/en/1827/
💡 JupyterLite preview: https://jupytergis--1827.org.readthedocs.build/en/1827/lite
💡 Specta preview: https://jupytergis--1827.org.readthedocs.build/en/1827/lite/specta

<!-- readthedocs-preview jupytergis end -->