### PR TITLE
Add story editor close button & make markdown editor tabs more clickable

### DIFF
--- a/packages/base/src/features/objectproperties/objectPropertiesDialog.tsx
+++ b/packages/base/src/features/objectproperties/objectPropertiesDialog.tsx
@@ -59,7 +59,7 @@ export class ObjectPropertiesWidget extends Dialog<void> {
 
     const body = (
       <Tabs defaultValue={initialTab} className="jgis-object-properties-tabs">
-        <TabsList>
+        <TabsList variant="underline">
           <TabsTrigger className="jgis-underline-indicator" value="properties">
             Properties
           </TabsTrigger>

--- a/packages/base/src/features/stac-browser/components/StacPanel.tsx
+++ b/packages/base/src/features/stac-browser/components/StacPanel.tsx
@@ -62,7 +62,10 @@ const StacPanelContent = ({ model }: IStacViewProps) => {
   return (
     <Tabs defaultValue="filters" style={{ boxShadow: 'none' }}>
       <TabsList variant="underline" className="jgis-stac-panel-tabs-list">
-        <TabsTrigger className="jgis-underline-indicator text-sm" value="filters">
+        <TabsTrigger
+          className="jgis-underline-indicator text-sm"
+          value="filters"
+        >
           Filters
         </TabsTrigger>
         <TabsTrigger

--- a/packages/base/src/features/stac-browser/components/StacPanel.tsx
+++ b/packages/base/src/features/stac-browser/components/StacPanel.tsx
@@ -60,16 +60,15 @@ const StacPanelContent = ({ model }: IStacViewProps) => {
     URL_TO_PANEL_MAP[selectedUrl] ?? StacFilterExtensionPanel;
 
   return (
-    <Tabs
-      defaultValue="filters"
-      className="jgis-panel-tabs"
-      style={{ boxShadow: 'none' }}
-    >
-      <TabsList className="jgis-stac-panel-tabs-list">
-        <TabsTrigger className={'text-sm'} value="filters">
+    <Tabs defaultValue="filters" style={{ boxShadow: 'none' }}>
+      <TabsList variant="underline" className="jgis-stac-panel-tabs-list">
+        <TabsTrigger className="jgis-underline-indicator text-sm" value="filters">
           Filters
         </TabsTrigger>
-        <TabsTrigger value="results">{`Results (${totalResults})`}</TabsTrigger>
+        <TabsTrigger
+          className="jgis-underline-indicator"
+          value="results"
+        >{`Results (${totalResults})`}</TabsTrigger>
       </TabsList>
       <TabsContent value="filters">
         <div className="jgis-stac-filter-extension-panel">

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -30,13 +30,21 @@ function disposeRenderer(renderer: Widget): void {
     return;
   }
 
-  if (renderer.isAttached) {
-    try {
+  // React may have already removed the host, leaving Lumino's isAttached
+  // true while node.isConnected is false. Widget.detach()/dispose() throw
+  // in that state — clear the flag so dispose can finish cleanly.
+  try {
+    if (renderer.isAttached && renderer.node.isConnected) {
       Widget.detach(renderer);
-    } catch {
-      // Host may already be gone when React unmounts the pane.
+    } else if (renderer.isAttached) {
+      renderer.clearFlag(Widget.Flag.IsAttached);
+    }
+  } catch {
+    if (renderer.isAttached) {
+      renderer.clearFlag(Widget.Flag.IsAttached);
     }
   }
+
   renderer.dispose();
 }
 

--- a/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
+++ b/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
@@ -15,6 +15,9 @@ import {
 
 type MarkdownEditorTab = 'write' | 'preview';
 
+const markdownTabTriggerClassName =
+  'bg-transparent shadow-none group-data-[variant=default]/tabs-list:data-active:bg-transparent group-data-[variant=default]/tabs-list:data-active:shadow-none data-active:bg-transparent data-active:shadow-none';
+
 export interface ISegmentMarkdownEditorProps {
   model: IJupyterGISModel;
   segmentId: string;
@@ -143,16 +146,20 @@ export function SegmentMarkdownEditor({
 
   return (
     <Tabs
-      className="jgis-panel-tabs"
+      className={'gap-0'}
       value={tab}
       onValueChange={nextTab => setTab(nextTab as MarkdownEditorTab)}
     >
       <TabsList
-        className="w-full rounded-b-none [&_[data-slot=tabs-trigger]]:text-muted-foreground"
+        className="w-full cursor-auto rounded-b-none [&_[data-slot=tabs-trigger]]:text-muted-foreground"
         aria-label="Markdown editor"
       >
-        <TabsTrigger value="write">Write</TabsTrigger>
-        <TabsTrigger value="preview">Preview</TabsTrigger>
+        <TabsTrigger className={markdownTabTriggerClassName} value="write">
+          <span className="jgis-underline-indicator">Write</span>
+        </TabsTrigger>
+        <TabsTrigger className={markdownTabTriggerClassName} value="preview">
+          <span className="jgis-underline-indicator">Preview</span>
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent

--- a/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
+++ b/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
@@ -15,9 +15,6 @@ import {
 
 type MarkdownEditorTab = 'write' | 'preview';
 
-const markdownTabTriggerClassName =
-  'bg-transparent shadow-none group-data-[variant=default]/tabs-list:data-active:bg-transparent group-data-[variant=default]/tabs-list:data-active:shadow-none data-active:bg-transparent data-active:shadow-none';
-
 export interface ISegmentMarkdownEditorProps {
   model: IJupyterGISModel;
   segmentId: string;
@@ -151,13 +148,14 @@ export function SegmentMarkdownEditor({
       onValueChange={nextTab => setTab(nextTab as MarkdownEditorTab)}
     >
       <TabsList
+        variant="underline"
         className="w-full cursor-auto rounded-b-none [&_[data-slot=tabs-trigger]]:text-muted-foreground"
         aria-label="Markdown editor"
       >
-        <TabsTrigger className={markdownTabTriggerClassName} value="write">
+        <TabsTrigger value="write">
           <span className="jgis-underline-indicator">Write</span>
         </TabsTrigger>
-        <TabsTrigger className={markdownTabTriggerClassName} value="preview">
+        <TabsTrigger value="preview">
           <span className="jgis-underline-indicator">Preview</span>
         </TabsTrigger>
       </TabsList>

--- a/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
+++ b/packages/base/src/features/story/components/SegmentMarkdownEditor.tsx
@@ -149,7 +149,7 @@ export function SegmentMarkdownEditor({
     >
       <TabsList
         variant="underline"
-        className="w-full cursor-auto rounded-b-none [&_[data-slot=tabs-trigger]]:text-muted-foreground"
+        className="w-full cursor-auto rounded-b-none"
         aria-label="Markdown editor"
       >
         <TabsTrigger value="write">

--- a/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
+++ b/packages/base/src/features/story/components/StoryEditorHeaderBar.tsx
@@ -1,6 +1,7 @@
 import { faGear } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IJGISStoryMap, IJupyterGISModel } from '@jupytergis/schema';
+import { Play } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { SegmentWidthSelector } from '@/src/features/story/components/SegmentWidthSelector';
@@ -221,23 +222,28 @@ export function StoryEditorHeaderBar({
         }}
       />
       <div className="jgis-story-editor-context-meta-group">
-        <Badge>
-          {story ? formatStoryTypeLabel(story.storyType) : 'No story'}
-        </Badge>
-
-        <span className="jgis-story-editor-context-meta">
-          {segmentCount} segment{segmentCount === 1 ? '' : 's'}
-        </span>
+        {!isMobile ? (
+          <>
+            <Badge>
+              {story ? formatStoryTypeLabel(story.storyType) : 'No story'}
+            </Badge>
+            <span className="jgis-story-editor-context-meta">
+              {segmentCount} segment{segmentCount === 1 ? '' : 's'}
+            </span>
+          </>
+        ) : null}
         {story && canPreview ? (
           <Button
             type="button"
-            variant="outline"
-            size="sm"
+            variant={isMobile ? 'ghost' : 'outline'}
+            size={isMobile ? 'icon-sm' : 'sm'}
+            aria-label="Preview story"
+            title="Preview story"
             onClick={() => {
               StoryEditorSession.getInstance().enterStoryPreviewMode();
             }}
           >
-            {isMobile ? 'Preview' : 'Preview story'}
+            {isMobile ? <Play /> : 'Preview story'}
           </Button>
         ) : null}
         {story && (

--- a/packages/base/src/features/story/storyEditorDialog.tsx
+++ b/packages/base/src/features/story/storyEditorDialog.tsx
@@ -47,6 +47,7 @@ export class StoryEditorWidget extends Dialog<boolean> {
       title: 'Story Editor',
       body,
       buttons: [],
+      hasClose: true,
     });
 
     this.model = options.model;

--- a/packages/base/src/shared/components/Tabs.tsx
+++ b/packages/base/src/shared/components/Tabs.tsx
@@ -28,12 +28,14 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-9 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none',
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-9 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none data-[variant=underline]:rounded-none',
   {
     variants: {
       variant: {
         default: 'bg-muted',
         line: 'gap-1 bg-transparent',
+        // Chrome for jgis-underline-indicator (no shadcn after: bar)
+        underline: 'h-auto gap-1 bg-secondary p-0',
       },
     },
     defaultVariants: {
@@ -82,9 +84,9 @@ const TabsTrigger = React.forwardRef<
       ref={mergedRef}
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-base font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-disabled:pointer-events-none aria-disabled:opacity-50 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-base font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[variant=underline]/tabs-list:h-auto group-data-[variant=underline]/tabs-list:shadow-none group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-disabled:pointer-events-none aria-disabled:opacity-50 group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none group-data-[variant=underline]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent',
-        'data-active:bg-background data-active:text-foreground',
+        'group-data-[variant=default]/tabs-list:data-active:bg-background group-data-[variant=default]/tabs-list:data-active:text-foreground group-data-[variant=line]/tabs-list:data-active:text-foreground group-data-[variant=underline]/tabs-list:data-active:text-foreground',
         'after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100',
         className,
       )}

--- a/packages/base/src/workspace/panels/components/TabbedPanel.tsx
+++ b/packages/base/src/workspace/panels/components/TabbedPanel.tsx
@@ -48,6 +48,7 @@ export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
     <Tabs className="jgis-panel-tabs" value={curTab || null}>
       <TabsList
         ref={tabsListRef}
+        variant="underline"
         onMouseDown={onTabListMouseDown}
         onTouchStart={onTabListTouchStart}
       >
@@ -55,6 +56,7 @@ export const TabbedPanel: React.FC<ITabbedPanelProps> = ({
           <TabsTrigger
             key={tab.name}
             value={tab.name}
+            className="jgis-underline-indicator"
             onClick={() => onTabClick(tab.name)}
           >
             {tab.title}

--- a/packages/base/src/workspace/panels/rightpanel.tsx
+++ b/packages/base/src/workspace/panels/rightpanel.tsx
@@ -80,11 +80,12 @@ const RightPanelComponent: React.FC<IRightPanelProps> = props => {
         style={{ display: rightPanelVisible ? 'block' : 'none' }}
       >
         <Tabs className="jgis-panel-tabs" value={curTab || null}>
-          <TabsList>
+          <TabsList variant="underline">
             {tabInfo.map(tab => (
               <TabsTrigger
                 key={`${tab.name}-${tab.title}`}
                 value={tab.name}
+                className="jgis-underline-indicator"
                 onClick={() => {
                   if (curTab !== tab.name) {
                     setCurTab(tab.name);

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -83,7 +83,9 @@
 }
 
 .jgis-underline-indicator[data-active],
-[data-active] > .jgis-underline-indicator {
+[data-active] > .jgis-underline-indicator,
+.jgis-underline-indicator:hover,
+:hover > .jgis-underline-indicator {
   opacity: 1;
 }
 

--- a/packages/base/style/base.css
+++ b/packages/base/style/base.css
@@ -68,6 +68,7 @@
   left: 0;
   width: 0;
   height: 3px;
+  opacity: 1;
   transition:
     background-color 300ms ease-in,
     width 300ms ease-in,
@@ -75,9 +76,15 @@
   background-color: transparent;
 }
 
-.jgis-underline-indicator[data-active]::after {
+.jgis-underline-indicator[data-active]::after,
+[data-active] > .jgis-underline-indicator::after {
   width: 100%;
   background-color: var(--jp-inverse-layout-color2);
+}
+
+.jgis-underline-indicator[data-active],
+[data-active] > .jgis-underline-indicator {
+  opacity: 1;
 }
 
 .errors {

--- a/packages/base/style/stacBrowser.css
+++ b/packages/base/style/stacBrowser.css
@@ -81,6 +81,7 @@
 }
 
 .jgis-stac-panel-tabs-list {
+  width: 100%;
   border-radius: 0;
 }
 

--- a/packages/base/style/storyEditorDialog.css
+++ b/packages/base/style/storyEditorDialog.css
@@ -20,10 +20,6 @@
 }
 
 @media (max-width: 960px) {
-  .jgis-story-editor-dialog .jp-Dialog-header {
-    display: none;
-  }
-
   .jgis-story-editor-dialog .jp-Dialog-content {
     width: 100%;
     max-width: 100%;
@@ -849,24 +845,25 @@ Radix won't set hidden so do it manually */
     height: 100%;
   }
 
-  /* Title on its own row; actions below */
+  /* Title + compact actions on one row */
   .jgis-story-editor-context-bar {
-    flex-direction: column;
+    flex-direction: row;
     flex-wrap: nowrap;
-    align-items: stretch;
+    align-items: center;
     gap: 0.375rem;
   }
 
   .jgis-story-editor-toolbar-title[data-slot='input'] {
-    flex: none;
-    width: 100%;
+    flex: 1 1 auto;
+    width: auto;
     min-width: 0;
     max-width: none;
   }
 
   .jgis-story-editor-context-meta-group {
-    gap: 0.375rem;
-    justify-content: flex-start;
+    flex-shrink: 0;
+    gap: 0.25rem;
+    justify-content: flex-end;
   }
 
   .jgis-story-editor-opacity-value {

--- a/packages/base/style/tabPanel.css
+++ b/packages/base/style/tabPanel.css
@@ -18,28 +18,6 @@
 .jgis-panel-tabs [data-slot='tabs-trigger'] {
   flex: none;
   height: auto;
-  background-color: transparent;
-  box-shadow: none;
-}
-
-.jgis-panel-tabs [data-slot='tabs-trigger']::after {
-  content: '';
-  position: absolute;
-  bottom: -00px;
-  left: 0;
-  width: 0;
-  height: 2px;
-  background-color: transparent;
-  opacity: 1;
-  transition:
-    background-color 300ms ease-in,
-    width 300ms ease-in,
-    opacity 300ms ease-in;
-}
-
-.jgis-panel-tabs [data-slot='tabs-trigger'][data-active]::after {
-  width: 100%;
-  background-color: var(--jp-inverse-layout-color2);
 }
 
 .jgis-panel-tab-content {


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Fix #1834 and #1832

Adds a close button to the story editor and expands the tab area you can click on to select the markdown view.

## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1844.org.readthedocs.build/en/1844/
💡 JupyterLite preview: https://jupytergis--1844.org.readthedocs.build/en/1844/lite
💡 Specta preview: https://jupytergis--1844.org.readthedocs.build/en/1844/lite/specta

<!-- readthedocs-preview jupytergis end -->