### PR TITLE
Enable enlarging markdown images

### DIFF
--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -5,7 +5,10 @@ import { Widget } from '@lumino/widgets';
 import React, { memo, useLayoutEffect, useRef, useState } from 'react';
 import { StyleModule } from 'style-mod';
 
-import { StoryMarkdownImageLightbox } from '@/src/features/story/components/StoryMarkdownImageLightbox';
+import {
+  StoryMarkdownImageLightbox,
+  bindStoryZoomableImage,
+} from '@/src/features/story/components/StoryMarkdownImageLightbox';
 import { useStoryRenderMime } from '@/src/features/story/components/StoryRenderMime';
 
 const MARKDOWN_MIME = 'text/markdown';
@@ -84,26 +87,17 @@ function bindZoomableImages(
       img.tabIndex = 0;
     }
 
-    const open = (): void => {
-      const src = img.currentSrc || img.src;
-
-      if (!src) {
-        return;
-      }
-
-      onOpen({ src, alt: img.alt || '' });
-    };
-
-    const handleClick = (event: MouseEvent): void => {
-      event.preventDefault();
-      event.stopPropagation();
-      open();
-    };
-
-    img.addEventListener('click', handleClick);
+    cleanups.push(
+      bindStoryZoomableImage(img, () => {
+        const src = img.currentSrc || img.src;
+        if (!src) {
+          return;
+        }
+        onOpen({ src, alt: img.alt || '' });
+      }),
+    );
 
     cleanups.push(() => {
-      img.removeEventListener('click', handleClick);
       img.classList.remove('jgis-story-markdown-zoomable-image');
     });
   }

--- a/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
+++ b/packages/base/src/features/story/components/RenderedStoryMarkdown.tsx
@@ -2,9 +2,10 @@ import type { IJupyterGISModel } from '@jupytergis/schema';
 import { jupyterHighlightStyle } from '@jupyterlab/codemirror';
 import { MimeModel } from '@jupyterlab/rendermime';
 import { Widget } from '@lumino/widgets';
-import React, { memo, useLayoutEffect, useRef } from 'react';
+import React, { memo, useLayoutEffect, useRef, useState } from 'react';
 import { StyleModule } from 'style-mod';
 
+import { StoryMarkdownImageLightbox } from '@/src/features/story/components/StoryMarkdownImageLightbox';
 import { useStoryRenderMime } from '@/src/features/story/components/StoryRenderMime';
 
 const MARKDOWN_MIME = 'text/markdown';
@@ -61,6 +62,59 @@ export function ensureJupyterHighlightStyle(): void {
   }
 }
 
+interface ILightboxImage {
+  src: string;
+  alt: string;
+}
+
+function bindZoomableImages(
+  host: HTMLElement,
+  onOpen: (image: ILightboxImage) => void,
+): () => void {
+  const images = Array.from(host.querySelectorAll('img'));
+  const cleanups: Array<() => void> = [];
+
+  for (const img of images) {
+    img.classList.add('jgis-story-markdown-zoomable-image');
+
+    if (!img.getAttribute('role')) {
+      img.setAttribute('role', 'button');
+    }
+    if (!img.hasAttribute('tabindex')) {
+      img.tabIndex = 0;
+    }
+
+    const open = (): void => {
+      const src = img.currentSrc || img.src;
+
+      if (!src) {
+        return;
+      }
+
+      onOpen({ src, alt: img.alt || '' });
+    };
+
+    const handleClick = (event: MouseEvent): void => {
+      event.preventDefault();
+      event.stopPropagation();
+      open();
+    };
+
+    img.addEventListener('click', handleClick);
+
+    cleanups.push(() => {
+      img.removeEventListener('click', handleClick);
+      img.classList.remove('jgis-story-markdown-zoomable-image');
+    });
+  }
+
+  return () => {
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+  };
+}
+
 /** Jupyter rendermime markdown output (shared by overlay and story editor). */
 export const RenderedStoryMarkdown = memo(
   ({
@@ -74,6 +128,7 @@ export const RenderedStoryMarkdown = memo(
     const hostRef = useRef<HTMLDivElement>(null);
     const onRenderedRef = useRef(onRendered);
     onRenderedRef.current = onRendered;
+    const [lightbox, setLightbox] = useState<ILightboxImage | null>(null);
 
     useLayoutEffect(() => {
       const host = hostRef.current;
@@ -91,6 +146,7 @@ export const RenderedStoryMarkdown = memo(
       });
 
       let cancelled = false;
+      let unbindImages: (() => void) | undefined;
 
       const run = async (): Promise<void> => {
         if (cancelled) {
@@ -118,6 +174,7 @@ export const RenderedStoryMarkdown = memo(
         }
 
         renderer.addClass('jp-MarkdownOutput');
+        unbindImages = bindZoomableImages(host, setLightbox);
         requestAnimationFrame(() => {
           if (!cancelled && !renderer.isDisposed) {
             onRenderedRef.current?.();
@@ -129,6 +186,7 @@ export const RenderedStoryMarkdown = memo(
 
       return () => {
         cancelled = true;
+        unbindImages?.();
         disposeRenderer(renderer);
       };
     }, [rendermime, source]);
@@ -142,7 +200,12 @@ export const RenderedStoryMarkdown = memo(
         <div
           ref={hostRef}
           className="specta-article-host-widget specta-cell-content"
-        ></div>
+        />
+        <StoryMarkdownImageLightbox
+          src={lightbox?.src ?? null}
+          alt={lightbox?.alt}
+          onClose={() => setLightbox(null)}
+        />
       </div>
     );
   },

--- a/packages/base/src/features/story/components/StoryImageSection.tsx
+++ b/packages/base/src/features/story/components/StoryImageSection.tsx
@@ -1,6 +1,9 @@
-import React, { useCallback, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-import { StoryMarkdownImageLightbox } from './StoryMarkdownImageLightbox';
+import {
+  StoryMarkdownImageLightbox,
+  bindStoryZoomableImage,
+} from './StoryMarkdownImageLightbox';
 
 interface IStoryImageSectionProps {
   imageUrl: string;
@@ -17,24 +20,32 @@ function StoryImageSection({
   slideNumber,
   navSlot,
 }: IStoryImageSectionProps) {
+  const imageRef = useRef<HTMLImageElement>(null);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  useEffect(() => {
+    const image = imageRef.current;
+    if (!image || !imageLoaded) {
+      return;
+    }
+
+    return bindStoryZoomableImage(image, () => {
+      setLightboxOpen(true);
+    });
+  }, [imageLoaded, imageUrl]);
+
   if (!imageLoaded) {
     return null;
   }
-
-  const [lightboxOpen, setLightboxOpen] = useState(false);
-
-  const handleOpen = useCallback(() => {
-    setLightboxOpen(true);
-  }, []);
 
   return (
     <div className="jgis-story-viewer-image-section">
       <div className="jgis-story-viewer-image-container">
         <img
+          ref={imageRef}
           src={imageUrl}
           alt="Story map image"
           className="jgis-story-viewer-image jgis-story-viewer-image-zoomable"
-          onClick={handleOpen}
           role="button"
           tabIndex={0}
         />

--- a/packages/base/src/features/story/components/StoryImageSection.tsx
+++ b/packages/base/src/features/story/components/StoryImageSection.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
+
+import { StoryMarkdownImageLightbox } from './StoryMarkdownImageLightbox';
 
 interface IStoryImageSectionProps {
   imageUrl: string;
@@ -19,13 +21,27 @@ function StoryImageSection({
     return null;
   }
 
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  const handleOpen = useCallback(() => {
+    setLightboxOpen(true);
+  }, []);
+
   return (
     <div className="jgis-story-viewer-image-section">
       <div className="jgis-story-viewer-image-container">
         <img
           src={imageUrl}
           alt="Story map image"
-          className="jgis-story-viewer-image"
+          className="jgis-story-viewer-image jgis-story-viewer-image-zoomable"
+          onClick={handleOpen}
+          role="button"
+          tabIndex={0}
+        />
+        <StoryMarkdownImageLightbox
+          src={lightboxOpen ? imageUrl : null}
+          alt="Story map image"
+          onClose={() => setLightboxOpen(false)}
         />
         {navSlot}
       </div>

--- a/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
+++ b/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
@@ -14,6 +14,95 @@ export interface IStoryMarkdownImageLightboxProps {
   onClose: () => void;
 }
 
+const MOVE_THRESHOLD_PX = 8;
+
+function getMobileListScroller(): HTMLElement | null {
+  return document.querySelector('.jgis-story-mobile-list-scroll');
+}
+
+/**
+ * Tap opens the lightbox. On mobile list stories vertical swipes on
+ * the image are forwarded instead of being swallowed.
+ */
+export function bindStoryZoomableImage(
+  element: HTMLElement,
+  onOpen: () => void,
+): () => void {
+  let startY = 0;
+  let startScrollTop = 0;
+  let tracking = false;
+  let didScroll = false;
+
+  const handleTouchStart = (event: TouchEvent): void => {
+    if (event.touches.length !== 1) {
+      tracking = false;
+      return;
+    }
+
+    const scroller = getMobileListScroller();
+    if (!scroller) {
+      tracking = false;
+      return;
+    }
+
+    tracking = true;
+    didScroll = false;
+    startY = event.touches[0].clientY;
+    startScrollTop = scroller.scrollTop;
+  };
+
+  const handleTouchMove = (event: TouchEvent): void => {
+    if (!tracking || event.touches.length !== 1) {
+      return;
+    }
+
+    const scroller = getMobileListScroller();
+    if (!scroller) {
+      return;
+    }
+
+    const dy = startY - event.touches[0].clientY;
+    if (!didScroll && Math.abs(dy) < MOVE_THRESHOLD_PX) {
+      return;
+    }
+
+    didScroll = true;
+    scroller.scrollTop = startScrollTop + dy;
+    event.preventDefault();
+  };
+
+  const handleTouchEnd = (): void => {
+    tracking = false;
+  };
+
+  const handleClick = (event: MouseEvent): void => {
+    if (didScroll) {
+      event.preventDefault();
+      event.stopPropagation();
+      didScroll = false;
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    onOpen();
+  };
+
+  element.addEventListener('touchstart', handleTouchStart, { passive: true });
+  element.addEventListener('touchmove', handleTouchMove, { passive: false });
+  element.addEventListener('touchend', handleTouchEnd);
+  element.addEventListener('touchcancel', handleTouchEnd);
+  element.addEventListener('click', handleClick);
+
+  return () => {
+    element.removeEventListener('touchstart', handleTouchStart);
+    element.removeEventListener('touchmove', handleTouchMove);
+    element.removeEventListener('touchend', handleTouchEnd);
+    element.removeEventListener('touchcancel', handleTouchEnd);
+    element.removeEventListener('click', handleClick);
+  };
+}
+
 export function StoryMarkdownImageLightbox({
   src,
   alt = '',

--- a/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
+++ b/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/src/shared/components/Dialog';
+import { cn } from '@/src/shared/components/utils';
+
+export interface IStoryMarkdownImageLightboxProps {
+  src: string | null;
+  alt?: string;
+  onClose: () => void;
+}
+
+const FIT_SCALE = 1;
+const ZOOMED_SCALE = 2;
+/** Wait to distinguish single-click (dismiss) from double-click (zoom). */
+const SINGLE_CLICK_CLOSE_MS = 280;
+
+export function StoryMarkdownImageLightbox({
+  src,
+  alt = '',
+  onClose,
+}: IStoryMarkdownImageLightboxProps): JSX.Element {
+  const open = Boolean(src);
+  const [scale, setScale] = useState(FIT_SCALE);
+  const scaleRef = useRef(scale);
+  scaleRef.current = scale;
+  const closeTimerRef = useRef<number | null>(null);
+
+  const clearCloseTimer = useCallback((): void => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      clearCloseTimer();
+      return;
+    }
+
+    setScale(FIT_SCALE);
+    clearCloseTimer();
+
+    return () => {
+      clearCloseTimer();
+    };
+  }, [open, src, clearCloseTimer]);
+
+  const handleClick = useCallback(() => {
+    if (scaleRef.current > FIT_SCALE) {
+      clearCloseTimer();
+      setScale(FIT_SCALE);
+      return;
+    }
+
+    clearCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null;
+      onClose();
+    }, SINGLE_CLICK_CLOSE_MS);
+  }, [clearCloseTimer, onClose]);
+
+  const handleDoubleClick = useCallback(() => {
+    clearCloseTimer();
+    if (scaleRef.current > FIT_SCALE) {
+      return;
+    }
+
+    setScale(ZOOMED_SCALE);
+  }, [clearCloseTimer]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={nextOpen => {
+        if (!nextOpen) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent
+        className={cn(
+          'inset-0 top-0 left-0 z-10050 h-dvh w-screen max-w-none translate-x-0 translate-y-0 gap-0 overflow-hidden rounded-none bg-black/95 p-0 text-white ring-0 max-sm:max-w-none data-open:zoom-in-100 data-closed:zoom-out-100',
+        )}
+      >
+        <DialogTitle className="sr-only">Image preview</DialogTitle>
+        <DialogDescription className="sr-only">
+          Double-click to zoom further. Click to zoom out or dismiss. Press
+          Escape or use Close to dismiss.
+        </DialogDescription>
+        <div
+          className={
+            'flex size-full cursor-zoom-out touch-manipulation items-center justify-center overflow-hidden select-none'
+          }
+          onClick={handleClick}
+          onDoubleClick={handleDoubleClick}
+        >
+          {src ? (
+            <img
+              className="jgis-story-image-lightbox-image"
+              src={src}
+              alt={alt}
+              draggable={false}
+              style={{ transform: `scale(${scale})` }}
+            />
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
+++ b/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
@@ -85,7 +85,7 @@ export function StoryMarkdownImageLightbox({
     >
       <DialogContent
         className={cn(
-          'inset-0 top-0 left-0 z-10050 h-dvh w-screen max-w-none translate-x-0 translate-y-0 gap-0 overflow-hidden rounded-none bg-black/95 p-0 text-white ring-0 max-sm:max-w-none data-open:zoom-in-100 data-closed:zoom-out-100',
+          'inset-0 top-0 left-0 z-10050 h-dvh w-screen max-w-none translate-x-0 translate-y-0 gap-0 overflow-hidden rounded-none bg-background/95 p-0 text-foreground ring-0 max-sm:max-w-none data-open:zoom-in-100 data-closed:zoom-out-100',
         )}
       >
         <DialogTitle className="sr-only">Image preview</DialogTitle>

--- a/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
+++ b/packages/base/src/features/story/components/StoryMarkdownImageLightbox.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
 
 import {
   Dialog,
@@ -14,65 +14,12 @@ export interface IStoryMarkdownImageLightboxProps {
   onClose: () => void;
 }
 
-const FIT_SCALE = 1;
-const ZOOMED_SCALE = 2;
-/** Wait to distinguish single-click (dismiss) from double-click (zoom). */
-const SINGLE_CLICK_CLOSE_MS = 280;
-
 export function StoryMarkdownImageLightbox({
   src,
   alt = '',
   onClose,
 }: IStoryMarkdownImageLightboxProps): JSX.Element {
   const open = Boolean(src);
-  const [scale, setScale] = useState(FIT_SCALE);
-  const scaleRef = useRef(scale);
-  scaleRef.current = scale;
-  const closeTimerRef = useRef<number | null>(null);
-
-  const clearCloseTimer = useCallback((): void => {
-    if (closeTimerRef.current !== null) {
-      window.clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!open) {
-      clearCloseTimer();
-      return;
-    }
-
-    setScale(FIT_SCALE);
-    clearCloseTimer();
-
-    return () => {
-      clearCloseTimer();
-    };
-  }, [open, src, clearCloseTimer]);
-
-  const handleClick = useCallback(() => {
-    if (scaleRef.current > FIT_SCALE) {
-      clearCloseTimer();
-      setScale(FIT_SCALE);
-      return;
-    }
-
-    clearCloseTimer();
-    closeTimerRef.current = window.setTimeout(() => {
-      closeTimerRef.current = null;
-      onClose();
-    }, SINGLE_CLICK_CLOSE_MS);
-  }, [clearCloseTimer, onClose]);
-
-  const handleDoubleClick = useCallback(() => {
-    clearCloseTimer();
-    if (scaleRef.current > FIT_SCALE) {
-      return;
-    }
-
-    setScale(ZOOMED_SCALE);
-  }, [clearCloseTimer]);
 
   return (
     <Dialog
@@ -90,15 +37,11 @@ export function StoryMarkdownImageLightbox({
       >
         <DialogTitle className="sr-only">Image preview</DialogTitle>
         <DialogDescription className="sr-only">
-          Double-click to zoom further. Click to zoom out or dismiss. Press
-          Escape or use Close to dismiss.
+          Click to dismiss. Press Escape or use Close to dismiss.
         </DialogDescription>
         <div
-          className={
-            'flex size-full cursor-zoom-out touch-manipulation items-center justify-center overflow-hidden select-none'
-          }
-          onClick={handleClick}
-          onDoubleClick={handleDoubleClick}
+          className="flex size-full cursor-zoom-out touch-manipulation items-center justify-center overflow-hidden select-none"
+          onClick={onClose}
         >
           {src ? (
             <img
@@ -106,7 +49,6 @@ export function StoryMarkdownImageLightbox({
               src={src}
               alt={alt}
               draggable={false}
-              style={{ transform: `scale(${scale})` }}
             />
           ) : null}
         </div>

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -486,6 +486,7 @@
     select,
     textarea,
     label,
+    img,
     [role='button'],
     [role='link']
   ) {

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -40,6 +40,10 @@
   border-radius: var(--jp-border-radius);
 }
 
+.jgis-story-viewer-image-zoomable {
+  cursor: zoom-in;
+}
+
 .jgis-story-viewer-nav-container {
   position: absolute;
   bottom: 0;

--- a/packages/base/style/storyPanel.css
+++ b/packages/base/style/storyPanel.css
@@ -490,7 +490,8 @@
     select,
     textarea,
     label,
-    img,
+    .jgis-story-markdown-zoomable-image,
+    .jgis-story-viewer-image-zoomable,
     [role='button'],
     [role='link']
   ) {

--- a/packages/base/style/storySpectaArticleOverlay.css
+++ b/packages/base/style/storySpectaArticleOverlay.css
@@ -171,6 +171,7 @@
   height: auto;
   object-fit: contain;
   transform-origin: center center;
+  pointer-events: none;
 }
 
 .jgis-story-rendered-markdown .specta-article-host-widget blockquote {

--- a/packages/base/style/storySpectaArticleOverlay.css
+++ b/packages/base/style/storySpectaArticleOverlay.css
@@ -171,9 +171,6 @@
   height: auto;
   object-fit: contain;
   transform-origin: center center;
-  pointer-events: none;
-  border-radius: 0;
-  margin: 0;
 }
 
 .jgis-story-rendered-markdown .specta-article-host-widget blockquote {

--- a/packages/base/style/storySpectaArticleOverlay.css
+++ b/packages/base/style/storySpectaArticleOverlay.css
@@ -158,6 +158,24 @@
   border-radius: 4px;
 }
 
+.jgis-story-rendered-markdown
+  .specta-article-host-widget
+  img.jgis-story-markdown-zoomable-image {
+  cursor: zoom-in;
+}
+
+.jgis-story-image-lightbox-image {
+  max-width: min(100vw, 100%);
+  max-height: min(100dvh, 100%);
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  transform-origin: center center;
+  pointer-events: none;
+  border-radius: 0;
+  margin: 0;
+}
+
 .jgis-story-rendered-markdown .specta-article-host-widget blockquote {
   border-left: 3px solid;
   padding-left: 1rem;


### PR DESCRIPTION
## Description

<!--
Insert Pull Request description here.

What does this PR change? Why?
-->
Close #1820 

Adds a lightbox for images in the story. 

https://github.com/user-attachments/assets/3a846643-eca9-4c9a-b152-78f8dee28965


https://github.com/user-attachments/assets/5d1bcaad-f475-4d27-a213-82bdee479d52


https://github.com/user-attachments/assets/f78ad01e-26d7-418e-a6f9-ab4aed30094a


Allow magnifying images in story presentations. 
## Checklist

- [x] PR has a descriptive title and content.
- [x] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [x] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [x] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1845.org.readthedocs.build/en/1845/
💡 JupyterLite preview: https://jupytergis--1845.org.readthedocs.build/en/1845/lite
💡 Specta preview: https://jupytergis--1845.org.readthedocs.build/en/1845/lite/specta

<!-- readthedocs-preview jupytergis end -->