### PR TITLE
Make collaborator cursors smaller and easier to tell apart

### DIFF
--- a/packages/base/src/mainview/CollaboratorPointers.tsx
+++ b/packages/base/src/mainview/CollaboratorPointers.tsx
@@ -14,6 +14,7 @@ export type ClientPointer = {
   avatarUrl?: string;
   color: string;
   coordinates: JgisCoordinates;
+  lonLat: { latitude: number; longitude: number };
 };
 
 const CollaboratorAvatar: React.FC<{ client: ClientPointer }> = ({

--- a/packages/base/src/mainview/CollaboratorPointers.tsx
+++ b/packages/base/src/mainview/CollaboratorPointers.tsx
@@ -14,7 +14,6 @@ export type ClientPointer = {
   avatarUrl?: string;
   color: string;
   coordinates: JgisCoordinates;
-  lonLat: { latitude: number; longitude: number };
 };
 
 const CollaboratorAvatar: React.FC<{ client: ClientPointer }> = ({
@@ -48,8 +47,6 @@ const CollaboratorAvatar: React.FC<{ client: ClientPointer }> = ({
 const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({
   clients,
 }) => {
-  const [openClientId, setOpenClientId] = useState<string | null>(null);
-
   return (
     <>
       {clients &&
@@ -65,9 +62,6 @@ const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({
             <div
               className="jGIS-Remote-Pointer"
               style={{ color: client.color }}
-              onClick={() =>
-                setOpenClientId(openClientId === clientId ? null : clientId)
-              }
             >
               <FontAwesomeIcon
                 icon={faArrowPointer}
@@ -83,15 +77,6 @@ const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({
                 </span>
               </div>
             </div>
-            {openClientId === clientId && (
-              <div
-                className="jGIS-Remote-Pointer-Coordinates"
-                style={{ borderColor: client.color }}
-              >
-                {client.lonLat.longitude.toFixed(2)},{' '}
-                {client.lonLat.latitude.toFixed(2)}
-              </div>
-            )}
           </div>
         ))}
     </>

--- a/packages/base/src/mainview/CollaboratorPointers.tsx
+++ b/packages/base/src/mainview/CollaboratorPointers.tsx
@@ -1,10 +1,7 @@
-import {
-  faArrowPointer,
-  faWindowMinimize,
-} from '@fortawesome/free-solid-svg-icons';
+import { faArrowPointer } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IDict, JgisCoordinates } from '@jupytergis/schema';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ICollaboratorPointersProps {
   clients: IDict<ClientPointer>;
@@ -13,21 +10,52 @@ interface ICollaboratorPointersProps {
 export type ClientPointer = {
   username: string;
   displayName: string;
+  initials: string;
+  avatarUrl?: string;
   color: string;
   coordinates: JgisCoordinates;
   lonLat: { latitude: number; longitude: number };
 };
 
+const CollaboratorAvatar: React.FC<{ client: ClientPointer }> = ({
+  client,
+}) => {
+  const [avatarFailed, setAvatarFailed] = useState(false);
+
+  useEffect(() => setAvatarFailed(false), [client.avatarUrl]);
+
+  const showAvatar = !!client.avatarUrl && !avatarFailed;
+
+  return (
+    <div
+      className="jGIS-Remote-Pointer-Avatar"
+      style={{ backgroundColor: showAvatar ? undefined : client.color }}
+      title={client.displayName}
+    >
+      {showAvatar ? (
+        <img
+          src={client.avatarUrl}
+          alt=""
+          onError={() => setAvatarFailed(true)}
+        />
+      ) : (
+        <span>{client.initials}</span>
+      )}
+    </div>
+  );
+};
+
 const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({
   clients,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [openClientId, setOpenClientId] = useState<string | null>(null);
 
   return (
     <>
       {clients &&
-        Object.values(clients).map(client => (
+        Object.entries(clients).map(([clientId, client]) => (
           <div
+            key={clientId}
             className="jGIS-Popup-Wrapper"
             style={{
               left: `${client.coordinates.x}px`,
@@ -35,51 +63,35 @@ const CollaboratorPointers: React.FC<ICollaboratorPointersProps> = ({
             }}
           >
             <div
-              key={client.username}
               className="jGIS-Remote-Pointer"
-              style={{
-                color: client.color,
-                cursor: 'pointer',
-              }}
-              onClick={() => {
-                setIsOpen(!isOpen);
-              }}
+              style={{ color: client.color }}
+              onClick={() =>
+                setOpenClientId(openClientId === clientId ? null : clientId)
+              }
             >
               <FontAwesomeIcon
                 icon={faArrowPointer}
                 className="jGIS-Remote-Pointer-Icon"
               />
-            </div>
-            <div
-              style={{
-                visibility: isOpen ? 'visible' : 'hidden',
-                background: client.color,
-              }}
-              className="jGIS-Remote-Pointer-Popup jGIS-Floating-Pointer-Popup"
-            >
               <div
-                className="jGIS-Popup-Topbar"
-                onClick={() => {
-                  setIsOpen(false);
-                }}
+                className="jGIS-Remote-Pointer-Label"
+                style={{ borderColor: client.color }}
               >
-                <FontAwesomeIcon
-                  icon={faWindowMinimize}
-                  className="jGIS-Popup-TopBarIcon"
-                />
-              </div>
-              <div className="jGIS-Remote-Pointer-Popup-Name">
-                {client.displayName}
-              </div>
-              <div className="jGIS-Remote-Pointer-Popup-Coordinates">
-                <br />
-                Pointer Location:
-                <br />
-                Longitude: {client.lonLat.longitude.toFixed(2)}
-                <br />
-                Latitude: {client.lonLat.latitude.toFixed(2)}
+                <CollaboratorAvatar client={client} />
+                <span className="jGIS-Remote-Pointer-Name">
+                  {client.displayName}
+                </span>
               </div>
             </div>
+            {openClientId === clientId && (
+              <div
+                className="jGIS-Remote-Pointer-Coordinates"
+                style={{ borderColor: client.color }}
+              >
+                {client.lonLat.longitude.toFixed(2)},{' '}
+                {client.lonLat.latitude.toFixed(2)}
+              </div>
+            )}
           </div>
         ))}
     </>

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2826,6 +2826,7 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           pointer.coordinates.x,
           pointer.coordinates.y,
         ]);
+        const lonLat = toLonLat([pointer.coordinates.x, pointer.coordinates.y]);
 
         if (!currentClientPointer) {
           currentClientPointer = {
@@ -2838,6 +2839,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
               x: pixel[0],
               y: pixel[1],
             },
+            lonLat: {
+              longitude: lonLat[0],
+              latitude: lonLat[1],
+            },
           };
         } else {
           currentClientPointer = {
@@ -2845,6 +2850,10 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
             coordinates: {
               x: pixel[0],
               y: pixel[1],
+            },
+            lonLat: {
+              longitude: lonLat[0],
+              latitude: lonLat[1],
             },
           };
         }

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2832,6 +2832,8 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           currentClientPointer = {
             username: client.user.username,
             displayName: client.user.display_name,
+            initials: client.user.initials ?? '',
+            avatarUrl: client.user.avatar_url,
             color: client.user.color,
             coordinates: {
               x: pixel[0],

--- a/packages/base/src/mainview/mainView.tsx
+++ b/packages/base/src/mainview/mainView.tsx
@@ -2826,7 +2826,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
           pointer.coordinates.x,
           pointer.coordinates.y,
         ]);
-        const lonLat = toLonLat([pointer.coordinates.x, pointer.coordinates.y]);
 
         if (!currentClientPointer) {
           currentClientPointer = {
@@ -2839,10 +2838,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
               x: pixel[0],
               y: pixel[1],
             },
-            lonLat: {
-              longitude: lonLat[0],
-              latitude: lonLat[1],
-            },
           };
         } else {
           currentClientPointer = {
@@ -2850,10 +2845,6 @@ export class MainView extends React.Component<IMainViewProps, IStates> {
             coordinates: {
               x: pixel[0],
               y: pixel[1],
-            },
-            lonLat: {
-              longitude: lonLat[0],
-              latitude: lonLat[1],
             },
           };
         }

--- a/python/jupytergis_lab/style/base.css
+++ b/python/jupytergis_lab/style/base.css
@@ -433,9 +433,16 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
   width: 12px;
   height: 12px;
   flex: 0 0 auto;
-  filter: drop-shadow(-1px 0px white) drop-shadow(1px 0px white)
-    drop-shadow(0px -1px white) drop-shadow(0px 1px white)
-    drop-shadow(0px 0px 1px black);
+  overflow: visible;
+  filter: drop-shadow(0 1px 1px rgb(0 0 0 / 35%));
+}
+
+.jGIS-Remote-Pointer-Icon path {
+  fill: var(--jp-layout-color1);
+  stroke: currentcolor;
+  stroke-width: 100px;
+  stroke-linejoin: round;
+  paint-order: stroke fill;
 }
 
 .jGIS-Remote-Pointer-Label {

--- a/python/jupytergis_lab/style/base.css
+++ b/python/jupytergis_lab/style/base.css
@@ -426,7 +426,6 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
   transition-property: left, top;
   transition-duration: 150ms;
   transition-timing-function: ease;
-  cursor: pointer;
   z-index: 20;
 }
 
@@ -478,22 +477,6 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.jGIS-Remote-Pointer-Coordinates {
-  position: absolute;
-  top: 32px;
-  left: 14px;
-  padding: 2px 6px;
-  background: var(--jp-layout-color1);
-  color: var(--jp-ui-font-color1);
-  border: 1px solid;
-  border-radius: var(--jp-border-radius);
-  box-shadow: var(--jp-elevation-z2);
-  font-size: 11px;
-  line-height: 1.2;
-  white-space: nowrap;
-  z-index: 40;
 }
 
 /* Hack to remove the malformed form button */

--- a/python/jupytergis_lab/style/base.css
+++ b/python/jupytergis_lab/style/base.css
@@ -420,47 +420,80 @@ div.jGIS-toolbar-widget > div.jp-Toolbar-item:last-child {
 
 .jGIS-Remote-Pointer {
   position: absolute;
-  transition-property: left, top, width, height;
+  display: flex;
+  align-items: flex-start;
+  gap: 2px;
+  transition-property: left, top;
   transition-duration: 150ms;
   transition-timing-function: ease;
+  cursor: pointer;
   z-index: 20;
 }
 
 .jGIS-Remote-Pointer-Icon {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
   filter: drop-shadow(-1px 0px white) drop-shadow(1px 0px white)
     drop-shadow(0px -1px white) drop-shadow(0px 1px white)
     drop-shadow(0px 0px 1px black);
 }
-.jGIS-Remote-Pointer-Icon:hover {
-  scale: 1.3;
-}
 
-.jGIS-Floating-Pointer-Popup {
-  position: absolute;
-  width: 160px;
-  box-shadow: var(--jp-elevation-z6);
-  z-index: 40;
-  max-height: 400px;
-  overflow: auto;
-}
-
-.jGIS-Remote-Pointer-Popup {
-  margin-left: 7px;
-  margin-top: 14px;
-  color: #fff;
-  padding: 1em;
-  border-radius: 0.5em;
-  font-size: 12px;
+.jGIS-Remote-Pointer-Label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 140px;
+  margin-top: 8px;
+  padding: 2px 6px 2px 2px;
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+  border: 1px solid;
+  border-radius: 10px;
+  box-shadow: var(--jp-elevation-z2);
+  font-size: 11px;
   line-height: 1.2;
 }
 
-.jGIS-Remote-Pointer-Popup-Name {
-  font-size: 16px;
-  color: #333;
+.jGIS-Remote-Pointer-Avatar {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 100%;
+  color: var(--jp-ui-inverse-font-color1);
+  font-size: 8px;
 }
 
-.jGIS-Remote-Pointer-Popup-Coordinates {
-  font-size: 14px;
+.jGIS-Remote-Pointer-Avatar > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.jGIS-Remote-Pointer-Name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.jGIS-Remote-Pointer-Coordinates {
+  position: absolute;
+  top: 32px;
+  left: 14px;
+  padding: 2px 6px;
+  background: var(--jp-layout-color1);
+  color: var(--jp-ui-font-color1);
+  border: 1px solid;
+  border-radius: var(--jp-border-radius);
+  box-shadow: var(--jp-elevation-z2);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+  z-index: 40;
 }
 
 /* Hack to remove the malformed form button */


### PR DESCRIPTION
## Description

Shall close #1831

Before:
<img width="452" height="374" alt="1265" src="https://github.com/user-attachments/assets/e727ac8e-be76-4ef5-83fb-e38ff15db1b5" />

After:
<img width="456" height="346" alt="15456" src="https://github.com/user-attachments/assets/9c5ffbd6-cb50-4f1b-8a19-da85358d7435" />



## Checklist

- [ ] PR has a descriptive title and content.
- [ ] PR description contains [references](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to any issues the PR resolves, e.g. `Resolves #XXX`.
- [ ] PR has one of the labels: documentation, bug, enhancement, feature, maintenance
- [ ] Checks are passing.
      Failing lint checks can be resolved with:
  - `pre-commit run --all-files`
  - `pnpm run lint`
- [ ] If you wish to be cited for your contribution, `CITATION.cff` contains an [author entry](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson) for yourself


<!-- readthedocs-preview jupytergis start -->
---
📚 Documentation preview: https://jupytergis--1848.org.readthedocs.build/en/1848/
💡 JupyterLite preview: https://jupytergis--1848.org.readthedocs.build/en/1848/lite
💡 Specta preview: https://jupytergis--1848.org.readthedocs.build/en/1848/lite/specta

<!-- readthedocs-preview jupytergis end -->